### PR TITLE
feat: bring page to front before acting on it

### DIFF
--- a/src/build-code/buildVirtualCode.ts
+++ b/src/build-code/buildVirtualCode.ts
@@ -7,7 +7,9 @@ export const buildVirtualCode = (steps: Step[]): VirtualCode => {
 
   const buildContext: StepLineBuildContext = {
     initializedFrames: new Map<string, string>(),
-    initializedPages: new Set(),
+    // page 0 is initialized and brought to front in "before"
+    initializedPages: new Set([0]),
+    visiblePage: 0,
   };
 
   steps.forEach((step) => {

--- a/test/build-code/buildStepLines.test.ts
+++ b/test/build-code/buildStepLines.test.ts
@@ -25,7 +25,7 @@ describe('escapeSelector', () => {
 });
 
 describe('buildStepLines', () => {
-  test('consecutive steps on different pages', () => {
+  test('step on new page, after step on a different page', () => {
     const lines = buildStepLines({
       ...baseStep,
       event: {
@@ -38,6 +38,31 @@ describe('buildStepLines', () => {
     expect(lines).toMatchInlineSnapshot(`
       Array [
         "const page2 = await qawolf.waitForPage(page.context(), 1);",
+        "await page2.click('[data-qa=\\"test-input\\"]');",
+      ]
+    `);
+  });
+
+  test('step on existing page, after step on a different page', () => {
+    const lines = buildStepLines(
+      {
+        ...baseStep,
+        event: {
+          ...baseStep.event,
+          page: 1,
+        },
+        index: 1,
+      },
+      {
+        initializedFrames: new Map<string, string>(),
+        initializedPages: new Set([0, 1]),
+        visiblePage: 0,
+      },
+    );
+
+    expect(lines).toMatchInlineSnapshot(`
+      Array [
+        "await page2.bringToFront();",
         "await page2.click('[data-qa=\\"test-input\\"]');",
       ]
     `);
@@ -78,7 +103,8 @@ describe('buildStepLines', () => {
       },
       {
         initializedFrames,
-        initializedPages: new Set(),
+        initializedPages: new Set([0]),
+        visiblePage: 0,
       },
     );
 
@@ -105,7 +131,8 @@ describe('buildStepLines', () => {
       },
       {
         initializedFrames,
-        initializedPages: new Set(),
+        initializedPages: new Set([0]),
+        visiblePage: 0,
       },
     );
 


### PR DESCRIPTION
Resolves #798 

## Background
If there are multiple pages, we generate multiple page variables in the output. For example, `page`, then `page2`, then `page3`, etc. After that, Playwright actions happen on certain pages (or frames). So we might have `page.fill(...)` followed by `page2.click(...)`, and so on.

## Problem
When we go from one acting on one page to acting on another page, and that second page is already initialized/loaded, that page stays in the background. This means the running test isn't visible if watching it run or recording a video.

## Solution
Call `${pageVariable}.bringToFront` each time before running an action on an existing page, when the previous action was not on that page.

## Testing
1. Find any website where there are a number of links that have target `_blank` (automatically open in a new tab).
2. Do `DEBUG=qawolf:* qawolf create <url>` with the code in this branch linked.
3. Click a link that opens a new tab, perform an action like clicking or scrolling in the new tab, then switch back to the first tab and click or scroll. Verify that each time you switch between tabs there is either a `qawolf.waitForPage()` line or a `page.bringToFront()` line.
4. Try more complex things like clicking the link multiple times, resulting in multiple tabs, and/or opening more new pages from new pages.
5. Run any QAWolf tests you generate, verifying that they run without errors.