### PR TITLE
Docker: add docker-host to hosts

### DIFF
--- a/bin/qawolf
+++ b/bin/qawolf
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+# expose the Docker host as an environment variable https://stackoverflow.com/a/31328031
+export DOCKER_HOST=$(ip route show | awk '/default/ {print $3}')
+
+# add it to hosts so external environment variables can reference it
+echo "$DOCKER_HOST docker-host" >> /etc/hosts
+
 qawolf-xvfb-run node ${QAWOLF_DIR}/packages/cli/lib/index.js "$@"


### PR DESCRIPTION
- export DOCKER_HOST as an environment variable

This is to make it easy to run tests against localhost in GitHub Actions / etc. Resolves #265