### PR TITLE
use sendCharacter for keys that are single characters

### DIFF
--- a/packages/browser/src/keyboard/index.ts
+++ b/packages/browser/src/keyboard/index.ts
@@ -1,6 +1,7 @@
-export { characterToCode } from "./keys";
+export { keyToCode } from "./keys";
 
 export {
+  keyEventToStroke,
   serializeStrokes,
   stringToStrokes,
   valueToStrokes

--- a/packages/browser/src/keyboard/keys.ts
+++ b/packages/browser/src/keyboard/keys.ts
@@ -1,12 +1,10 @@
 import KeyDefinitions, { KeyDefinition } from "puppeteer/lib/USKeyboardLayout";
-import { Stroke } from "./Stroke";
 import "../types";
 
 // organizes the KeyDefinitions from USKeyboardLayout
 const codeToDefinition: { [code: string]: KeyDefinition } = {};
 const keyToDefinition: { [key: string]: KeyDefinition } = {};
 const shiftCodeToDefinition: { [code: string]: KeyDefinition } = {};
-const shiftKeyToDefinition: { [key: string]: KeyDefinition } = {};
 
 Object.keys(KeyDefinitions).forEach(key => {
   const definition = KeyDefinitions[key];
@@ -24,69 +22,8 @@ Object.keys(KeyDefinitions).forEach(key => {
     if (!shiftCodeToDefinition[definition.code]) {
       shiftCodeToDefinition[definition.code] = definition;
     }
-
-    if (!shiftKeyToDefinition[definition.shiftKey]) {
-      shiftKeyToDefinition[definition.shiftKey] = definition;
-    }
   }
 });
-
-export const characterToCode = (character: string): string | null => {
-  const definition = keyToDefinition[character];
-  return definition ? definition.code : null;
-};
-
-export const characterToStrokes = (character: string): Stroke[] => {
-  const strokes: Stroke[] = [];
-
-  const shiftKeyDefinition = shiftKeyToDefinition[character];
-  const keyDefinition = keyToDefinition[character];
-
-  if (!shiftKeyDefinition && !keyDefinition) {
-    // sendCharacter if we cannot find the key definition
-    strokes.push({
-      index: strokes.length,
-      type: "→",
-      value: character
-    });
-
-    return strokes;
-  }
-
-  const code = shiftKeyDefinition
-    ? shiftKeyDefinition.code
-    : keyDefinition.code;
-
-  if (shiftKeyDefinition) {
-    strokes.push({
-      index: strokes.length,
-      type: "↓",
-      value: "Shift"
-    });
-  }
-
-  strokes.push({
-    index: strokes.length,
-    type: "↓",
-    value: code
-  });
-
-  strokes.push({
-    index: strokes.length,
-    type: "↑",
-    value: code
-  });
-
-  if (shiftKeyDefinition) {
-    strokes.push({
-      index: strokes.length,
-      type: "↑",
-      value: "Shift"
-    });
-  }
-
-  return strokes;
-};
 
 export const codeToCharacter = (
   code: string,
@@ -105,4 +42,9 @@ export const codeToCharacter = (
   }
 
   return character;
+};
+
+export const keyToCode = (key: string): string | null => {
+  const definition = keyToDefinition[key];
+  return definition ? definition.code : null;
 };

--- a/packages/browser/src/keyboard/serializeStrokes.ts
+++ b/packages/browser/src/keyboard/serializeStrokes.ts
@@ -1,5 +1,5 @@
-import { flatten } from "lodash";
-import { characterToStrokes } from "./keys";
+import { KeyEvent } from "@qawolf/types";
+import { keyToCode } from "./keys";
 import { simplifyStrokes } from "./simplifyStrokes";
 import { Stroke, StrokeType } from "./Stroke";
 
@@ -20,6 +20,38 @@ export const deserializeStrokes = (serialized: string) => {
   return strokes;
 };
 
+export const keyEventToStroke = (
+  name: "keydown" | "keyup",
+  // KeyboardEvent.key
+  // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+  key: string,
+  index: number
+): Stroke | null => {
+  if (key.length === 1) {
+    // if the key is once character use sendCharacter
+    // this allows us to support international characters
+    // and skip keyup strokes
+    if (name === "keyup") return null;
+
+    return {
+      index,
+      type: "→",
+      value: key
+    };
+  }
+
+  // if the key is longer than a character it's a special key
+  // so use keyboard.up(code)/ keyboard.down(code)
+  const code = keyToCode(key);
+  if (!code) throw new Error(`${key} was not recognized`);
+
+  return {
+    index,
+    type: name === "keydown" ? "↓" : "↑",
+    value: code
+  };
+};
+
 export const serializeStrokes = (strokes: Stroke[]) => {
   const sortedStrokes = strokes.sort((a, b) => a.index - b.index);
 
@@ -31,11 +63,11 @@ export const serializeStrokes = (strokes: Stroke[]) => {
 };
 
 export const stringToStrokes = (value: string): Stroke[] => {
-  const strokes = flatten(
-    value.split("").map(character => characterToStrokes(character))
-  );
-
-  strokes.forEach((s, i) => (s.index = i));
+  const strokes = value.split("").map<Stroke>((character, i) => ({
+    index: i,
+    type: "→",
+    value: character
+  }));
 
   return strokes;
 };

--- a/packages/browser/src/keyboard/serializeStrokes.ts
+++ b/packages/browser/src/keyboard/serializeStrokes.ts
@@ -28,9 +28,9 @@ export const keyEventToStroke = (
   index: number
 ): Stroke | null => {
   if (key.length === 1) {
-    // if the key is once character use sendCharacter
-    // this allows us to support international characters
-    // and skip keyup strokes
+    // If the key is once character
+    // for keydown: use sendCharacter to support international characters
+    // for keyup: skip the event
     if (name === "keyup") return null;
 
     return {

--- a/packages/browser/src/keyboard/simplifyStrokes.ts
+++ b/packages/browser/src/keyboard/simplifyStrokes.ts
@@ -2,6 +2,10 @@ import { codeToCharacter } from "./keys";
 import { Stroke } from "./Stroke";
 
 class StrokeParser {
+  /**
+   * It is possible to simplify strokes to a plain string when Shift is the only special key
+   * because we can map the down strokes to their shift values.
+   */
   private _strokes: Stroke[];
   private _simplified: string = "";
   private _shiftDown: boolean = false;

--- a/packages/browser/tests/keyboard/keys.test.ts
+++ b/packages/browser/tests/keyboard/keys.test.ts
@@ -1,11 +1,11 @@
-import { characterToCode } from "../../src/keyboard/keys";
+import { keyToCode } from "../../src/keyboard/keys";
 
-describe("characterToCode", () => {
+describe("keyToCode", () => {
   it("converts a character to it's USKeyboard code", () => {
-    expect(characterToCode("S")).toEqual("KeyS");
+    expect(keyToCode("S")).toEqual("KeyS");
   });
 
   it("converts a non-USKeyboard character to null", () => {
-    expect(characterToCode("嗨")).toEqual(null);
+    expect(keyToCode("嗨")).toEqual(null);
   });
 });

--- a/packages/browser/tests/keyboard/serializeStrokes.test.ts
+++ b/packages/browser/tests/keyboard/serializeStrokes.test.ts
@@ -1,5 +1,6 @@
 import {
   deserializeStrokes,
+  keyEventToStroke,
   serializeStrokes,
   stringToStrokes
 } from "../../src/keyboard/serializeStrokes";
@@ -12,6 +13,46 @@ describe("deserializeStrokes", () => {
       "↓KeyY",
       "↑KeyY"
     ]);
+  });
+});
+
+describe("keyEventToStroke", () => {
+  describe("keydown", () => {
+    it("converts single character keys to sendCharacter", () => {
+      expect(keyEventToStroke("keydown", "h", 0)).toEqual({
+        index: 0,
+        type: "→",
+        value: "h"
+      });
+      expect(keyEventToStroke("keydown", "嗨", 0)).toEqual({
+        index: 0,
+        type: "→",
+        value: "嗨"
+      });
+    });
+
+    it("converts special character keys to keyboard.down", () => {
+      expect(keyEventToStroke("keydown", "Enter", 0)).toEqual({
+        index: 0,
+        type: "↓",
+        value: "NumpadEnter"
+      });
+    });
+  });
+
+  describe("keyup", () => {
+    it("skips single character keys", () => {
+      expect(keyEventToStroke("keyup", "h", 0)).toEqual(null);
+      expect(keyEventToStroke("keyup", "嗨", 0)).toEqual(null);
+    });
+
+    it("converts special character keys to keyboard.up", () => {
+      expect(keyEventToStroke("keyup", "Tab", 0)).toEqual({
+        index: 0,
+        type: "↑",
+        value: "Tab"
+      });
+    });
   });
 });
 
@@ -32,51 +73,18 @@ describe("serializeStrokes", () => {
 });
 
 describe("stringToStrokes", () => {
-  it("handles lower case characters", () => {
-    const strokes = stringToStrokes("hey");
+  it("converts to a sequence of sendCharacter", () => {
+    const strokes = stringToStrokes("hey YO! 嗨");
     expect(strokes.map(s => `${s.type}${s.value}`)).toEqual([
-      "↓KeyH",
-      "↑KeyH",
-      "↓KeyE",
-      "↑KeyE",
-      "↓KeyY",
-      "↑KeyY"
-    ]);
-  });
-
-  it("handles shift characters", () => {
-    const strokes = stringToStrokes("YO!");
-    expect(strokes.map(s => `${s.type}${s.value}`)).toEqual([
-      "↓Shift",
-      "↓KeyY",
-      "↑KeyY",
-      "↑Shift",
-      "↓Shift",
-      "↓KeyO",
-      "↑KeyO",
-      "↑Shift",
-      "↓Shift",
-      "↓Digit1",
-      "↑Digit1",
-      "↑Shift"
-    ]);
-  });
-
-  it("handles special characters", () => {
-    const strokes = stringToStrokes("嗨! 嗨!");
-    expect(strokes.map(s => `${s.type}${s.value}`)).toEqual([
-      "→嗨",
-      "↓Shift",
-      "↓Digit1",
-      "↑Digit1",
-      "↑Shift",
-      "↓Space",
-      "↑Space",
-      "→嗨",
-      "↓Shift",
-      "↓Digit1",
-      "↑Digit1",
-      "↑Shift"
+      "→h",
+      "→e",
+      "→y",
+      "→ ",
+      "→Y",
+      "→O",
+      "→!",
+      "→ ",
+      "→嗨"
     ]);
   });
 });

--- a/packages/build-workflow/src/buildTypeSteps.ts
+++ b/packages/build-workflow/src/buildTypeSteps.ts
@@ -1,5 +1,5 @@
 import {
-  characterToCode,
+  keyEventToStroke,
   serializeStrokes,
   stringToStrokes,
   Stroke,
@@ -68,20 +68,11 @@ export class TypeStepFactory {
       return;
     }
 
-    const code = characterToCode(event.value);
-    let type: StrokeType = event.name === "keydown" ? "↓" : "↑";
-    if (!code) {
-      // sendCharacter if we cannot find the key's code
-      type = "→";
-    }
+    const stroke = keyEventToStroke(event.name, event.value, index);
+    if (!stroke) return;
 
     if (!this.pendingEvent) this.pendingEvent = event;
-
-    this.pendingStrokes.push({
-      index,
-      type,
-      value: code ? code : event.value
-    });
+    this.pendingStrokes.push(stroke);
   }
 
   buildPasteStrokes(event: PasteEvent, index: number) {

--- a/packages/web-tests/tests/Recorder.test.ts
+++ b/packages/web-tests/tests/Recorder.test.ts
@@ -128,22 +128,9 @@ describe("Recorder", () => {
     const events = page.qawolf.events.filter(e => e.isTrusted);
 
     expect(events[0].target.node.attrs.id).toEqual("password");
+    // we will not receive any events for "secret" since it is all sendCharacter
     expect(
       (events.filter(e => isKeyEvent(e)) as KeyEvent[]).map(e => e.value)
-    ).toEqual([
-      "s",
-      "s",
-      "e",
-      "e",
-      "c",
-      "c",
-      "r",
-      "r",
-      "e",
-      "e",
-      "t",
-      "t",
-      "Enter"
-    ]);
+    ).toEqual(["Enter"]);
   });
 });


### PR DESCRIPTION
fixes #240

- remove characterToStrokes logic which made bad assumptions for non-us keyboards, this simplifies our keyboard code a lot
- instead use sendCharacter for single characters (we will add a little complexity to that in https://github.com/qawolf/qawolf/issues/242 to better support hotkeys)