### PR TITLE
🖱️Record mousedown instead of click. Use Playwright click by default.

### DIFF
--- a/packages/browser/src/actions/clickElement.ts
+++ b/packages/browser/src/actions/clickElement.ts
@@ -11,25 +11,26 @@ export const clickElement = async (
 ): Promise<void> => {
   logger.verbose(`clickElement: received ${JSON.stringify(options)}`);
 
-  // ElementHandle.click scrolls an element into view, finds it's coordinates, and clicks on that point.
-  // There are corner cases like custom scrolling where it will break.
-  // https://github.com/puppeteer/puppeteer/issues/2190#issuecomment-380254352
-  // We ran into unexplainable issues with clients where it would hang, but simulating a click works fine.
-  // https://github.com/puppeteer/puppeteer/issues/3347
-  // Since simulating the click is simpler and works more often, we default to it.
-  // However we expose ElementHandle.click behind an option, simulate=false, in case it is needed.
-  // For example, we use simulate=false for the Recorder test since we need a trusted click event.
-  if (options.simulate === false) {
-    await elementHandle.evaluate(element =>
-      console.log("qawolf: click", element)
-    );
-    await elementHandle.click();
-  } else {
+  if (options.simulate) {
+    // We provide options.simulate as a workaround for when Playwright click does not work.
+    // ElementHandle.click scrolls an element into view, finds it's coordinates, and clicks on that point.
+    // There are corner cases like custom scrolling where it will break.
+    // https://github.com/puppeteer/puppeteer/issues/2190#issuecomment-380254352
+    // We ran into unexplainable issues with clients where it would hang, but simulating a click works fine.
+    // https://github.com/puppeteer/puppeteer/issues/3347
+    // However we default to the original Playwright click since there are also scenarios
+    // where simulating a click does not work (ex. Material-UI Dropdown).
+    // This also keeps our API closer to the Playwright API.
     await elementHandle.evaluate((element: HTMLElement) => {
       console.log("qawolf: click", element);
       const clickEvent = new MouseEvent("click", { bubbles: true });
       element.dispatchEvent(clickEvent);
     });
+  } else {
+    await elementHandle.evaluate(element =>
+      console.log("qawolf: click", element)
+    );
+    await elementHandle.click();
   }
 
   logger.verbose("clickElement: clicked");

--- a/packages/build-workflow/src/buildClickSteps.ts
+++ b/packages/build-workflow/src/buildClickSteps.ts
@@ -8,7 +8,7 @@ export const buildClickSteps = (events: ElementEvent[]): Step[] => {
     const event = events[i];
 
     // ignore other actions
-    if (event.name !== "click") continue;
+    if (event.name !== "mousedown") continue;
 
     // ignore system initiated clicks
     if (!event.isTrusted) continue;

--- a/packages/test/events/click_username.json
+++ b/packages/test/events/click_username.json
@@ -1,42 +1,42 @@
 [
- {
-  "isTrusted": true,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
+  {
+    "isTrusted": true,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
     },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575827963971
- }
+    "time": 1575827963971
+  }
 ]

--- a/packages/test/events/dropdown.json
+++ b/packages/test/events/dropdown.json
@@ -1,179 +1,179 @@
 [
- {
-  "isTrusted": true,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "select",
-    "voidElement": false,
-    "attrs": {
-     "id": "dropdown",
-     "innertext": "Please select an option Option 1 Option 2"
+  {
+    "isTrusted": true,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "select",
+        "voidElement": false,
+        "attrs": {
+          "id": "dropdown",
+          "innertext": "Please select an option Option 1 Option 2"
+        },
+        "children": [
+          {
+            "type": "text",
+            "content": "      "
+          },
+          {
+            "type": "tag",
+            "name": "option",
+            "voidElement": false,
+            "attrs": {
+              "value": "",
+              "disabled": "disabled",
+              "selected": "selected"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Please select an option"
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "option",
+            "voidElement": false,
+            "attrs": {
+              "value": "1"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Option 1"
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "option",
+            "voidElement": false,
+            "attrs": {
+              "value": "2"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Option 2"
+              }
+            ]
+          }
+        ]
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "example"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "id": "content",
+            "class": "large-12 columns"
+          },
+          "children": []
+        }
+      ]
     },
-    "children": [
-     {
-      "type": "text",
-      "content": "      "
-     },
-     {
-      "type": "tag",
-      "name": "option",
-      "voidElement": false,
-      "attrs": {
-       "value": "",
-       "disabled": "disabled",
-       "selected": "selected"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Please select an option"
-       }
-      ]
-     },
-     {
-      "type": "tag",
-      "name": "option",
-      "voidElement": false,
-      "attrs": {
-       "value": "1"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Option 1"
-       }
-      ]
-     },
-     {
-      "type": "tag",
-      "name": "option",
-      "voidElement": false,
-      "attrs": {
-       "value": "2"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Option 2"
-       }
-      ]
-     }
-    ]
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "example"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "id": "content",
-      "class": "large-12 columns"
-     },
-     "children": []
-    }
-   ]
+    "time": 1575827987391
   },
-  "time": 1575827987391
- },
- {
-  "isTrusted": true,
-  "name": "input",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "select",
-    "voidElement": false,
-    "attrs": {
-     "id": "dropdown",
-     "innertext": "Please select an option Option 1 Option 2"
+  {
+    "isTrusted": true,
+    "name": "input",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "select",
+        "voidElement": false,
+        "attrs": {
+          "id": "dropdown",
+          "innertext": "Please select an option Option 1 Option 2"
+        },
+        "children": [
+          {
+            "type": "text",
+            "content": "      "
+          },
+          {
+            "type": "tag",
+            "name": "option",
+            "voidElement": false,
+            "attrs": {
+              "value": "",
+              "disabled": "disabled",
+              "selected": "selected"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Please select an option"
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "option",
+            "voidElement": false,
+            "attrs": {
+              "value": "1"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Option 1"
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "option",
+            "voidElement": false,
+            "attrs": {
+              "value": "2"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Option 2"
+              }
+            ]
+          }
+        ]
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "example"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "id": "content",
+            "class": "large-12 columns"
+          },
+          "children": []
+        }
+      ]
     },
-    "children": [
-     {
-      "type": "text",
-      "content": "      "
-     },
-     {
-      "type": "tag",
-      "name": "option",
-      "voidElement": false,
-      "attrs": {
-       "value": "",
-       "disabled": "disabled",
-       "selected": "selected"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Please select an option"
-       }
-      ]
-     },
-     {
-      "type": "tag",
-      "name": "option",
-      "voidElement": false,
-      "attrs": {
-       "value": "1"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Option 1"
-       }
-      ]
-     },
-     {
-      "type": "tag",
-      "name": "option",
-      "voidElement": false,
-      "attrs": {
-       "value": "2"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Option 2"
-       }
-      ]
-     }
-    ]
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "example"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "id": "content",
-      "class": "large-12 columns"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575827988391,
-  "value": "2"
- }
+    "time": 1575827988391,
+    "value": "2"
+  }
 ]

--- a/packages/test/events/githubIssuesShortcut.json
+++ b/packages/test/events/githubIssuesShortcut.json
@@ -1,196 +1,196 @@
 [
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "body",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1576875771742,
-  "value": "g"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "body",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1576875772155,
-  "value": "i"
- },
- {
-  "isTrusted": false,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "a",
-    "voidElement": false,
-    "attrs": {
-     "itemprop": "url",
-     "data-hotkey": "g i",
-     "class": "js-selected-navigation-item reponav-item",
-     "data-selected-links": "repo_issues repo_labels repo_milestones /qawolf/qawolf/issues",
-     "href": "/qawolf/qawolf/issues",
-     "innertext": "Issues 10"
-    },
-    "children": [
-     {
-      "type": "text",
-      "content": "        "
-     },
-     {
-      "type": "tag",
-      "name": "div",
-      "voidElement": false,
-      "attrs": {
-       "class": "d-inline"
-      },
-      "children": [
-       {
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
         "type": "tag",
-        "name": "svg",
+        "name": "body",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1576875771742,
+    "value": "g"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "body",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1576875772155,
+    "value": "i"
+  },
+  {
+    "isTrusted": false,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "a",
         "voidElement": false,
         "attrs": {
-         "class": "octicon octicon-issue-opened",
-         "viewBox": "0 0 14 16",
-         "version": "1.1",
-         "width": "14",
-         "height": "16",
-         "aria-hidden": "true"
+          "itemprop": "url",
+          "data-hotkey": "g i",
+          "class": "js-selected-navigation-item reponav-item",
+          "data-selected-links": "repo_issues repo_labels repo_milestones /qawolf/qawolf/issues",
+          "href": "/qawolf/qawolf/issues",
+          "innertext": "Issues 10"
         },
         "children": [
-         {
+          {
+            "type": "text",
+            "content": "        "
+          },
+          {
+            "type": "tag",
+            "name": "div",
+            "voidElement": false,
+            "attrs": {
+              "class": "d-inline"
+            },
+            "children": [
+              {
+                "type": "tag",
+                "name": "svg",
+                "voidElement": false,
+                "attrs": {
+                  "class": "octicon octicon-issue-opened",
+                  "viewBox": "0 0 14 16",
+                  "version": "1.1",
+                  "width": "14",
+                  "height": "16",
+                  "aria-hidden": "true"
+                },
+                "children": [
+                  {
+                    "type": "tag",
+                    "name": "path",
+                    "voidElement": true,
+                    "attrs": {
+                      "fill-rule": "evenodd",
+                      "d": "M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 011.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+                    },
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "span",
+            "voidElement": false,
+            "attrs": {
+              "itemprop": "name"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "Issues"
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "span",
+            "voidElement": false,
+            "attrs": {
+              "class": "Counter"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": "10"
+              }
+            ]
+          },
+          {
+            "type": "tag",
+            "name": "meta",
+            "voidElement": true,
+            "attrs": {
+              "itemprop": "position",
+              "content": "2"
+            },
+            "children": []
+          }
+        ]
+      },
+      "ancestors": [
+        {
           "type": "tag",
-          "name": "path",
-          "voidElement": true,
+          "name": "span",
+          "voidElement": false,
           "attrs": {
-           "fill-rule": "evenodd",
-           "d": "M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 011.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"
+            "itemscope": "",
+            "itemtype": "http://schema.org/ListItem",
+            "itemprop": "itemListElement"
           },
           "children": []
-         }
-        ]
-       }
+        },
+        {
+          "type": "tag",
+          "name": "nav",
+          "voidElement": false,
+          "attrs": {
+            "class": "hx_reponav reponav js-repo-nav js-sidenav-container-pjax container",
+            "itemscope": "",
+            "itemtype": "http://schema.org/BreadcrumbList",
+            "aria-label": "Repository",
+            "data-pjax": "#js-repo-pjax-container"
+          },
+          "children": []
+        }
       ]
-     },
-     {
-      "type": "tag",
-      "name": "span",
-      "voidElement": false,
-      "attrs": {
-       "itemprop": "name"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "Issues"
-       }
-      ]
-     },
-     {
-      "type": "tag",
-      "name": "span",
-      "voidElement": false,
-      "attrs": {
-       "class": "Counter"
-      },
-      "children": [
-       {
-        "type": "text",
-        "content": "10"
-       }
-      ]
-     },
-     {
-      "type": "tag",
-      "name": "meta",
-      "voidElement": true,
-      "attrs": {
-       "itemprop": "position",
-       "content": "2"
-      },
-      "children": []
-     }
-    ]
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "span",
-     "voidElement": false,
-     "attrs": {
-      "itemscope": "",
-      "itemtype": "http://schema.org/ListItem",
-      "itemprop": "itemListElement"
-     },
-     "children": []
     },
-    {
-     "type": "tag",
-     "name": "nav",
-     "voidElement": false,
-     "attrs": {
-      "class": "hx_reponav reponav js-repo-nav js-sidenav-container-pjax container",
-      "itemscope": "",
-      "itemtype": "http://schema.org/BreadcrumbList",
-      "aria-label": "Repository",
-      "data-pjax": "#js-repo-pjax-container"
-     },
-     "children": []
-    }
-   ]
+    "time": 1576875772159
   },
-  "time": 1576875772159
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "body",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "body",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1576875772278,
+    "value": "i"
   },
-  "time": 1576875772278,
-  "value": "i"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "body",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1576875772346,
-  "value": "g"
- }
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "body",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1576875772346,
+    "value": "g"
+  }
 ]

--- a/packages/test/events/scroll_login.json
+++ b/packages/test/events/scroll_login.json
@@ -1,1714 +1,1714 @@
 [
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030656,
-  "value": {
-   "x": 0,
-   "y": 4
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030671,
-  "value": {
-   "x": 0,
-   "y": 12
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030688,
-  "value": {
-   "x": 0,
-   "y": 25
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030705,
-  "value": {
-   "x": 0,
-   "y": 39
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030721,
-  "value": {
-   "x": 0,
-   "y": 57
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030737,
-  "value": {
-   "x": 0,
-   "y": 78
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030754,
-  "value": {
-   "x": 0,
-   "y": 95
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030770,
-  "value": {
-   "x": 0,
-   "y": 116
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030803,
-  "value": {
-   "x": 0,
-   "y": 136
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030820,
-  "value": {
-   "x": 0,
-   "y": 156
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030837,
-  "value": {
-   "x": 0,
-   "y": 176
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030854,
-  "value": {
-   "x": 0,
-   "y": 196
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030870,
-  "value": {
-   "x": 0,
-   "y": 215
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030887,
-  "value": {
-   "x": 0,
-   "y": 234
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030904,
-  "value": {
-   "x": 0,
-   "y": 252
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030920,
-  "value": {
-   "x": 0,
-   "y": 269
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030937,
-  "value": {
-   "x": 0,
-   "y": 285
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030953,
-  "value": {
-   "x": 0,
-   "y": 299
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030971,
-  "value": {
-   "x": 0,
-   "y": 312
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828030987,
-  "value": {
-   "x": 0,
-   "y": 324
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828031004,
-  "value": {
-   "x": 0,
-   "y": 335
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828031020,
-  "value": {
-   "x": 0,
-   "y": 345
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828031037,
-  "value": {
-   "x": 0,
-   "y": 354
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828031054,
-  "value": {
-   "x": 0,
-   "y": 363
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828031070,
-  "value": {
-   "x": 0,
-   "y": 371
-  }
- },
- {
-  "isTrusted": true,
-  "name": "scroll",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "html",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828031087,
-  "value": {
-   "x": 0,
-   "y": 378
-  }
- },
- {
-  "isTrusted": true,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "a",
-    "voidElement": false,
-    "attrs": {
-     "href": "/login",
-     "innertext": "Form Authentication"
-    },
-    "children": [
-     {
-      "type": "text",
-      "content": "Form Authentication"
-     }
-    ]
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "li",
-     "voidElement": false,
-     "attrs": {},
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "ul",
-     "voidElement": false,
-     "attrs": {},
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828031784
- },
- {
-  "isTrusted": true,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828032614
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033184,
-  "value": "t"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033262,
-  "value": "t"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033362,
-  "value": "o"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033442,
-  "value": "o"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033537,
-  "value": "m"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033624,
-  "value": "m"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033704,
-  "value": "s"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033779,
-  "value": "s"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033798,
-  "value": "m"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033890,
-  "value": "m"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033902,
-  "value": "i"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033982,
-  "value": "i"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828033994,
-  "value": "t"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034071,
-  "value": "t"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034107,
-  "value": "h"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034172,
-  "value": "h"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "text",
-     "name": "username",
-     "id": "username",
-     "labels": "Username"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034290,
-  "value": "Tab"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034353,
-  "value": "Tab"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034561,
-  "value": "Meta"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034757,
-  "value": "v"
- },
- {
-  "isTrusted": true,
-  "name": "paste",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034896,
-  "value": "SuperSecretPassword!"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034899,
-  "value": "Meta"
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828034900,
-  "value": "v"
- },
- {
-  "isTrusted": true,
-  "name": "keydown",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "input",
-    "voidElement": true,
-    "attrs": {
-     "type": "password",
-     "name": "password",
-     "id": "password",
-     "labels": "Password"
-    },
-    "children": []
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "large-6 small-12 columns"
-     },
-     "children": []
-    },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "row"
-     },
-     "children": []
-    }
-   ]
-  },
-  "time": 1575828035608,
-  "value": "Enter"
- },
- {
-  "isTrusted": true,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "button",
-    "voidElement": false,
-    "attrs": {
-     "class": "radius",
-     "type": "submit",
-     "innertext": "Login"
-    },
-    "children": [
-     {
-      "type": "tag",
-      "name": "i",
-      "voidElement": false,
-      "attrs": {
-       "class": "fa fa-2x fa-sign-in"
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
       },
-      "children": [
-       {
-        "type": "text",
-        "content": " Login"
-       }
-      ]
-     }
-    ]
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "form",
-     "voidElement": false,
-     "attrs": {
-      "name": "login",
-      "id": "login",
-      "action": "/authenticate",
-      "method": "post"
-     },
-     "children": []
+      "ancestors": []
     },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "example"
-     },
-     "children": []
+    "time": 1575828030656,
+    "value": {
+      "x": 0,
+      "y": 4
     }
-   ]
   },
-  "time": 1575828035609
- },
- {
-  "isTrusted": true,
-  "name": "keyup",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "body",
-    "voidElement": true,
-    "attrs": {},
-    "children": []
-   },
-   "ancestors": []
-  },
-  "time": 1575828035689,
-  "value": "Enter"
- },
- {
-  "isTrusted": true,
-  "name": "click",
-  "page": 0,
-  "target": {
-   "node": {
-    "type": "tag",
-    "name": "a",
-    "voidElement": false,
-    "attrs": {
-     "class": "button secondary radius",
-     "href": "/logout",
-     "innertext": "Logout"
-    },
-    "children": [
-     {
-      "type": "tag",
-      "name": "i",
-      "voidElement": false,
-      "attrs": {
-       "class": "icon-2x icon-signout"
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
       },
-      "children": [
-       {
-        "type": "text",
-        "content": " Logout"
-       }
-      ]
-     }
-    ]
-   },
-   "ancestors": [
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "class": "example"
-     },
-     "children": []
+      "ancestors": []
     },
-    {
-     "type": "tag",
-     "name": "div",
-     "voidElement": false,
-     "attrs": {
-      "id": "content",
-      "class": "large-12 columns"
-     },
-     "children": []
+    "time": 1575828030671,
+    "value": {
+      "x": 0,
+      "y": 12
     }
-   ]
   },
-  "time": 1575828036707
- }
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030688,
+    "value": {
+      "x": 0,
+      "y": 25
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030705,
+    "value": {
+      "x": 0,
+      "y": 39
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030721,
+    "value": {
+      "x": 0,
+      "y": 57
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030737,
+    "value": {
+      "x": 0,
+      "y": 78
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030754,
+    "value": {
+      "x": 0,
+      "y": 95
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030770,
+    "value": {
+      "x": 0,
+      "y": 116
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030803,
+    "value": {
+      "x": 0,
+      "y": 136
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030820,
+    "value": {
+      "x": 0,
+      "y": 156
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030837,
+    "value": {
+      "x": 0,
+      "y": 176
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030854,
+    "value": {
+      "x": 0,
+      "y": 196
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030870,
+    "value": {
+      "x": 0,
+      "y": 215
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030887,
+    "value": {
+      "x": 0,
+      "y": 234
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030904,
+    "value": {
+      "x": 0,
+      "y": 252
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030920,
+    "value": {
+      "x": 0,
+      "y": 269
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030937,
+    "value": {
+      "x": 0,
+      "y": 285
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030953,
+    "value": {
+      "x": 0,
+      "y": 299
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030971,
+    "value": {
+      "x": 0,
+      "y": 312
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828030987,
+    "value": {
+      "x": 0,
+      "y": 324
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828031004,
+    "value": {
+      "x": 0,
+      "y": 335
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828031020,
+    "value": {
+      "x": 0,
+      "y": 345
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828031037,
+    "value": {
+      "x": 0,
+      "y": 354
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828031054,
+    "value": {
+      "x": 0,
+      "y": 363
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828031070,
+    "value": {
+      "x": 0,
+      "y": 371
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "scroll",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "html",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828031087,
+    "value": {
+      "x": 0,
+      "y": 378
+    }
+  },
+  {
+    "isTrusted": true,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "a",
+        "voidElement": false,
+        "attrs": {
+          "href": "/login",
+          "innertext": "Form Authentication"
+        },
+        "children": [
+          {
+            "type": "text",
+            "content": "Form Authentication"
+          }
+        ]
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "li",
+          "voidElement": false,
+          "attrs": {},
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "ul",
+          "voidElement": false,
+          "attrs": {},
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828031784
+  },
+  {
+    "isTrusted": true,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828032614
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033184,
+    "value": "t"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033262,
+    "value": "t"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033362,
+    "value": "o"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033442,
+    "value": "o"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033537,
+    "value": "m"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033624,
+    "value": "m"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033704,
+    "value": "s"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033779,
+    "value": "s"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033798,
+    "value": "m"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033890,
+    "value": "m"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033902,
+    "value": "i"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033982,
+    "value": "i"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828033994,
+    "value": "t"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034071,
+    "value": "t"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034107,
+    "value": "h"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034172,
+    "value": "h"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "text",
+          "name": "username",
+          "id": "username",
+          "labels": "Username"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034290,
+    "value": "Tab"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034353,
+    "value": "Tab"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034561,
+    "value": "Meta"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034757,
+    "value": "v"
+  },
+  {
+    "isTrusted": true,
+    "name": "paste",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034896,
+    "value": "SuperSecretPassword!"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034899,
+    "value": "Meta"
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828034900,
+    "value": "v"
+  },
+  {
+    "isTrusted": true,
+    "name": "keydown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "input",
+        "voidElement": true,
+        "attrs": {
+          "type": "password",
+          "name": "password",
+          "id": "password",
+          "labels": "Password"
+        },
+        "children": []
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "large-6 small-12 columns"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "row"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828035608,
+    "value": "Enter"
+  },
+  {
+    "isTrusted": true,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "button",
+        "voidElement": false,
+        "attrs": {
+          "class": "radius",
+          "type": "submit",
+          "innertext": "Login"
+        },
+        "children": [
+          {
+            "type": "tag",
+            "name": "i",
+            "voidElement": false,
+            "attrs": {
+              "class": "fa fa-2x fa-sign-in"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": " Login"
+              }
+            ]
+          }
+        ]
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "form",
+          "voidElement": false,
+          "attrs": {
+            "name": "login",
+            "id": "login",
+            "action": "/authenticate",
+            "method": "post"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "example"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828035609
+  },
+  {
+    "isTrusted": true,
+    "name": "keyup",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "body",
+        "voidElement": true,
+        "attrs": {},
+        "children": []
+      },
+      "ancestors": []
+    },
+    "time": 1575828035689,
+    "value": "Enter"
+  },
+  {
+    "isTrusted": true,
+    "name": "mousedown",
+    "page": 0,
+    "target": {
+      "node": {
+        "type": "tag",
+        "name": "a",
+        "voidElement": false,
+        "attrs": {
+          "class": "button secondary radius",
+          "href": "/logout",
+          "innertext": "Logout"
+        },
+        "children": [
+          {
+            "type": "tag",
+            "name": "i",
+            "voidElement": false,
+            "attrs": {
+              "class": "icon-2x icon-signout"
+            },
+            "children": [
+              {
+                "type": "text",
+                "content": " Logout"
+              }
+            ]
+          }
+        ]
+      },
+      "ancestors": [
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "class": "example"
+          },
+          "children": []
+        },
+        {
+          "type": "tag",
+          "name": "div",
+          "voidElement": false,
+          "attrs": {
+            "id": "content",
+            "class": "large-12 columns"
+          },
+          "children": []
+        }
+      ]
+    },
+    "time": 1575828036707
+  }
 ]

--- a/packages/test/events/selectall.json
+++ b/packages/test/events/selectall.json
@@ -1,7 +1,7 @@
 [
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 0,
     "target": {
       "node": {

--- a/packages/test/events/threePages.json
+++ b/packages/test/events/threePages.json
@@ -1,7 +1,7 @@
 [
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 0,
     "target": {
       "node": {
@@ -38,7 +38,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 0,
     "target": {
       "node": {
@@ -75,7 +75,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 1,
     "target": {
       "node": {
@@ -110,7 +110,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 1,
     "target": {
       "node": {
@@ -145,7 +145,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 1,
     "target": {
       "node": {
@@ -180,7 +180,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 2,
     "target": {
       "node": {
@@ -215,7 +215,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 2,
     "target": {
       "node": {
@@ -250,7 +250,7 @@
   },
   {
     "isTrusted": true,
-    "name": "click",
+    "name": "mousedown",
     "page": 2,
     "target": {
       "node": {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -10,8 +10,8 @@ export interface ElementEvent {
 }
 
 export type ElementEventName =
-  | "click"
   | "input"
+  | "mousedown"
   | "keydown"
   | "keyup"
   | "paste"

--- a/packages/web-tests/tests/Recorder.test.ts
+++ b/packages/web-tests/tests/Recorder.test.ts
@@ -37,7 +37,7 @@ describe("Recorder", () => {
 
     await Promise.all([
       page.waitForNavigation(),
-      context.click({ html: "<a>Content editables</a>" }, { simulate: false })
+      context.click({ html: "<a>Content editables</a>" })
     ]);
 
     await context.close();

--- a/packages/web-tests/tests/Recorder.test.ts
+++ b/packages/web-tests/tests/Recorder.test.ts
@@ -44,7 +44,7 @@ describe("Recorder", () => {
 
     const events = await context.qawolf().recordedEvents();
     expect(events.length).toEqual(1);
-    expect(events[0].name).toEqual("click");
+    expect(events[0].name).toEqual("mousedown");
     expect(events[0].target.node.attrs.href).toEqual("/content-editables");
   });
 

--- a/packages/web-tests/tests/format.test.ts
+++ b/packages/web-tests/tests/format.test.ts
@@ -1,46 +1,35 @@
-import { DocSelector } from "@qawolf/types";
 import { describeDoc } from "@qawolf/web";
+
+const doc = (attrs: object) => ({
+  ancestors: [],
+  node: {
+    attrs,
+    name: "input",
+    type: "tag",
+    voidElement: false
+  }
+});
 
 describe("describeDoc", () => {
   it("formats labels", () => {
-    expect(
-      describeDoc({
-        ancestors: [],
-        node: {
-          attrs: { labels: "name username" },
-          name: "input",
-          type: "tag",
-          voidElement: false
-        }
-      })
-    ).toBe(' "name username"');
+    expect(describeDoc(doc({ labels: "name username" }))).toBe(
+      ' "name username"'
+    );
   });
 
   it("shortens target name if needed", () => {
-    expect(
-      describeDoc({
-        ancestors: [],
-        node: {
-          attrs: { innertext: `sign in${"x".repeat(200)}` },
-          name: "input",
-          type: "tag",
-          voidElement: false
-        }
-      })
-    ).toBe(' "sign inxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..."');
+    expect(describeDoc(doc({ innertext: `sign in${"x".repeat(200)}` }))).toBe(
+      ' "sign inxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx..."'
+    );
   });
 
   it("escapes single quotes", () => {
-    expect(
-      describeDoc({
-        ancestors: [],
-        node: {
-          attrs: { labels: "someone's" },
-          name: "input",
-          type: "tag",
-          voidElement: false
-        }
-      })
-    ).toBe(` "someones"`);
+    expect(describeDoc(doc({ labels: "someone's" }))).toBe(` "someones"`);
+
+    expect(describeDoc(doc({ labels: "'" }))).toBe("");
+  });
+
+  it("removes invisible characters", () => {
+    expect(describeDoc(doc({ labels: "​" }))).toBe("");
   });
 });

--- a/packages/web/src/Recorder.ts
+++ b/packages/web/src/Recorder.ts
@@ -61,7 +61,9 @@ export class Recorder {
   }
 
   private recordEvents() {
-    this.recordEvent("click", event => {
+    // Record mousedown instead of click since it happens first.
+    // This is useful for situations where components change the click target (Material UI non-native Select).
+    this.recordEvent("mousedown", event => {
       // getClickableAncestor chooses the top most clickable ancestor.
       // The ancestor is likely a better target than the descendant.
       // Ex. when you click on the i (button > i) or rect (a > svg > rect)

--- a/packages/web/src/Recorder.ts
+++ b/packages/web/src/Recorder.ts
@@ -64,6 +64,10 @@ export class Recorder {
     // Record mousedown instead of click since it happens first.
     // This is useful for situations where components change the click target (Material UI non-native Select).
     this.recordEvent("mousedown", event => {
+      // only the main button (not right clicks/etc)
+      // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+      if (event.button !== 0) return;
+
       // getClickableAncestor chooses the top most clickable ancestor.
       // The ancestor is likely a better target than the descendant.
       // Ex. when you click on the i (button > i) or rect (a > svg > rect)

--- a/packages/web/src/Recorder.ts
+++ b/packages/web/src/Recorder.ts
@@ -78,7 +78,7 @@ export class Recorder {
           target
         }),
         isTrusted: event.isTrusted,
-        name: "click",
+        name: "mousedown",
         page: this._pageIndex,
         target: nodeToDocSelector(target),
         time: Date.now()

--- a/packages/web/src/element.ts
+++ b/packages/web/src/element.ts
@@ -10,8 +10,8 @@ export const getClickableAncestor = (element: HTMLElement): HTMLElement => {
   console.debug("qawolf: get clickable ancestor for", getXpath(element));
 
   while (ancestor.parentElement) {
-    // choose the common clickable element type as the clickable ancestor
     if (["a", "button", "input"].includes(ancestor.tagName.toLowerCase())) {
+      // stop crawling when the ancestor is a good clickable tag
       console.debug(
         `qawolf: found clickable ancestor: ${ancestor.tagName}`,
         getXpath(ancestor)
@@ -19,22 +19,22 @@ export const getClickableAncestor = (element: HTMLElement): HTMLElement => {
       return ancestor;
     }
 
-    // stop crawling at the first non-clickable element
     if (
       !isClickable(
         ancestor.parentElement,
         window.getComputedStyle(ancestor.parentElement)
       )
     ) {
-      console.debug(
-        "qawolf: no clickable ancestor, use target",
-        getXpath(element)
-      );
-      return element;
+      // stop crawling at the first non-clickable element
+      console.debug("qawolf: found clickable ancestor", getXpath(ancestor));
+      return ancestor;
     }
 
     ancestor = ancestor.parentElement;
   }
+
+  // stop crawling at the root
+  console.debug("qawolf: found clickable ancestor", getXpath(ancestor));
 
   return ancestor;
 };

--- a/packages/web/src/format.ts
+++ b/packages/web/src/format.ts
@@ -7,7 +7,7 @@ export const describeDoc = (html: DocSelector): string => {
   const attrs = target.attrs || {};
 
   // ex. "departure date"
-  let description =
+  let description: string =
     attrs.labels ||
     attrs.name ||
     attrs.placeholder ||
@@ -22,9 +22,16 @@ export const describeDoc = (html: DocSelector): string => {
     description = `${description.substring(0, 40)}...`;
   }
 
+  // strip single quotes so the description is valid javascript
+  description = description.replace("'", "");
+
+  // remove invisible characters which look like an empty string but have a length
+  // https://www.w3resource.com/javascript-exercises/javascript-string-exercise-32.php
+  // https://stackoverflow.com/a/21797208/230462
+  description = description.replace(/[^\x20-\x7E]/g, "");
+
   if (description.length) {
-    // strip single quotes so the description is valid javascript
-    return ` "${description}"`.replace("'", "");
+    return ` "${description}"`;
   }
 
   return "";


### PR DESCRIPTION
Clicking on the Material UI dropdown (with native set to false) would create code for clicking on the body #418. This is because it oddly emits the click on the body instead of the element. 

- Changed the Recorder to listen for mousedown instead and the target is correct. This is most likely since it happens right away (we use capture: true in our listener).

- Reverted click to use Playwright click by default, and simulate is hidden behind the option. I go back and forth on simulating clicks or not, however I think we should prefer things closer to Playwright API when possible. When people have issues with click they can report a bug to Playwright and switch the option to simulate. Relates to #334.

To Do

- [x] Test mousedown works properly for various scenarios
- [x] Improve description generation

Resolves #418 