### PR TITLE
Simulate click by default

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -197,8 +197,9 @@ A [puppeteer.Browser] with actions and assertions to [find](review_test_code#ele
   - `css` <?[CssSelector]> find the first visible element with `document.querySelector(css)`.
   - `html` <?[string]> find the closest match to this html element.
   - `text` <?[string]> find an element with this text.
-- `options` <[FindElementOptions]> find the element with these options.
+- `options` <[FindElementOptions] & ClickOptions> find the element with these options.
   - `page` <?[number]> the index of the page to use in order of creation, starting with 0. defaults to the last used page.
+  - `simulate` <?[boolean]> simulate the click with [HTMLElement.click()]. Defaults to `true`.
   - `sleepMs` <?[number]> sleep after an element is found for this time in milliseconds. Defaults to [QAW_SLEEP_MS](#qaw_sleep_ms).
   - `timeoutMs` <?[number]> maximum time to wait for an element and page. Defaults to [QAW_TIMEOUT_MS](#qaw_timeout_ms).
   - `waitForRequests` <?[boolean]> wait until the page completes all network requests (limited to 10s per request). Defaults to `true`.
@@ -448,6 +449,7 @@ await browser.type(selectors[1], "my@email.com");
 [findelementoptions]: #interface-findelementoptions "FindElementOptions"
 [findpageoptions]: #interface-findpageoptions "FindPageOptions"
 [function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function "Function"
+[htmlelement.click()]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/click "HTMLElement.click"
 [keyboard.down]: https://github.com/puppeteer/puppeteer/blob/v2.0.0/docs/api.md#keyboarddownkey-options "keyboard.down"
 [keyboard.up]: https://github.com/puppeteer/puppeteer/blob/v2.0.0/docs/api.md#keyboardupkey "keyboard.up"
 [number]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Number_type "number"

--- a/packages/browser/src/actions/clickElement.ts
+++ b/packages/browser/src/actions/clickElement.ts
@@ -11,6 +11,14 @@ export const clickElement = async (
 ): Promise<void> => {
   logger.verbose(`clickElement: received ${JSON.stringify(options)}`);
 
+  // ElementHandle.click scrolls an element into view, finds it's coordinates, and clicks on that point.
+  // There are corner cases like custom scrolling where it will break.
+  // https://github.com/puppeteer/puppeteer/issues/2190#issuecomment-380254352
+  // We ran into unexplainable issues with clients where it would hang, but simulating a click works fine.
+  // https://github.com/puppeteer/puppeteer/issues/3347
+  // Since simulating the click is simpler and works more often, we default to it.
+  // However we expose ElementHandle.click behind an option, simulate=false, in case it is needed.
+  // For example, we use simulate=false for the Recorder test since we need a trusted click event.
   if (options.simulate === false) {
     await element.click();
   } else {

--- a/packages/browser/src/actions/clickElement.ts
+++ b/packages/browser/src/actions/clickElement.ts
@@ -1,8 +1,21 @@
 import { logger } from "@qawolf/logger";
 import { ElementHandle } from "puppeteer";
 
-export const clickElement = async (element: ElementHandle): Promise<void> => {
-  logger.verbose("clickElement");
+export type ClickOptions = {
+  simulate?: boolean;
+};
 
-  await element.click();
+export const clickElement = async (
+  element: ElementHandle,
+  options: ClickOptions = {}
+): Promise<void> => {
+  logger.verbose(`clickElement: received ${JSON.stringify(options)}`);
+
+  if (options.simulate === false) {
+    await element.click();
+  } else {
+    await element.evaluate(e => (e as HTMLElement).click());
+  }
+
+  logger.verbose("clickElement: clicked");
 };

--- a/packages/browser/src/actions/index.ts
+++ b/packages/browser/src/actions/index.ts
@@ -1,5 +1,5 @@
 export { clearElement } from "./clearElement";
-export { clickElement } from "./clickElement";
+export { clickElement, ClickOptions } from "./clickElement";
 export { scrollElement } from "./scrollElement";
 export { selectElement } from "./selectElement";
 export { typeElement } from "./typeElement";

--- a/packages/browser/src/browser/Browser.ts
+++ b/packages/browser/src/browser/Browser.ts
@@ -10,6 +10,7 @@ import {
   DirectNavigationOptions,
   ElementHandle
 } from "puppeteer";
+import { ClickOptions } from "../actions/clickElement";
 import { Page } from "../page/Page";
 import { QAWolfBrowser } from "./QAWolfBrowser";
 
@@ -17,7 +18,7 @@ import { QAWolfBrowser } from "./QAWolfBrowser";
 export interface Browser extends PuppeteerBrowser {
   click(
     selector: Selector,
-    options?: FindElementOptions
+    options?: FindElementOptions & ClickOptions
   ): Promise<ElementHandle>;
 
   find: (

--- a/packages/browser/src/browser/QAWolfBrowser.ts
+++ b/packages/browser/src/browser/QAWolfBrowser.ts
@@ -18,6 +18,7 @@ import {
   DirectNavigationOptions,
   ElementHandle
 } from "puppeteer";
+import { ClickOptions } from "../actions/clickElement";
 import { Browser } from "./Browser";
 import { decorateBrowser } from "./decorateBrowser";
 import { createDomReplayer } from "../page/createDomReplayer";
@@ -67,7 +68,7 @@ export class QAWolfBrowser {
 
   public async click(
     selector: Selector,
-    options: FindElementOptions = {}
+    options: FindElementOptions & ClickOptions = {}
   ): Promise<ElementHandle> {
     const page = await this.page({
       ...options,

--- a/packages/browser/src/page/QAWolfPage.ts
+++ b/packages/browser/src/page/QAWolfPage.ts
@@ -10,6 +10,7 @@ import { ElementHandle } from "puppeteer";
 import { eventWithTime } from "rrweb/typings/types";
 import {
   clickElement,
+  ClickOptions,
   scrollElement,
   selectElement,
   typeElement
@@ -36,7 +37,7 @@ export class QAWolfPage {
 
   public click(
     selector: Selector,
-    options: FindElementOptions = {}
+    options: FindElementOptions & ClickOptions = {}
   ): Promise<ElementHandle> {
     logger.verbose(`Page ${this._index}: click`);
 
@@ -46,7 +47,7 @@ export class QAWolfPage {
         action: "click"
       });
 
-      await clickElement(element);
+      await clickElement(element, options);
 
       return element;
     });

--- a/packages/web-tests/tests/Recorder.test.ts
+++ b/packages/web-tests/tests/Recorder.test.ts
@@ -9,7 +9,7 @@ describe("Recorder", () => {
       recordEvents: true,
       url: CONFIG.testUrl
     });
-    await browser.click({ html: "<a>broken images</a>" });
+    await browser.click({ html: "<a>broken images</a>" }, { simulate: false });
 
     // close the browser to ensure events are transmitted
     await sleep(1000);


### PR DESCRIPTION
Default click to use HTMLElement.click with is more stable than ElementHandle.click. Provide option to `{ simulate: false }`.

Relates to https://github.com/puppeteer/puppeteer/issues/3347