### PR TITLE
setup QAWolfPage to manage page instead of Browser

### DIFF
--- a/packages/browser/src/Browser.ts
+++ b/packages/browser/src/Browser.ts
@@ -1,12 +1,11 @@
-import { CONFIG } from "@qawolf/config";
 import { logger } from "@qawolf/logger";
-import { BrowserStep, Locator, Size } from "@qawolf/types";
-import { QAWolfWeb, waitFor } from "@qawolf/web";
-import puppeteer, { Page, ElementHandle, Serializable } from "puppeteer";
+import { BrowserStep, Size } from "@qawolf/types";
+import { waitFor } from "@qawolf/web";
+import puppeteer, { Page, ElementHandle } from "puppeteer";
 import { launchPuppeteerBrowser } from "./browserUtils";
 import { getDevice } from "./device";
-import { injectWebBundle } from "./pageUtils";
-import { RequestTracker } from "./RequestTracker";
+import { findElement } from "./pageUtils";
+import { QAWolfPage } from "./QAWolfPage";
 
 export type BrowserCreateOptions = {
   size?: Size;
@@ -21,13 +20,10 @@ export class Browser {
   private _currentPageIndex: number = 0;
   private _device: puppeteer.devices.Device;
   // stored in order of open
-  private _pages: Page[] = [];
-  private _requests: RequestTracker;
+  private _pages: QAWolfPage[] = [];
 
-  // protect constructor to force using async Browser.create()
-  protected constructor() {
-    this._requests = new RequestTracker();
-  }
+  // protect constructor to force using async create()
+  protected constructor() {}
 
   public static async create(options: BrowserCreateOptions = {}) {
     /**
@@ -45,12 +41,11 @@ export class Browser {
     return self;
   }
 
-  public get device() {
-    return this._device;
-  }
-
   public async close(): Promise<void> {
-    this._requests.dispose();
+    for (let page of this._pages) {
+      page.dispose();
+    }
+
     await this._browser.close();
     logger.verbose("Browser: closed");
   }
@@ -59,36 +54,13 @@ export class Browser {
     return this.getPage(this._currentPageIndex);
   }
 
+  public get device() {
+    return this._device;
+  }
+
   public async element(step: BrowserStep): Promise<ElementHandle> {
-    logger.verbose(
-      `Browser: find element for ${JSON.stringify(step.target).substring(
-        0,
-        100
-      )}`
-    );
-
     const page = await this.getPage(step.pageId, true);
-
-    const jsHandle = await page.evaluateHandle(
-      (locator: Locator) => {
-        const qawolf: QAWolfWeb = (window as any).qawolf;
-        return qawolf.locate.waitForElement(locator);
-      },
-      {
-        action: step.action,
-        dataAttribute: CONFIG.dataAttribute,
-        target: step.target,
-        timeoutMs: CONFIG.locatorTimeoutMs,
-        value: step.value
-      } as Serializable
-    );
-
-    const handle = jsHandle.asElement();
-    if (!handle) {
-      throw new Error(`No element handle found for step ${step}`);
-    }
-
-    return handle;
+    return findElement(page, step);
   }
 
   public async goto(url: string): Promise<Page> {
@@ -110,7 +82,6 @@ export class Browser {
 
     const page = await waitFor(() => {
       if (index >= this._pages.length) return null;
-
       return this._pages[index];
     }, timeoutMs);
 
@@ -120,22 +91,16 @@ export class Browser {
 
     // when headless = false the tab needs to be activated
     // for the execution context to run
-    await page.bringToFront();
+    await page.super.bringToFront();
+
     if (waitForRequests) {
-      await this._requests.waitUntilComplete(page);
+      await page.waitForRequests();
     }
 
     this._currentPageIndex = index;
-    logger.verbose(`Browser: getPage(${index}) activated ${page.url()}`);
+    logger.verbose(`Browser: getPage(${index}) activated ${page.super.url()}`);
 
-    return page;
-  }
-
-  private async managePage(page: Page) {
-    await injectWebBundle(page);
-    await page.emulate(this._device);
-    this._requests.track(page);
-    this._pages.push(page);
+    return page.super;
   }
 
   private async managePages() {
@@ -145,11 +110,11 @@ export class Browser {
       // when there are multiple pages open at the start
       throw new Error("Must managePages before opening pages");
     }
-    await this.managePage(pages[0]);
+    this._pages.push(await QAWolfPage.create(pages[0], this._device));
 
     this._browser.on("targetcreated", async target => {
       const page = await target.page();
-      if (page) this.managePage(page);
+      if (page) this._pages.push(await QAWolfPage.create(page, this._device));
     });
   }
 }

--- a/packages/browser/src/QAWolfPage.ts
+++ b/packages/browser/src/QAWolfPage.ts
@@ -1,0 +1,42 @@
+import fs from "fs-extra";
+import path from "path";
+import { devices, Page } from "puppeteer";
+import { RequestTracker } from "./RequestTracker";
+
+const webBundle = fs.readFileSync(
+  path.resolve(path.dirname(require.resolve("@qawolf/web")), "./qawolf.web.js"),
+  "utf8"
+);
+
+export class QAWolfPage {
+  private _page: Page;
+  private _requests: RequestTracker;
+
+  // protect constructor to force using async create()
+  protected constructor(page: Page) {
+    this._page = page;
+    this._requests = new RequestTracker(page);
+  }
+
+  public static async create(page: Page, device: devices.Device) {
+    await Promise.all([
+      page.evaluate(webBundle),
+      page.evaluateOnNewDocument(webBundle),
+      page.emulate(device)
+    ]);
+
+    return new QAWolfPage(page);
+  }
+
+  public dispose() {
+    this._requests.dispose();
+  }
+
+  public get super() {
+    return this._page;
+  }
+
+  public waitForRequests() {
+    return this._requests.waitUntilComplete();
+  }
+}

--- a/packages/browser/src/RequestTracker.ts
+++ b/packages/browser/src/RequestTracker.ts
@@ -4,104 +4,91 @@ import { Page, Request, PageEventObj } from "puppeteer";
 
 type Callback = () => void;
 
-type Tracker = {
-  page: Page;
-  requests: Request[];
-  onComplete: Callback[];
-};
-
 export class RequestTracker {
+  private _onComplete: Callback[] = [];
   private _onDispose: (() => void)[] = [];
 
-  private _trackers: Tracker[] = [];
+  private _page: Page;
+
+  private _requests: Request[] = [];
 
   // how long until we ignore a request
   private _timeout: number;
 
-  constructor(timeout: number = 10000) {
+  constructor(page: Page, timeout: number = 10000) {
+    this._page = page;
     this._timeout = timeout;
-  }
 
-  public track(page: Page) {
-    const tracker: Tracker = {
-      page,
-      requests: [],
-      onComplete: []
-    };
-    this._trackers.push(tracker);
+    this.on("request", (request: Request) => this.handleRequest(request));
 
-    const removeRequest = (request: Request, reason: string) => {
-      const items = remove(tracker.requests, i => i === request);
-      // ignore since it was already removed
-      if (items.length < 1) return;
-
-      logger.debug(
-        `RequestTracker: request-- ${reason} ${
-          tracker.requests.length
-        } ${page.url().substring(0, 100)}`
-      );
-
-      if (tracker.requests.length === 0) {
-        tracker.onComplete.forEach(done => done());
-        tracker.onComplete = [];
-      }
-    };
-
-    this.on(page, "request", (request: Request) => {
-      tracker.requests.push(request);
-
-      logger.debug(
-        `RequestTracker: request++ ${
-          tracker.requests.length
-        } ${page.url().substring(0, 100)}`
-      );
-
-      const intervalId = setTimeout(
-        () => removeRequest(request, "timeout"),
-        this._timeout
-      );
-      this._onDispose.push(() => clearInterval(intervalId));
-    });
-
-    this.on(page, "requestfailed", request =>
-      removeRequest(request, "requestfailed")
+    this.on("requestfailed", request =>
+      this.handleRemoveRequest(request, "requestfailed")
     );
 
-    this.on(page, "requestfinished", request =>
-      removeRequest(request, "requestfinished")
+    this.on("requestfinished", request =>
+      this.handleRemoveRequest(request, "requestfinished")
     );
-  }
-
-  public async waitUntilComplete(page: Page) {
-    logger.verbose(`RequestTracker: waitUntilComplete ${page.url()}`);
-
-    return new Promise(resolve => {
-      const tracker = this._trackers.find(c => c.page === page);
-      if (!tracker) throw new Error(`Cannot find counter. Page is not tracked`);
-
-      if (tracker.requests.length === 0) {
-        logger.verbose(
-          `RequestTracker: waitUntilComplete resolved immediately ${page.url()}`
-        );
-        resolve();
-        return;
-      }
-
-      tracker.onComplete.push(resolve);
-    });
   }
 
   public dispose() {
     this._onDispose.forEach(f => f());
   }
 
+  public async waitUntilComplete() {
+    logger.verbose(`RequestTracker: waitUntilComplete ${this._page.url()}`);
+
+    return new Promise(resolve => {
+      if (this._requests.length === 0) {
+        logger.verbose(
+          `RequestTracker: waitUntilComplete resolved immediately ${this._page.url()}`
+        );
+        resolve();
+        return;
+      }
+
+      this._onComplete.push(resolve);
+    });
+  }
+
+  private handleRequest(request: Request) {
+    this._requests.push(request);
+
+    logger.debug(
+      `RequestTracker: request++ ${
+        this._requests.length
+      } ${this._page.url().substring(0, 100)}`
+    );
+
+    const intervalId = setTimeout(
+      () => this.handleRemoveRequest(request, "timeout"),
+      this._timeout
+    );
+    this._onDispose.push(() => clearInterval(intervalId));
+  }
+
+  private handleRemoveRequest(request: Request, reason: string) {
+    const items = remove(this._requests, i => i === request);
+    // ignore since it was already removed
+    if (items.length < 1) return;
+
+    logger.debug(
+      `RequestTracker: request-- ${reason} ${
+        this._requests.length
+      } ${this._page.url().substring(0, 100)}`
+    );
+
+    if (this._requests.length === 0) {
+      this._onComplete.forEach(done => done());
+      this._onComplete = [];
+    }
+  }
+
   private on<K extends keyof PageEventObj>(
-    page: Page,
     eventName: K,
     handler: (e: PageEventObj[K], ...args: any[]) => void
   ) {
-    page.on(eventName, handler);
+    this._page.on(eventName, handler);
 
-    this._onDispose.push(() => page.removeListener(eventName, handler));
+    this._onDispose.push(() => this._page.removeListener(eventName, handler));
   }
 }

--- a/packages/browser/tests/RequestTracker.test.ts
+++ b/packages/browser/tests/RequestTracker.test.ts
@@ -15,11 +15,10 @@ describe("waitUntilComplete", () => {
   afterAll(() => page.browser().close());
 
   it("resolves when there are no outstanding requests", () => {
-    const counter = new RequestTracker();
-    counter.track(page);
+    const counter = new RequestTracker(page);
 
     const callback = jest.fn();
-    counter.waitUntilComplete(page).then(callback);
+    counter.waitUntilComplete().then(callback);
 
     return new Promise(resolve => {
       process.nextTick(() => {
@@ -30,14 +29,13 @@ describe("waitUntilComplete", () => {
   });
 
   it("resolves after outstanding requests are 0", async () => {
-    const counter = new RequestTracker();
-    counter.track(page);
+    const counter = new RequestTracker(page);
 
     page.emit("request", 1);
     page.emit("request", 2);
 
     const callback = jest.fn();
-    counter.waitUntilComplete(page).then(callback);
+    counter.waitUntilComplete().then(callback);
 
     expect(callback).not.toBeCalled();
     page.emit("requestfinished", 1);
@@ -52,13 +50,12 @@ describe("waitUntilComplete", () => {
   });
 
   it("resolves after timeout", () => {
-    const counter = new RequestTracker(30000);
-    counter.track(page);
+    const counter = new RequestTracker(page, 30000);
 
     page.emit("request", {});
 
     const callback = jest.fn();
-    counter.waitUntilComplete(page).then(callback);
+    counter.waitUntilComplete().then(callback);
     expect(callback).not.toBeCalled();
 
     expect(callback).not.toBeCalled();


### PR DESCRIPTION
Goal: Slim down Browser to make it more readable, create a home for managing the page

- separate findElement to pageUtil to slim down Browser

setup QAWolfPage:
- injects QAWolf library
- emulates the device
- manages waiting for requests