### PR TITLE
Support non-US keyboards

### DIFF
--- a/packages/browser/src/actions.ts
+++ b/packages/browser/src/actions.ts
@@ -86,6 +86,6 @@ export const type = async (page: Page, value: string): Promise<void> => {
       await page.keyboard.up(stroke.code);
     }
 
-    await sleep(25);
+    await sleep(CONFIG.keyDelayMs);
   }
 };

--- a/packages/browser/src/keyboard.ts
+++ b/packages/browser/src/keyboard.ts
@@ -44,10 +44,15 @@ export const buildStrokesForString = (keysToType: string) => {
   keysToType.split("").forEach(key => {
     // null if not a shift key
     const shiftKeyDefinition = shiftKeyToDefinitions[key];
+    const keyDefinition = keyToDefinition[key];
+
+    if (!shiftKeyDefinition && !keyDefinition) {
+      throw new Error(`Unrecognized key "${key}"`);
+    }
 
     const code = shiftKeyDefinition
       ? shiftKeyDefinition.code
-      : keyToDefinition[key].code;
+      : keyDefinition.code;
 
     if (shiftKeyDefinition) {
       strokes.push({

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -27,13 +27,14 @@ export const CONFIG = {
   domPath: process.env.QAW_DOM_PATH,
   findTimeoutMs: parseNumber(process.env.QAW_FIND_TIMEOUT_MS, 30000),
   headless: parseBool(process.env.QAW_HEADLESS),
+  keyDelayMs: parseNumber(process.env.QAW_KEY_DELAY_MS, 0),
   logLevel: process.env.QAW_LOG_LEVEL,
   logPath: process.env.QAW_LOG_PATH,
   navigationTimeout: parseNumber(process.env.QAW_NAVIGATION_TIMEOUT, 60000),
   serial: parseBool(process.env.QAW_SERIAL),
-  // slow down each step by 2s to make it watchable
+  // slow down each step by 1s to make it watchable
   // this also gives sites time to setup their handlers
-  sleepMs: parseNumber(process.env.QAW_SLEEP_MS, 2000),
+  sleepMs: parseNumber(process.env.QAW_SLEEP_MS, 1000),
   testUrl,
   videoPath: process.env.QAW_VIDEO_PATH
 };


### PR DESCRIPTION
Resolves #176

- add QAW_KEY_DELAY_MS config
- change QAW_SLEEP_MS default to 1s

To Do

- [ ] support [sendCharacter](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#keyboardsendcharacterchar) with → prefix
- [ ] collect all input events -- include select input events and non-us characters
- [ ] refactor press / merging logic it's 🤢
- [ ] serialize input events for non-us keyboard characters as →