### PR TITLE
Browser.find: retryExecutionError

### DIFF
--- a/packages/browser/src/find/find.ts
+++ b/packages/browser/src/find/find.ts
@@ -3,6 +3,7 @@ import { ElementHandle, Page } from "puppeteer";
 import { findCss } from "./findCss";
 import { findHtml, HtmlSelector } from "./findHtml";
 import { findText } from "./findText";
+import { retryExecutionError } from "../retry";
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors
 export type CssSelector = string;
@@ -14,22 +15,24 @@ export type Selector =
       text?: string;
     };
 
-export const find = async (
+export const find = (
   page: Page,
   selector: Selector,
   options: FindOptions
 ): Promise<ElementHandle | null> => {
-  if (typeof selector === "string") {
-    return findCss(page, selector, options);
-  }
+  return retryExecutionError(async () => {
+    if (typeof selector === "string") {
+      return findCss(page, selector, options);
+    }
 
-  if (selector.html) {
-    return findHtml(page, selector.html, options);
-  }
+    if (selector.html) {
+      return findHtml(page, selector.html, options);
+    }
 
-  if (selector.text) {
-    return findText(page, selector.text, options);
-  }
+    if (selector.text) {
+      return findText(page, selector.text, options);
+    }
 
-  throw new Error(`Invalid selector ${selector}`);
+    throw new Error(`Invalid selector ${selector}`);
+  });
 };

--- a/packages/browser/src/find/findHtml.ts
+++ b/packages/browser/src/find/findHtml.ts
@@ -18,7 +18,9 @@ export const findHtml = async (
       : selector;
 
   logger.verbose(
-    `findHtml: ${serializeDocSelector(docSelector)} ${JSON.stringify(options)}`
+    `findHtml: ${JSON.stringify(
+      serializeDocSelector(docSelector)
+    )} ${JSON.stringify(options)}`
   );
 
   const jsHandle = await page.evaluateHandle(

--- a/packages/browser/src/find/findText.ts
+++ b/packages/browser/src/find/findText.ts
@@ -8,7 +8,7 @@ export const findText = async (
   text: string,
   options: FindOptions
 ): Promise<ElementHandle<Element> | null> => {
-  logger.verbose(`findText: ${text}`);
+  logger.verbose(`findText: "${text}" until timeout ${options.timeoutMs}`);
 
   const jsHandle = await page.evaluateHandle(
     (text, options) => {

--- a/packages/browser/tests/Browser.test.ts
+++ b/packages/browser/tests/Browser.test.ts
@@ -59,7 +59,7 @@ describe("Browser.currentPage", () => {
   });
 });
 
-describe("Browser.findElement", () => {
+describe("Browser.find", () => {
   it("finds an element", async () => {
     const browser = await Browser.create({ url: `${CONFIG.testUrl}login` });
 

--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -208,11 +208,22 @@ export class Runner {
       // reload the element in case it changed since the sleep
       if (selectorOrStep) {
         logger.verbose("Runner: beforeAction reload element after sleep");
-        element = await this._browser.find(selectorOrStep, {
-          action,
-          timeoutMs: 0,
-          waitForRequests: false
-        });
+
+        try {
+          // try to find it immediately
+          element = await this._browser.find(selectorOrStep, {
+            action,
+            timeoutMs: 0,
+            waitForRequests: false
+          });
+        } catch (e) {
+          // if it cannot be found immediately wait longer
+          element = await this._browser.find(selectorOrStep, {
+            action,
+            timeoutMs: CONFIG.findTimeoutMs,
+            waitForRequests: false
+          });
+        }
       }
     }
 

--- a/packages/web/src/find/findText.ts
+++ b/packages/web/src/find/findText.ts
@@ -1,5 +1,6 @@
 import { FindOptions } from "@qawolf/types";
 import { cleanText } from "../lang";
+import { queryActionElements } from "./query";
 import { waitFor } from "../wait";
 
 export const findText = async (
@@ -11,10 +12,14 @@ export const findText = async (
 
   return waitFor(
     () => {
-      const elements = document.querySelectorAll("*");
+      const elements = queryActionElements(options.action || "click");
+
       for (let i = 0; i < elements.length; i++) {
         const element = elements[i] as HTMLElement;
-        if (cleanText(element.innerText) === selector) return element;
+        if (cleanText(element.innerText) === selector) {
+          console.log("found text", element);
+          return element;
+        }
       }
 
       return null;


### PR DESCRIPTION
- Browser.find: retryExecutionError

- findText: use queryActionElements to only choose valid / visible elements

- Runner.beforeAction: if an element is not immediately found after sleep, look for it again with the findTimeout. eg. the page reloads in between the sleep