### PR TITLE
innertext: cleanText before setting as an attribute

### DIFF
--- a/packages/browser/tests/web/serialize.test.ts
+++ b/packages/browser/tests/web/serialize.test.ts
@@ -65,7 +65,7 @@ describe("nodeToHtml", () => {
     });
 
     expect(html).toEqual(
-      '<button class="radius" type="submit" innertext=" Login"><i class="fa fa-2x fa-sign-in"> Login</i></button>'
+      '<button class="radius" type="submit" innertext="login"><i class="fa fa-2x fa-sign-in"> Login</i></button>'
     );
   });
 

--- a/packages/web/src/serialize.ts
+++ b/packages/web/src/serialize.ts
@@ -9,6 +9,7 @@ import {
   parse as parseHtml,
   stringify as stringifyDocArray
 } from "@jperl/html-parse-stringify";
+import { cleanText } from "./lang";
 import "./types";
 
 type SerializeNodeOptions = {
@@ -105,7 +106,8 @@ export const nodeToHtml = (
   }
 
   if (options.innerText && element.innerText) {
-    element.setAttribute("innertext", element.innerText);
+    // clean the text to prevent weird serialization of line breaks
+    element.setAttribute("innertext", cleanText(element.innerText));
   }
 
   if (options.labels && element.labels) {


### PR DESCRIPTION
 to prevent weird unicode characters for line breaks `can click "Sort flights by: &#10;Sort flights by dr..."`