### PR TITLE
fix: use any data-test* for selector

### DIFF
--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -4,7 +4,7 @@ import { isDynamic } from './isDynamic';
 import { SelectorPart } from './types';
 
 const DEFAULT_ATTRIBUTE =
-  'data-cy,data-e2e,data-qa,data-test,data-testid,/^qa-.*/';
+  'data-cy,data-e2e,data-qa,/^data-test.*/,/^qa-.*/';
 
 // make sure to update CueTypeRank if editing this
 const CSS_ATTRIBUTES = [
@@ -122,6 +122,8 @@ export const buildTextCues = ({
   ) {
     text = element.value;
   }
+
+  console.debug(`qawolf: found text="${text}" for element`, element);
 
   if (
     !text ||


### PR DESCRIPTION
A fix for the "secondary issue" described in https://github.com/qawolf/qawolf/issues/737

In addition to `data-testid` attributes, now `data-test-id` and any other attribute beginning with `data-test` will be preferred when using the default QA Wolf configuration.