### PR TITLE
Fix 'Invalid command "create"' error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ QA Wolf is tested against the [maintenance LTS](https://github.com/nodejs/Releas
 Create a [Puppeteer](https://github.com/puppeteer/puppeteer) and [Jest](https://jestjs.io/) test:
 
 ```bash
-npx qawolf create <url> [name]
+npx qawolf record <url> [name]
 ```
 
 ![Create a test](https://storage.googleapis.com/docs.qawolf.com/home/create-test-small.gif)


### PR DESCRIPTION
I have referenced [this documentation](https://docs.qawolf.com/docs/quick_start#-create-a-browser-test).

![image](https://user-images.githubusercontent.com/10116129/72116170-bac2fb80-338c-11ea-9070-d69b78c55917.png)
