### PR TITLE
Make isDynamic more stringent on trailing characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       }
     },
     "@qawolf/sandbox": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.15.tgz",
-      "integrity": "sha512-b2JV8BFh+IxuR9/AC9w47z6BfOKrB3suJPKnB5WBo0wOnXu5fjBh3502q4o3T3cvkc/eDAPxSZqd5fUo6g3/ig==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.16.tgz",
+      "integrity": "sha512-+d9RIOkFHqLFsZvaeyabsV5Z3qnxkfwtOefWL5OXMfPENxU7pzfXUHrKBJ54Ubc2uZwyYnNoDWIvJy3fA/ON6A==",
       "dev": true,
       "requires": {
         "serve": "^11.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
-    "@qawolf/sandbox": "0.1.15",
+    "@qawolf/sandbox": "0.1.16",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.3",

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "files": [
     "bin",
     "build"

--- a/packages/sandbox/src/pages/Buttons/HtmlButtons.js
+++ b/packages/sandbox/src/pages/Buttons/HtmlButtons.js
@@ -23,10 +23,10 @@ function HtmlButtons() {
       <button id="whitespace-button">{'     I have extra whitespace  '}</button>
       <br />
       <br />
-      <button className="btn-a btn-1">Classes</button>
-      <button className="btn-a btn-2">Classes</button>
-      <button className="btn-b btn-1">Classes</button>
-      <button className="btn-b btn-2">Classes</button>
+      <button className="first-half type-one">Classes</button>
+      <button className="first-half type-two">Classes</button>
+      <button className="second-half type-one">Classes</button>
+      <button className="second-half type-two">Classes</button>
       <br />
       <br />
       <button id="nested">

--- a/src/web/isDynamic.ts
+++ b/src/web/isDynamic.ts
@@ -37,15 +37,14 @@ const SCORE_THRESHOLD = 0.5;
 export const getTokens = (value: string): string[] => {
   const tokens = [];
 
-  // remove a numeric or alphabetic suffix
-  // ex: btn-1, btn_z -> btn
-  const symbol = value.replace(/[-_]+(\d+|\w)$/, '');
-
   // split by space, dash, and camel case
-  symbol.split(/[ \-_]+|(?=[A-Z])/).forEach((token) => {
-    if (!token) return; // ignore empty string
+  value.split(/[ \-_]+|(?=[A-Z])/).forEach((token) => {
+    // remove a numeric or alphabetic suffix
+    // ex: btn-1, btn_z -> btn
+    const symbol = token.replace(/[-_]+(\d+|\w)$/, '');
+    if (!symbol) return; // ignore empty string
 
-    tokens.push(token.toLowerCase());
+    tokens.push(symbol.toLowerCase());
   });
 
   return tokens;

--- a/src/web/isDynamic.ts
+++ b/src/web/isDynamic.ts
@@ -39,12 +39,9 @@ export const getTokens = (value: string): string[] => {
 
   // split by space, dash, and camel case
   value.split(/[ \-_]+|(?=[A-Z])/).forEach((token) => {
-    // remove a numeric or alphabetic suffix
-    // ex: btn-1, btn_z -> btn
-    const symbol = token.replace(/[-_]+(\d+|\w)$/, '');
-    if (!symbol) return; // ignore empty string
+    if (!token) return; // ignore empty string
 
-    tokens.push(symbol.toLowerCase());
+    tokens.push(token.toLowerCase());
   });
 
   return tokens;

--- a/test/web/isDynamic.test.ts
+++ b/test/web/isDynamic.test.ts
@@ -9,9 +9,9 @@ describe('isDynamic', () => {
     'gLFyf',
     'intercom-123v9c3',
     'StyledBox-sc-13pk1d4-0',
+    'StyledLayer-rmtehz-0',
     'TSPr2b',
     'u_0_b',
-    'StyledLayer-rmtehz-0',
   ])('is dynamic: %s', (example) => {
     expect(isDynamic(example)).toBe(true);
   });

--- a/test/web/isDynamic.test.ts
+++ b/test/web/isDynamic.test.ts
@@ -11,6 +11,7 @@ describe('isDynamic', () => {
     'StyledBox-sc-13pk1d4-0',
     'TSPr2b',
     'u_0_b',
+    'StyledLayer-rmtehz-0',
   ])('is dynamic: %s', (example) => {
     expect(isDynamic(example)).toBe(true);
   });
@@ -19,7 +20,6 @@ describe('isDynamic', () => {
     'app',
     'b-content__page-input',
     'btn',
-    'btn-b',
     'btn-playr-primary',
     'central-textlogo__image',
     'col-sm-12',

--- a/test/web/selector.test.ts
+++ b/test/web/selector.test.ts
@@ -100,7 +100,7 @@ describe('buildSelector', () => {
         // selects the ancestor
         [['#html-button-child', '[data-qa="html-button-with-children"]']],
         [['.MuiButton-label', '[data-qa="material-button"]']],
-        ['.btn-b.btn-2'],
+        ['.second-half.type-two'],
       ])('builds expected selector %o', (selector) => expectSelector(selector));
     });
 
@@ -224,7 +224,7 @@ describe('buildSelector', () => {
         [['#button', '[data-test="click"] [data-qa="button"]']],
         // unique selectors
         [['#unique', '[data-qa="unique"]']],
-        [['#dog-0', '[data-qa="radio-group"] #dog-0']],
+        [['#dog-0', '[data-qa="radio-group"] [value="dog-0"]']],
       ])('builds expected selector %o', (selector) => expectSelector(selector));
     });
 


### PR DESCRIPTION
* The class `StyledLayer-rmtehz-0` was not marked as dynamic, because the `0` at the end was filtered out from the tokens array
* By including it, `isDynamic` is more stringent, which I think is OK (better to be safe than sorry)
* Affected one test case: `btn-b` is currently not considered dynamic, but with this change it will be