### PR TITLE
fix: removed semicolon in PATCH_HANDLE

### DIFF
--- a/src/create-code/patchCode.ts
+++ b/src/create-code/patchCode.ts
@@ -5,7 +5,7 @@ type PatchOptions = {
   patch: string;
 };
 
-export const PATCH_HANDLE = 'await qawolf.create();';
+export const PATCH_HANDLE = 'await qawolf.create()';
 
 export const canPatch = (code: string): boolean => {
   return code.includes(PATCH_HANDLE);


### PR DESCRIPTION
it prevents me from editing tests when I have `"semi": false` in my prettier config with error
`Could not find await qawolf.create(); in caller`