### PR TITLE
Update ci templates for 0.8.0

### DIFF
--- a/packages/cli/static/azure.hbs
+++ b/packages/cli/static/azure.hbs
@@ -10,6 +10,7 @@ steps:
 
   - script: npm install
 
+  # # Start local server
   # - script: npm run start & npx wait-on http://localhost:3000
 
   - script: npx qawolf test

--- a/packages/cli/static/azure.hbs
+++ b/packages/cli/static/azure.hbs
@@ -1,25 +1,25 @@
 # configure the pipeline to run based on different triggers
 # see https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema#triggers
-resources:
-  containers:
-    - container: qawolf
-      image: qawolf/qawolf:v{{{version}}}
-
 pool:
-  vmImage: "ubuntu-16.04"
-
-container: qawolf
+  vmImage: "ubuntu-18.04"
 
 steps:
-  - script: qawolf test
+  - task: NodeTool@0
+    inputs:
+      versionSpec: "12.x"
+
+  - script: npm install
+
+  # - script: npm run start & npx wait-on http://localhost:3000
+
+  - script: npx qawolf test
     env:
-      # output artifacts
       QAW_ARTIFACT_PATH: $(System.DefaultWorkingDirectory)/artifacts
-      # # configure tests with environment variables
-      # # https://docs.qawolf.com/docs/configuration
+      # configure tests with environment variables
+      # https://docs.qawolf.com/docs/configuration
       # QAW_SLEEP_MS: 0
-      # # you can also use secret environment variables
-      # # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables
+      # you can also use secret environment variables
+      # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables
       # LOGIN_PASSWORD: $(SECRET_PASSWORD)
 
   - publish: $(System.DefaultWorkingDirectory)/artifacts

--- a/packages/cli/static/circleci.hbs
+++ b/packages/cli/static/circleci.hbs
@@ -2,28 +2,38 @@ version: 2
 jobs:
   build:
     docker:
-      - image: qawolf/qawolf:v{{{version}}}
-        environment:
-          # output artifacts
-          QAW_ARTIFACT_PATH: /tmp/artifacts
-          # # configure tests with environment variables
-          # # https://docs.qawolf.com/docs/configuration
-          # QAW_SLEEP_MS: 0
-          # # you can also use secret environment variables
-          # # https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
-          # LOGIN_PASSWORD: ${SECRET_PASSWORD}
-
-      # # use your container in the workflow
-      # - image: owner/image:tag
+      - image: circleci/node:12.14.0-browsers
     steps:
-      # checkout to include the .qawolf/ folder
       - checkout
 
+      - restore_cache:
+          key: dependency-cache-\{{ checksum "package-lock.json" }}
+
       - run:
-          command: qawolf test
+          command: npm install
+
+      - save_cache:
+          key: dependency-cache-\{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+
+      - run:
+          command: |
+            # npm run start & 
+            # npx wait-on http://localhost:3000
+            npx qawolf test
+          environment:
+            QAW_ARTIFACT_PATH: /tmp/artifacts
+            # # configure tests with environment variables
+            # # https://docs.qawolf.com/docs/configuration
+            # QAW_SLEEP_MS: 0
+            # # you can also use secret environment variables
+            # # https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
+            # LOGIN_PASSWORD: ${SECRET_PASSWORD}
 
       - store_artifacts:
           path: /tmp/artifacts
+
 # # example for running on a schedule, edit to suit your use case
 # # documentation: https://circleci.com/docs/2.0/configuration-reference/#schedule
 # workflows:

--- a/packages/cli/static/circleci.hbs
+++ b/packages/cli/static/circleci.hbs
@@ -19,6 +19,7 @@ jobs:
 
       - run:
           command: |
+            # # Start local server
             # npm run start & 
             # npx wait-on http://localhost:3000
             npx qawolf test

--- a/packages/cli/static/github.hbs
+++ b/packages/cli/static/github.hbs
@@ -9,33 +9,38 @@ on:
   #   - cron: "0 * * * *" # every hour
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
+
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+
+      - uses: actions/cache@v1
         with:
-          fetch-depth: 50
-      - name: qawolf test
-        uses: docker://qawolf/qawolf:v{{{version}}}
-        with:
-          args: "qawolf test"
+          path: ~/.npm
+          key: $\{{ runner.os }}-node-$\{{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            $\{{ runner.os }}-node-
+
+      - run: npm install
+
+      # - name: Start local server
+      #   run: npm run start & npx wait-on http://localhost:3000
+
+      - run: npx qawolf test
         env:
-          # output artifacts
-          QAW_ARTIFACT_PATH: /tmp/artifacts
+          QAW_ARTIFACT_PATH: $\{{ github.workspace }}/artifacts
         #   # configure tests with environment variables
         #   # https://docs.qawolf.com/docs/configuration
         #   QAW_SLEEP_MS: 0
         #   # you can also use GitHub secrets for environment variables
         #   # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets
         #   LOGIN_PASSWORD: $\{{ secrets.PASSWORD }}
+
       - name: Upload Artifacts
-        # include test artifacts
-        # edit below to only include artifacts in certain scenarios
         if: always()
         uses: actions/upload-artifact@master
         with:
           name: qawolf
-          path: "./artifacts"
-    ## use your container in the workflow
-    # services:
-    #   my_service:
-    #     image: owner/image:tag
+          path: $\{{ github.workspace }}/artifacts

--- a/packages/cli/static/gitlab.hbs
+++ b/packages/cli/static/gitlab.hbs
@@ -7,6 +7,7 @@ qawolf:
 
   script:
     - npm install
+    # # Start local server
     # - npm run start & npx wait-on http://localhost:3000
     - npx qawolf test
 

--- a/packages/cli/static/gitlab.hbs
+++ b/packages/cli/static/gitlab.hbs
@@ -1,15 +1,26 @@
 qawolf:
   image: qawolf/qawolf:v{{{version}}}
-  script: qawolf test
+
+  cache:
+    paths:
+      - node_modules/
+
+  script:
+    - npm install
+    # - npm run start & npx wait-on http://localhost:3000
+    - npx qawolf test
+
   variables:
-    # output artifacts
-    QAW_ARTIFACT_PATH: /tmp/artifacts
+    QAW_ARTIFACT_PATH: $CI_PROJECT_DIR/artifacts
     ## configure tests with environment variables
     ## https://docs.qawolf.com/docs/configuration
     # QAW_SLEEP_MS: 0
     ## you can also use GitLab protected environment variables
     ## https://docs.gitlab.com/ee/ci/variables/#protected-environment-variables
     # LOGIN_PASSWORD: $SECRET_PASSWORD
+  
   artifacts:
+    when: always
     paths:
       - $CI_PROJECT_DIR/artifacts
+    expire_in: 1 week

--- a/packages/qawolf/package-lock.json
+++ b/packages/qawolf/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qawolf",
-  "version": "0.8.0-alpha.0",
+  "version": "0.8.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -348,15 +348,15 @@
       }
     },
     "@qawolf/browser": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/browser/-/browser-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-LkZJOhisKR9dEkSw1AGnaaZ7bTTut/ZFbr7PhRa0/v/Eo8Er1+Fm3LuRQ61An9mU94POWVBX+ZJ+wXM3+1HGjg==",
+      "version": "0.8.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/browser/-/browser-0.8.0-alpha.2.tgz",
+      "integrity": "sha512-2ua8WXkN4g0Jose3+aDnbpP4yp0l1sAmJCvvxwTgq0RVkt7KPygvHUF40TFSTEXh+GH9FLq/d8xLhIjyA8nM7w==",
       "requires": {
-        "@qawolf/config": "^0.8.0-alpha.0",
-        "@qawolf/logger": "^0.8.0-alpha.0",
-        "@qawolf/screen": "^0.8.0-alpha.0",
+        "@qawolf/config": "^0.8.0-alpha.1",
+        "@qawolf/logger": "^0.8.0-alpha.1",
+        "@qawolf/screen": "^0.8.0-alpha.1",
         "@qawolf/types": "^0.8.0-alpha.0",
-        "@qawolf/web": "^0.8.0-alpha.0",
+        "@qawolf/web": "^0.8.0-alpha.1",
         "fs-extra": "^8.1.0",
         "lodash": "^4.17.15",
         "puppeteer": "^2.0.0",
@@ -364,23 +364,23 @@
       }
     },
     "@qawolf/build-code": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/build-code/-/build-code-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-nHPIjxDZEksRUQHW0opxSq4qgKw5eiTSVuEjXjk0dVI/1s94RQGy826M1pIjCP9u9npi4jvUzignFdT2ORkedw==",
+      "version": "0.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@qawolf/build-code/-/build-code-0.8.0-alpha.1.tgz",
+      "integrity": "sha512-hn89rOlpkDzKgtFYDgTyxWarMZJWU0fH8aoiTqHqkQy3NGq+QrWB6N3NFKq7e3XTxqVFJPsZQ4azam1JcmiqKQ==",
       "requires": {
-        "@qawolf/config": "^0.8.0-alpha.0",
-        "@qawolf/web": "^0.8.0-alpha.0",
+        "@qawolf/config": "^0.8.0-alpha.1",
+        "@qawolf/web": "^0.8.0-alpha.1",
         "fs-extra": "^8.1.0",
         "handlebars": "^4.4.3"
       }
     },
     "@qawolf/build-workflow": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/build-workflow/-/build-workflow-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-2d3cZbK1Wd8bNHoIW54JsXQEdGSbX+75MobJNx1q4g5eRiAX0CTeBkGkLFAGUk+kv04dPZeAxBUEBgIyhJpa4g==",
+      "version": "0.8.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/build-workflow/-/build-workflow-0.8.0-alpha.2.tgz",
+      "integrity": "sha512-rDAFeLhEiwcugp4n1GFhUZRrCK9BMg70/ZfjI6+EDbI5LPqaYwiJ+JqCbRPf918KQwTJHNknIPw5jzQGE6MAxw==",
       "requires": {
-        "@qawolf/browser": "^0.8.0-alpha.0",
-        "@qawolf/logger": "^0.8.0-alpha.0",
+        "@qawolf/browser": "^0.8.0-alpha.2",
+        "@qawolf/logger": "^0.8.0-alpha.1",
         "lodash": "^4.17.15"
       }
     },
@@ -390,17 +390,17 @@
       "integrity": "sha512-D5H5RjqqE+YxI2oeTgSRuIjdy/hli90H5mMd81bBrYlOfB/f4TBsKMoaWfzI5E4bmFzLfQJuvvepTaWrxVfBug=="
     },
     "@qawolf/cli": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/cli/-/cli-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-5hLMcxkh1m/a40nosa8ijGdFf96tNt27WmF/RKEltiW0xR3r2f7UAEtnTN8r8lkZOQ/dkQTlneIA10tsWgy2eA==",
+      "version": "0.8.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/cli/-/cli-0.8.0-alpha.2.tgz",
+      "integrity": "sha512-mRhpNTEtwyd3851DGK2K/5+sYDFv9aUxR/0eUDkB05c84qHHZcT9ng9NfXcCdygJch8H5aZUcJZPcircOmMNGA==",
       "requires": {
-        "@qawolf/browser": "^0.8.0-alpha.0",
-        "@qawolf/build-code": "^0.8.0-alpha.0",
-        "@qawolf/build-workflow": "^0.8.0-alpha.0",
-        "@qawolf/config": "^0.8.0-alpha.0",
-        "@qawolf/jasmine-fail-fast": "^2.0.1",
-        "@qawolf/logger": "^0.8.0-alpha.0",
-        "@qawolf/web": "^0.8.0-alpha.0",
+        "@qawolf/browser": "^0.8.0-alpha.2",
+        "@qawolf/build-code": "^0.8.0-alpha.1",
+        "@qawolf/build-workflow": "^0.8.0-alpha.2",
+        "@qawolf/config": "^0.8.0-alpha.1",
+        "@qawolf/jest-fail-fast": "^0.8.0-alpha.2",
+        "@qawolf/logger": "^0.8.0-alpha.1",
+        "@qawolf/web": "^0.8.0-alpha.1",
         "commander": "^3.0.2",
         "fs-extra": "^8.1.0",
         "inquirer": "^7.0.0",
@@ -412,9 +412,9 @@
       }
     },
     "@qawolf/config": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/config/-/config-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-C8F7KBe53FQe+XAFWEJYU7PGhVQ2RLjKkU2mHpQ2tCsE20qWNw9sKLF68Cf5qICSuKZ9N4nXFIKz7OR8ud2rxQ==",
+      "version": "0.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@qawolf/config/-/config-0.8.0-alpha.1.tgz",
+      "integrity": "sha512-FsITjBVMqQ3JLV1c5lHBoaUSGeXmRAZhQWjqef7gg4Y7jlsN3pngXhy+jGhHwUMm2CDUklGGtBHMjIK9UMpb9g==",
       "requires": {
         "dotenv": "^8.1.0",
         "fs-extra": "^8.1.0"
@@ -428,24 +428,33 @@
         "lodash": "^4.17.15"
       }
     },
-    "@qawolf/logger": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/logger/-/logger-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-PlJZ29I6+nklfJfezMLfssTY8sWEHma16KgliCevVdjXqkHtYQ66e1Fqu9wRdO82mKjmVT2PCN52UguCJffybQ==",
+    "@qawolf/jest-fail-fast": {
+      "version": "0.8.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@qawolf/jest-fail-fast/-/jest-fail-fast-0.8.0-alpha.2.tgz",
+      "integrity": "sha512-0e3Tzu4WxEmznuqHa7cMjUkTOlRpfPJPZjuQ8DKeQxGMJsGnLuqQNnDRlljPrhY1kNQrnj1hF+GI6XPmrUwyQw==",
       "requires": {
-        "@qawolf/config": "^0.8.0-alpha.0",
+        "@qawolf/jasmine-fail-fast": "^2.0.1"
+      }
+    },
+    "@qawolf/logger": {
+      "version": "0.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@qawolf/logger/-/logger-0.8.0-alpha.1.tgz",
+      "integrity": "sha512-9nqC0xefEgLucF7UMuMKEUx/ZgmSzD+B6o27vztTcTF1aldWnCkn4nHynHyuEiQq0y4YUsFk1JYQnohSCEipLw==",
+      "requires": {
+        "@qawolf/config": "^0.8.0-alpha.1",
         "winston": "^3.2.1"
       }
     },
     "@qawolf/screen": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/screen/-/screen-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-3k+vX8WCIy5g3elQ0oaJeM6yrmu9k5xoCyqsvk6SA9EP0QkDGCQLoRdXwmMajI856JtNAdgQ0RDOpW2As5mmsA==",
+      "version": "0.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@qawolf/screen/-/screen-0.8.0-alpha.1.tgz",
+      "integrity": "sha512-wUcHj50KH3SzBLnHihdJOBB/gnjU1B5nKJNaNvlqmwW1D2l7hkSOt17fLTh1qJuwVbFR2kIy1Eu5wdoFwGlqJA==",
       "requires": {
         "@qawolf/ci-info": "^2.1.0",
-        "@qawolf/config": "^0.8.0-alpha.0",
-        "@qawolf/logger": "^0.8.0-alpha.0",
-        "@qawolf/web": "^0.8.0-alpha.0",
+        "@qawolf/config": "^0.8.0-alpha.1",
+        "@qawolf/logger": "^0.8.0-alpha.1",
+        "@qawolf/web": "^0.8.0-alpha.1",
+        "ffmpeg-static": "^3.0.0",
         "fs-extra": "^8.1.0",
         "xvfb": "^0.3.0"
       }
@@ -456,9 +465,9 @@
       "integrity": "sha512-c8pCvEH0UFfyTQUP+6b+B1vabEh9dSc6eQa6BSdKV/AjxFrTV/xxkHzExdG/5JzSfIffTDtyNqjh/cge58UJjQ=="
     },
     "@qawolf/web": {
-      "version": "0.8.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@qawolf/web/-/web-0.8.0-alpha.0.tgz",
-      "integrity": "sha512-UU9tPE7P3bjX2XiO6hLL2lM5GnoJTU+5V8kJQu7Qd9eVYVlXvBjpfR+fsHNcfDe9MRNJ5vOke73crtJyu93sGA==",
+      "version": "0.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@qawolf/web/-/web-0.8.0-alpha.1.tgz",
+      "integrity": "sha512-KZ8IjRsK5BLG+h1wegMwuko1+EzBsZVpdkdxa7AW4JCFwwmMx9Qm6C0H5v3TB9w90eOUMG2uF/FxKgzDCVpdVg==",
       "requires": {
         "@jperl/html-parse-stringify": "1.0.4"
       }
@@ -1992,6 +2001,11 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
+    },
+    "ffmpeg-static": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-3.0.0.tgz",
+      "integrity": "sha512-LCBAB1J10ku7+SWbFTLJ4zjDtrniwYDMIyRmg1Vxvzst5TyCrsrfKHg1YPrvvsUhrzknTXxL6NoUG6s2xftbcg=="
     },
     "figures": {
       "version": "3.1.0",


### PR DESCRIPTION
#306 

- Use node directly instead of docker
- Include commented out example of starting node server
- Cache node_modules