### PR TITLE
Use waiting selector method instead of $ method to get iframe handle

### DIFF
--- a/src/build-code/buildStepLines.ts
+++ b/src/build-code/buildStepLines.ts
@@ -83,7 +83,7 @@ export const buildStepLines = (
         initializedFrames.size ? initializedFrames.size + 1 : ''
       }`;
       lines.push(
-        `const ${frameVariableName} = await (await ${pageVariableName}.$(${escapeSelector(
+        `const ${frameVariableName} = await (await ${pageVariableName}.waitForSelector(${escapeSelector(
           frameSelector,
         )})).contentFrame();`,
       );


### PR DESCRIPTION
I had timing problems clicking a button in an iframe:

```
~/D/N/QaWolf $ npx qawolf test myFirstTest
Test: chromium
npx jest --config="node_modules/qawolf/js-jest.config.json" --rootDir=.qawolf --testTimeout=60000 myFirstTest

 FAIL  .qawolf/myFirstTest.test.js (5.019 s)
  ✕ myFirstTest (3929 ms)

  ● myFirstTest

    TypeError: Cannot read property 'contentFrame' of null

      20 |   await page.click(".clickable .clickable");
      21 |   await page.click('[href="/WebApp/Open/ScannerSim/"]');
    > 22 |   const frame = await (await page.$("#sim")).contentFrame();
         |                                              ^
      23 |   await frame.click(".nav-button");
      24 | });
      25 | 

      at Object.test (myFirstTest.test.js:22:46)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        5.401 s, estimated 6 s
Ran all test suites matching /myFirstTest/i.
```

...which i was able to resolve by exchanging the `$` selection method with `waitForSelector` in the code generation module, which seems to be safer as it respects timeout options according to playwright docs.

I'd love to use qawolf in production for ci-testing, so i really need iframes to work in a stable manner, any help or advice is appreciated.