### PR TITLE
do not choose non-common clickable element types

### DIFF
--- a/packages/browser/tests/web/element.test.ts
+++ b/packages/browser/tests/web/element.test.ts
@@ -28,7 +28,7 @@ describe("getClickableAncestor", () => {
     expect(xpath).toEqual("//*[@id='login']/button");
   });
 
-  it("short-circuits on an element with the data attribute", async () => {
+  it("chooses the element with the data attribute if it finds one", async () => {
     const xpath = await page.evaluate(() => {
       const qawolf: QAWolfWeb = (window as any).qawolf;
       const submitIcon = document.getElementsByTagName("i")[0]!;
@@ -44,6 +44,17 @@ describe("getClickableAncestor", () => {
     });
 
     expect(xpath).toEqual("//*[@id='login']/button/i");
+  });
+
+  it("chooses the original element when there is no clickable ancestor", async () => {
+    const xpath = await page.evaluate(() => {
+      const qawolf: QAWolfWeb = (window as any).qawolf;
+      const button = document.getElementsByTagName("button")[0]!;
+      const ancestor = qawolf.element.getClickableAncestor(button, "data-qa");
+      return qawolf.xpath.getXpath(ancestor);
+    });
+
+    expect(xpath).toEqual("//*[@id='login']/button");
   });
 });
 

--- a/packages/web/src/element.ts
+++ b/packages/web/src/element.ts
@@ -5,37 +5,43 @@ export const getClickableAncestor = (
   dataAttribute: string
 ): HTMLElement => {
   /**
-   * Crawl up until we reach the top "clickable" ancestor
+   * Crawl up until we reach the top "clickable" ancestor.
+   * If a target is the descendant of a clickable element with the data attribute choose it.
+   * If the target is the descendant of "a"/"button"/"input" choose it.
+   * Otherwise choose the original element as the target.
    */
   let ancestor = element;
   console.log("get clickable ancestor for", getXpath(element));
 
   while (ancestor.parentElement) {
-    // short-circuit when we encounter a data value
+    // choose the data value element as the clickable ancestor
     const dataValue = getDataValue(ancestor, dataAttribute);
     if (dataValue) {
       console.log(
-        `get clickable ancestor with ${dataAttribute}="${dataValue}"`,
+        `found clickable ancestor: ${dataAttribute}="${dataValue}"`,
         getXpath(ancestor)
       );
       return ancestor;
     }
 
-    // short-circuit when we encounter a common clickable element type
-    // there may be a parent that is still clickable but does something else
+    // choose the common clickable element type as the clickable ancestor
     if (["a", "button", "input"].includes(ancestor.tagName.toLowerCase())) {
+      console.log(
+        `found clickable ancestor: ${ancestor.tagName}`,
+        getXpath(ancestor)
+      );
       return ancestor;
     }
 
-    // stop at the top clickable ancestor
+    // stop crawling at the first non-clickable element
     if (
       !isClickable(
         ancestor.parentElement,
         window.getComputedStyle(ancestor.parentElement)
       )
     ) {
-      console.log("got clickable ancestor", getXpath(ancestor));
-      return ancestor;
+      console.log("no clickable ancestor, use target", getXpath(element));
+      return element;
     }
 
     ancestor = ancestor.parentElement;


### PR DESCRIPTION
If a target is the descendant of a button/a/input we want to click the parent -- otherwise choose the target. This is to avoid the issue where a parent div does something different. Eg dropdown divs.