### PR TITLE
fix timeoutMs = 0

### DIFF
--- a/packages/browser/src/actions.ts
+++ b/packages/browser/src/actions.ts
@@ -1,7 +1,7 @@
 import { CONFIG } from "@qawolf/config";
 import { logger } from "@qawolf/logger";
 import { ScrollValue } from "@qawolf/types";
-import { QAWolfWeb, sleep } from "@qawolf/web";
+import { isNil, QAWolfWeb, sleep } from "@qawolf/web";
 import { ElementHandle, Page } from "puppeteer";
 import { valueToStrokes } from "./strokes";
 
@@ -58,6 +58,8 @@ export const select = async (
   timeoutMs?: number
 ): Promise<void> => {
   logger.verbose("actions.select");
+  const findTimeoutMs = (isNil(timeoutMs) ? CONFIG.findTimeoutMs : timeoutMs)!;
+
   // ensure option with desired value is loaded before selecting
   await elementHandle.evaluate(
     (element: HTMLSelectElement, value: string | null, timeoutMs: number) => {
@@ -65,7 +67,7 @@ export const select = async (
       return qawolf.select.waitForOption(element, value, timeoutMs);
     },
     value,
-    timeoutMs || CONFIG.findTimeoutMs
+    findTimeoutMs
   );
 
   await elementHandle.select(value || "");

--- a/packages/browser/src/find.ts
+++ b/packages/browser/src/find.ts
@@ -1,6 +1,6 @@
 import { CONFIG } from "@qawolf/config";
 import { logger } from "@qawolf/logger";
-import { QAWolfWeb, waitFor } from "@qawolf/web";
+import { isNil, QAWolfWeb, waitFor } from "@qawolf/web";
 import { Locator, Step } from "@qawolf/types";
 import { ElementHandle, Page, Serializable } from "puppeteer";
 import { retryExecutionError } from "./retry";
@@ -18,6 +18,7 @@ export const findElement = async (
   logger.verbose(
     `findElement: ${JSON.stringify(step.target).substring(0, 100)}`
   );
+  const findTimeoutMs = (isNil(timeoutMs) ? CONFIG.findTimeoutMs : timeoutMs)!;
 
   const jsHandle = await page.evaluateHandle(
     (locator: Locator) => {
@@ -28,7 +29,7 @@ export const findElement = async (
       action: step.action,
       dataAttribute: CONFIG.dataAttribute,
       target: step.target,
-      timeoutMs: timeoutMs || CONFIG.findTimeoutMs,
+      timeoutMs: findTimeoutMs,
       value: step.value
     } as Serializable
   );
@@ -46,7 +47,7 @@ export const findProperty = async (
   { property, selector }: FindPropertyArgs,
   timeoutMs?: number
 ): Promise<string | null | undefined> => {
-  const waitForTimeoutMs = timeoutMs || CONFIG.findTimeoutMs;
+  const findTimeoutMs = (isNil(timeoutMs) ? CONFIG.findTimeoutMs : timeoutMs)!;
 
   const result = await retryExecutionError(async () => {
     const elementHandle = await waitFor(
@@ -57,7 +58,7 @@ export const findProperty = async (
 
         return elementHandles[0];
       },
-      waitForTimeoutMs,
+      findTimeoutMs,
       100
     );
     if (!elementHandle) return null;
@@ -76,7 +77,7 @@ export const hasText = async (
   text: string,
   timeoutMs?: number
 ): Promise<boolean> => {
-  const waitForTimeoutMs = timeoutMs || CONFIG.findTimeoutMs;
+  const findTimeoutMs = (isNil(timeoutMs) ? CONFIG.findTimeoutMs : timeoutMs)!;
 
   const result = await retryExecutionError(async () => {
     const pageHasText = await page.evaluate(
@@ -85,7 +86,7 @@ export const hasText = async (
 
         return qawolf.find.hasText(text, timeoutMs);
       },
-      { text, timeoutMs: waitForTimeoutMs }
+      { text, timeoutMs: findTimeoutMs }
     );
 
     return pageHasText;

--- a/packages/browser/tests/web/hasText.test.ts
+++ b/packages/browser/tests/web/hasText.test.ts
@@ -25,7 +25,7 @@ describe("hasText", () => {
   });
 
   it("returns false if timeout reached", async () => {
-    const result = await hasText(page, "tomsmith", -1);
+    const result = await hasText(page, "sup", 0);
     expect(result).toBe(false);
   });
 });

--- a/packages/browser/tests/web/wait.test.ts
+++ b/packages/browser/tests/web/wait.test.ts
@@ -5,9 +5,10 @@ describe("waitUntil", () => {
     const booleanFn = jest.fn();
     booleanFn.mockReturnValue(true);
 
+    await waitUntil(booleanFn, 0);
     await waitUntil(booleanFn, 250);
 
-    expect(booleanFn).toBeCalledTimes(1);
+    expect(booleanFn).toBeCalledTimes(2);
   });
 
   it("throws error if condition never met", async () => {

--- a/packages/jest-environment/src/RunnerEnvironment.ts
+++ b/packages/jest-environment/src/RunnerEnvironment.ts
@@ -4,7 +4,7 @@ import { CONFIG } from "@qawolf/config";
 import { logger } from "@qawolf/logger";
 import { Runner } from "@qawolf/runner";
 import { Workflow } from "@qawolf/types";
-import { waitUntil } from "@qawolf/web";
+import { isNil, waitUntil } from "@qawolf/web";
 import { pathExists, readJSON } from "fs-extra";
 import NodeEnvironment from "jest-environment-node";
 import path from "path";
@@ -43,12 +43,17 @@ export class RunnerEnvironment extends NodeEnvironment {
     this.global.steps = runner.workflow.steps;
     this.global.values = runner.values;
 
-    // default timeoutMs to CONFIG
     this.global.waitUntil = (
       booleanFn: () => boolean,
       timeoutMs?: number,
       sleepMs?: number
-    ) => waitUntil(booleanFn, timeoutMs || CONFIG.findTimeoutMs, sleepMs);
+    ) =>
+      waitUntil(
+        booleanFn,
+        // default timeoutMs to CONFIG.findTimeoutMs
+        (isNil(timeoutMs) ? CONFIG.findTimeoutMs : timeoutMs)!,
+        sleepMs
+      );
 
     this.global.workflow = runner.workflow;
 

--- a/packages/web/src/wait.ts
+++ b/packages/web/src/wait.ts
@@ -9,12 +9,12 @@ export const waitFor = async <T>(
 ): Promise<T | null> => {
   const startTime = Date.now();
 
-  while (Date.now() - startTime < timeoutMs) {
+  do {
     const value = valueFn();
     if (value) return value;
 
     await sleep(sleepMs);
-  }
+  } while (Date.now() - startTime < timeoutMs);
 
   return null;
 };
@@ -26,12 +26,12 @@ export const waitUntil = async (
 ): Promise<void> => {
   const startTime = Date.now();
 
-  while (Date.now() - startTime < timeoutMs) {
+  do {
     const conditionMet = await booleanFn();
     if (conditionMet) return;
 
     await sleep(sleepMs);
-  }
+  } while (Date.now() - startTime < timeoutMs);
 
   throw new Error(
     `waitUntil: waited ${timeoutMs} milliseconds but condition never met`


### PR DESCRIPTION
Fixes an issue where finding element after beforeAction sleep was not respecting timeout=0.

This caused test timeouts and slows down tests w/o strong matches.