### PR TITLE
fix: speed up selector generation

### DIFF
--- a/src/web/selectorEngine.ts
+++ b/src/web/selectorEngine.ts
@@ -10,7 +10,7 @@ try {
   // do not require the evaluator but depend on this file
 }
 
-const { createTextSelector, querySelectorAll } = evaluator || {};
+const { createTextSelector, querySelector } = evaluator || {};
 /* eslint-enable @typescript-eslint/no-var-requires */
 
 type IsMatch = {
@@ -56,7 +56,7 @@ export const getElementText = (element: HTMLElement): string | undefined => {
 export const isMatch = ({ selectorParts, target }: IsMatch): boolean => {
   // We must pass `target.ownerDocument` rather than `document`
   // because sometimes this is called from other frames.
-  const result = querySelectorAll({ parts: selectorParts }, target.ownerDocument);
+  const result = querySelector({ parts: selectorParts }, target.ownerDocument);
 
-  return result[0] === target;
+  return result === target;
 };

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -13,5 +13,5 @@ export type Evaluator = {
 
   isVisible(element: Element): boolean;
 
-  querySelectorAll(selector: ParsedSelector, root: Node): HTMLElement[];
+  querySelector(selector: ParsedSelector, root: Node): HTMLElement;
 };

--- a/src/web/webpack.config.js
+++ b/src/web/webpack.config.js
@@ -7,8 +7,8 @@ const virtualModules = new VirtualModulesPlugin({
   const evaluator = new (${selectorEvaluatorSource.source})([]);
   const createTextSelector = (element) => evaluator.engines.get('text').create(document, element);
   const isVisible = (element) => evaluator.isVisible(element);
-  const querySelectorAll = (...args) => evaluator.querySelectorAll(...args);
-  module.exports = { createTextSelector, isVisible, querySelectorAll };`,
+  const querySelector = (...args) => evaluator.querySelector(...args);
+  module.exports = { createTextSelector, isVisible, querySelector };`,
 });
 
 module.exports = {


### PR DESCRIPTION
Resolves #799

Use querySelector instead of querySelectorAll. This cuts trimExcessCues to ~200ms instead of many seconds on the expensive search input cues. We can rank and limit the initial cue list size as well if we run into a worse case.