### PR TITLE
fix: fill correct value for contenteditable inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       }
     },
     "@qawolf/sandbox": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.20.tgz",
-      "integrity": "sha512-Kmg8vs1QKUXuiGP8OtDtcUlN3hxz9dgC0XWmwq1/1V/E3Yt5P6LI8T2nffmCQV9gPVG2v6IAqXdjTlKGIorRXQ==",
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.21.tgz",
+      "integrity": "sha512-4uLawdQeTEWLM7kGzq45OJ3/oqsxMy2FoN4fyNllnl41e95hGjeD99xZobkdNmOTyeaYaHFJmB1e3Z5EYGUhAQ==",
       "dev": true,
       "requires": {
         "serve": "^11.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
-    "@qawolf/sandbox": "0.1.20",
+    "@qawolf/sandbox": "0.1.21",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.3",

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "files": [
     "bin",
     "build"

--- a/packages/sandbox/src/pages/TextInputs/HtmlTextInputs.js
+++ b/packages/sandbox/src/pages/TextInputs/HtmlTextInputs.js
@@ -42,6 +42,15 @@ function HtmlTextInputs() {
       <br />
       <br />
       <textarea data-qa="html-textarea" placeholder="Textarea" />
+      <br />
+      <br />
+      <h4>Edge Cases</h4>
+      <input
+        contenteditable="true"
+        data-qa="html-text-input-content-editable"
+        placeholder="Content editable text input"
+        type="text"
+      />
     </div>
   );
 }

--- a/src/web/PageEventCollector.ts
+++ b/src/web/PageEventCollector.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_ATTRIBUTE_LIST } from './attribute';
 import {
   getClickableAncestor,
+  getInputElementValue,
   getTopmostEditableElement,
   isVisible,
 } from './element';
@@ -100,7 +101,7 @@ export class PageEventCollector {
 
     this.listen('change', (event) => {
       const target = event.target as HTMLInputElement;
-      this.sendEvent('change', event, target.value);
+      this.sendEvent('change', event, getInputElementValue(target));
     });
 
     this.listen('click', (event) => {
@@ -116,11 +117,7 @@ export class PageEventCollector {
 
     this.listen('input', (event) => {
       const target = event.target as HTMLInputElement;
-      this.sendEvent(
-        'input',
-        event,
-        target.isContentEditable ? target.innerText : target.value,
-      );
+      this.sendEvent('input', event, getInputElementValue(target));
     });
 
     this.listen('keydown', (event) => {

--- a/src/web/element.ts
+++ b/src/web/element.ts
@@ -115,7 +115,9 @@ export const getTopmostEditableElement = (
  *   For example, returns the `.value` or the `.innerText` of a content-editable.
  *   If no value can be determined, returns `null`.
  */
-export const getInputElementValue = (element: HTMLInputElement): string|null => {
+export const getInputElementValue = (
+  element: HTMLInputElement,
+): string | null => {
   // In the wild, we've seen examples of input elements with `contenteditable=true`,
   // but an `input` never has inner text, so we check for `input` tag name here.
   if (element.isContentEditable && element.tagName.toLowerCase() !== 'input') {

--- a/src/web/element.ts
+++ b/src/web/element.ts
@@ -109,3 +109,18 @@ export const getTopmostEditableElement = (
   // This should never be hit, but here as a safety
   return element;
 };
+
+/**
+ * @summary Returns the current "value" of an element. Pass in an event `target`.
+ *   For example, returns the `.value` or the `.innerText` of a content-editable.
+ *   If no value can be determined, returns `null`.
+ */
+export const getInputElementValue = (element: HTMLInputElement): string|null => {
+  // In the wild, we've seen examples of input elements with `contenteditable=true`,
+  // but an `input` never has inner text, so we check for `input` tag name here.
+  if (element.isContentEditable && element.tagName.toLowerCase() !== 'input') {
+    return element.innerText;
+  }
+
+  return element.value || null;
+};

--- a/src/web/qawolf.ts
+++ b/src/web/qawolf.ts
@@ -7,6 +7,7 @@ export {
 } from './cues';
 export {
   getClickableAncestor,
+  getInputElementValue,
   getTopmostEditableElement,
   isClickable,
   isVisible,

--- a/test/web/element.test.ts
+++ b/test/web/element.test.ts
@@ -62,6 +62,54 @@ describe('getClickableAncestor', () => {
   });
 });
 
+describe('getInputElementValue', () => {
+  it('gets value from text input', async () => {
+    await page.goto(`${TEST_URL}text-inputs`);
+
+    const value = await page.evaluate(() => {
+      const web: QAWolfWeb = (window as any).qawolf;
+      const element = document.querySelector('[data-qa="html-text-input"]') as HTMLInputElement;
+      if (!element) throw new Error('element not found');
+
+      element.value = 'I have value';
+
+      return web.getInputElementValue(element);
+    });
+
+    expect(value).toEqual('I have value');
+  });
+
+  it('gets value from contenteditable element', async () => {
+    await page.goto(`${TEST_URL}content-editables`);
+
+    const value = await page.evaluate(() => {
+      const web: QAWolfWeb = (window as any).qawolf;
+      const element = document.querySelector('[data-qa="content-editable"]') as HTMLInputElement;
+      if (!element) throw new Error('element not found');
+
+      return web.getInputElementValue(element);
+    });
+
+    expect(value).toEqual('Edit me!');
+  });
+
+  it('gets value from input element that also has contenteditable attribute', async () => {
+    await page.goto(`${TEST_URL}text-inputs`);
+
+    const value = await page.evaluate(() => {
+      const web: QAWolfWeb = (window as any).qawolf;
+      const element = document.querySelector('[data-qa="html-text-input-content-editable"]') as HTMLInputElement;
+      if (!element) throw new Error('element not found');
+
+      element.value = 'I have value';
+
+      return web.getInputElementValue(element);
+    });
+
+    expect(value).toEqual('I have value');
+  });
+});
+
 describe('getTopmostEditableElement', () => {
   beforeAll(() => page.goto(`${TEST_URL}content-editables`));
 


### PR DESCRIPTION
- Create `getInputElementValue` function with adjusted logic
- Create tests for it

Fixes #801. Refer to the problem description [here](https://github.com/qawolf/qawolf/issues/801#issuecomment-683141690)