### PR TITLE
feat: support for dblclick

### DIFF
--- a/src/build-code/VirtualCode.ts
+++ b/src/build-code/VirtualCode.ts
@@ -32,8 +32,10 @@ export class VirtualCode {
           compareToLine,
           existingLineIndex
         );
+        // remove all existing lines after the first changed line
         removedLines = this._lines.slice(existingLineIndex);
-        debug('found removed lines: %j', removedLines);
+        debug('remove lines: %j', removedLines);
+        // and on the compareTo side, we now know that every line after this is new
         newLines = compareToLines.slice(existingLineIndex);
         break;
       }
@@ -41,6 +43,8 @@ export class VirtualCode {
 
     if (removedLines.length === 0) {
       debug('no changed lines');
+      // if compareToLines started with all the same lines as we previously
+      // had, then every additional line (if any) is new.
       newLines = compareToLines.slice(this._lines.length);
     }
 
@@ -49,7 +53,7 @@ export class VirtualCode {
       return null;
     }
 
-    debug('found new lines: %j', newLines);
+    debug('new lines: %j', newLines);
     return { newLines, removedLines };
   }
 

--- a/src/build-code/VirtualCode.ts
+++ b/src/build-code/VirtualCode.ts
@@ -3,8 +3,8 @@ import Debug from 'debug';
 const debug = Debug('qawolf:VirtualCode');
 
 type LinePatch = {
-  original: string;
-  updated: string;
+  newLines: string[];
+  removedLines: string[];
 };
 
 export class VirtualCode {
@@ -15,37 +15,42 @@ export class VirtualCode {
   }
 
   public buildPatch(compareTo: VirtualCode): LinePatch | null {
-    /**
-     * Check if the last line changed.
-     */
-    const lastIndex = this._lines.length - 1;
-    if (lastIndex < 0) {
-      debug('no lines to update');
-      return null;
-    }
-
-    const lastLine = this._lines[lastIndex];
+    let newLines: string[] = [];
+    let removedLines: string[] = [];
 
     const compareToLines = compareTo.lines();
-    if (lastIndex >= compareToLines.length) {
-      // if the last line no longer exists
-      // we will update it when a new line arrives
-      debug('last line no longer exists, wait to update');
+
+    // Get the list of existing lines that have been removed
+    // from the end of the new line list.
+    for (let existingLineIndex = 0; existingLineIndex < this._lines.length; existingLineIndex++) {
+      const existingLine = this._lines[existingLineIndex];
+      const compareToLine = compareToLines[existingLineIndex];
+      if (existingLine !== compareToLine) {
+        debug(
+          'first changed line went from "%s" to "%s" at index %d',
+          existingLine,
+          compareToLine,
+          existingLineIndex
+        );
+        removedLines = this._lines.slice(existingLineIndex);
+        debug('found removed lines: %j', removedLines);
+        newLines = compareToLines.slice(existingLineIndex);
+        break;
+      }
+    }
+
+    if (removedLines.length === 0) {
+      debug('no changed lines');
+      newLines = compareToLines.slice(this._lines.length);
+    }
+
+    if (newLines.length === 0) {
+      debug('no new lines');
       return null;
     }
 
-    const compareToLastLine = compareToLines[lastIndex];
-    if (lastLine === compareToLastLine) {
-      debug(
-        'last line did not change: "%j" === "%j"',
-        lastLine,
-        compareToLastLine,
-      );
-      return null;
-    }
-
-    debug('last line changed from "%j" to "%j"', lastLine, compareToLastLine);
-    return { original: lastLine, updated: compareToLastLine };
+    debug('found new lines: %j', newLines);
+    return { newLines, removedLines };
   }
 
   // for tests
@@ -55,10 +60,5 @@ export class VirtualCode {
 
   public lines(): string[] {
     return this._lines;
-  }
-
-  public newLines(compareTo: VirtualCode): string[] {
-    const newLines = compareTo.lines().slice(this._lines.length);
-    return newLines;
   }
 }

--- a/src/create-code/CodeReconciler.ts
+++ b/src/create-code/CodeReconciler.ts
@@ -1,6 +1,6 @@
 import Debug from 'debug';
 import { VirtualCode } from '../build-code/VirtualCode';
-import { patchCode, PATCH_HANDLE } from './patchCode';
+import { patchCode } from './patchCode';
 
 const debug = Debug('qawolf:CodeReconciler');
 
@@ -13,77 +13,29 @@ export class CodeReconciler {
   // the virtual representation of the current code
   _virtualCode: VirtualCode = new VirtualCode([]);
 
-  _insertNewLines({ actualCode, virtualCode }: ReconcileOptions): string {
-    const newLines = this._virtualCode.newLines(virtualCode);
-    if (newLines.length < 1) return actualCode;
+  public hasChanges(virtualCode: VirtualCode): boolean {
+    return !!this._virtualCode.buildPatch(virtualCode);
+  }
 
-    const patch = newLines.map((line) => `${line}\n`).join('') + PATCH_HANDLE;
-    debug(`insert new lines: ${patch}`);
+  /**
+   * @summary Compares the previous virtual code with the new virtual
+   *   code, and then uses that diff to update the `actualCode` and
+   *   return the modified actual code.
+   */
+  public reconcile({ actualCode, virtualCode }: ReconcileOptions): string {
+    const linePatch = this._virtualCode.buildPatch(virtualCode);
+    if (!linePatch) return actualCode;
 
     try {
-      return patchCode({ code: actualCode, patch });
+      return patchCode({
+        code: actualCode,
+        patchLines: linePatch.newLines,
+        replaceLines: linePatch.removedLines,
+      });
     } catch (e) {
       debug('skip new lines: cannot find patch handle');
       return actualCode;
     }
-  }
-
-  _updateLastLine({ actualCode, virtualCode }: ReconcileOptions): string {
-    /**
-     * Update the last expression if it changed.
-     */
-    const linePatch = this._virtualCode.buildPatch(virtualCode);
-    if (!linePatch) return actualCode;
-
-    // find the last occurrence of the original expression
-    const indexToReplace = actualCode.lastIndexOf(linePatch.original);
-
-    // we cannot find the original expression so return the unmodified code
-    if (indexToReplace < 0) {
-      debug(
-        'skip last line update: cannot find original code to update "%j"',
-        linePatch.original,
-      );
-      return actualCode;
-    }
-
-    debug('update last line');
-
-    const updatedCode =
-      actualCode.slice(0, indexToReplace) +
-      actualCode
-        .slice(indexToReplace)
-        .replace(linePatch.original, linePatch.updated);
-
-    return updatedCode;
-  }
-
-  public hasChanges(virtualCode: VirtualCode): boolean {
-    const hasPatch = !!this._virtualCode.buildPatch(virtualCode);
-    if (hasPatch) {
-      debug('has patch for last line');
-      return true;
-    }
-
-    const hasNewLines = this._virtualCode.newLines(virtualCode).length > 0;
-    if (hasNewLines) {
-      debug('has new lines');
-      return true;
-    }
-
-    debug('no changes');
-    return false;
-  }
-
-  public reconcile({ actualCode, virtualCode }: ReconcileOptions): string {
-    let updatedCode = this._updateLastLine({ actualCode, virtualCode });
-
-    updatedCode = this._insertNewLines({
-      actualCode: updatedCode,
-      virtualCode,
-    });
-
-    return updatedCode;
   }
 
   public update(virtualCode: VirtualCode): void {

--- a/src/create-code/patchCode.ts
+++ b/src/create-code/patchCode.ts
@@ -2,7 +2,8 @@ import { getIndentation, indent, removeLinesIncluding } from './format';
 
 type PatchOptions = {
   code: string;
-  patch: string;
+  patchLines: string[];
+  replaceLines: string[];
 };
 
 export const CREATE_HANDLE = 'qawolf.create()';
@@ -22,13 +23,18 @@ export const indentPatch = (code: string, patch: string): string => {
   return indent(patch, numSpaces, 1);
 };
 
-export const patchCode = ({ code, patch }: PatchOptions): string => {
+export const patchCode = ({ code, patchLines, replaceLines }: PatchOptions): string => {
   if (!canPatch(code)) {
     throw new Error('Cannot patch without handle');
   }
 
-  const patchedCode = code.replace(PATCH_HANDLE, indentPatch(code, patch));
-  return patchedCode;
+  const replaceLinesWithHandle = [...(replaceLines || []), PATCH_HANDLE];
+  const indentedReplaceLines = indentPatch(code, replaceLinesWithHandle.join('\n'));
+
+  const patchLinesWithHandle = [...(patchLines || []), PATCH_HANDLE];
+  const indentedPatch = indentPatch(code, patchLinesWithHandle.join('\n'));
+
+  return code.replace(indentedReplaceLines, indentedPatch);
 };
 
 export const removePatchHandle = (code: string): string => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type Action =
   | 'click'
+  | 'dblclick'
   | 'fill'
   | 'press'
   | 'scroll'
@@ -18,6 +19,7 @@ export interface Doc {
 export interface ElementEvent {
   frameIndex?: number;
   frameSelector?: string;
+  isDoubleClick: boolean;
   isTrusted: boolean;
   name: ElementEventName;
   page: number;
@@ -30,6 +32,7 @@ export interface ElementEvent {
 export type ElementEventName =
   | 'change'
   | 'click'
+  | 'dblclick'
   | 'input'
   | 'keydown'
   | 'keyup'

--- a/src/web/PageEventCollector.ts
+++ b/src/web/PageEventCollector.ts
@@ -1,8 +1,7 @@
 import { DEFAULT_ATTRIBUTE_LIST } from './attribute';
 import {
-  getClickableAncestor,
   getInputElementValue,
-  getTopmostEditableElement,
+  getMouseEventTarget,
   isVisible,
 } from './element';
 import { buildSelector } from './selector';
@@ -52,16 +51,24 @@ export class PageEventCollector {
     const eventCallback: EventCallback = (window as any).qawElementEvent;
     if (!eventCallback) return;
 
-    const target = event.target as HTMLElement;
+    const isClick = ['click', 'mousedown'].includes(eventName);
+
+    let target = event.target as HTMLElement;
+    if (isClick) {
+      target = getMouseEventTarget(event as MouseEvent, this._attributes);
+    }
+
     const isTargetVisible = isVisible(target, window.getComputedStyle(target));
+    const clickCount = eventName === 'click' ? (event as UIEvent).detail : 0;
 
     const elementEvent: types.ElementEvent = {
+      isDoubleClick: clickCount > 1,
       isTrusted: event.isTrusted && isTargetVisible,
       name: eventName,
       page: -1, // set in ContextEventCollector
       selector: buildSelector({
         attributes: this._attributes,
-        isClick: ['click', 'mousedown'].includes(eventName),
+        isClick,
         target,
       }),
       target: nodeToDoc(target),
@@ -81,22 +88,29 @@ export class PageEventCollector {
   }
 
   private collectEvents(): void {
+    //////// MOUSE EVENTS ////////
+
     this.listen('mousedown', (event) => {
       // only the main button (not right clicks/etc)
       // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
       if (event.button !== 0) return;
 
-      // getClickableAncestor chooses the top most clickable ancestor.
-      // The ancestor is likely a better target than the descendant.
-      // Ex. when you click on the i (button > i) or rect (a > svg > rect)
-      // chances are the ancestor (button, a) is a better target to find.
-      // XXX if anyone runs into issues with this behavior we can allow disabling it from a flag.
-      let target = getClickableAncestor(
-        event.target as HTMLElement,
-        this._attributes,
-      );
-      target = getTopmostEditableElement(target);
-      this.sendEvent('mousedown', { ...event, target });
+      this.sendEvent('mousedown', event);
+    });
+
+    this.listen('click', (event) => {
+      // only the main button (not right clicks/etc)
+      // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+      if (event.button !== 0) return;
+
+      this.sendEvent('click', event);
+    });
+
+    //////// INPUT EVENTS ////////
+
+    this.listen('input', (event) => {
+      const target = event.target as HTMLInputElement;
+      this.sendEvent('input', event, getInputElementValue(target));
     });
 
     this.listen('change', (event) => {
@@ -104,21 +118,7 @@ export class PageEventCollector {
       this.sendEvent('change', event, getInputElementValue(target));
     });
 
-    this.listen('click', (event) => {
-      if (event.button !== 0) return;
-
-      let target = getClickableAncestor(
-        event.target as HTMLElement,
-        this._attributes,
-      );
-      target = getTopmostEditableElement(target);
-      this.sendEvent('click', { ...event, target });
-    });
-
-    this.listen('input', (event) => {
-      const target = event.target as HTMLInputElement;
-      this.sendEvent('input', event, getInputElementValue(target));
-    });
+    //////// KEYBOARD EVENTS ////////
 
     this.listen('keydown', (event) => {
       this.sendEvent('keydown', event, event.key);
@@ -127,6 +127,8 @@ export class PageEventCollector {
     this.listen('keyup', (event) => {
       this.sendEvent('keyup', event, event.key);
     });
+
+    //////// OTHER EVENTS ////////
 
     this.listen('paste', (event) => {
       if (!event.clipboardData) return;

--- a/src/web/element.ts
+++ b/src/web/element.ts
@@ -111,6 +111,26 @@ export const getTopmostEditableElement = (
 };
 
 /**
+ * @summary Returns the best target element for reproducing a mouse event.
+ */
+export const getMouseEventTarget = (
+  event: MouseEvent,
+  attributes: string[],
+): HTMLElement => {
+  // getClickableAncestor chooses the top most clickable ancestor.
+  // The ancestor is likely a better target than the descendant.
+  // Ex. when you click on the i (button > i) or rect (a > svg > rect)
+  // chances are the ancestor (button, a) is a better target to find.
+  // XXX if anyone runs into issues with this behavior we can allow disabling it from a flag.
+  const target = getClickableAncestor(
+    event.target as HTMLElement,
+    attributes,
+  );
+
+  return getTopmostEditableElement(target);
+};
+
+/**
  * @summary Returns the current "value" of an element. Pass in an event `target`.
  *   For example, returns the `.value` or the `.innerText` of a content-editable.
  *   If no value can be determined, returns `null`.

--- a/src/web/qawolf.ts
+++ b/src/web/qawolf.ts
@@ -8,6 +8,7 @@ export {
 export {
   getClickableAncestor,
   getInputElementValue,
+  getMouseEventTarget,
   getTopmostEditableElement,
   isClickable,
   isVisible,

--- a/test/build-code/fixtures.ts
+++ b/test/build-code/fixtures.ts
@@ -1,6 +1,7 @@
 import { ElementEvent, Step } from '../../src/types';
 
 export const baseEvent: ElementEvent = {
+  isDoubleClick: false,
   isTrusted: true,
   name: 'mousedown',
   page: 0,

--- a/test/build-workflow/__snapshots__/buildSteps.test.ts.snap
+++ b/test/build-workflow/__snapshots__/buildSteps.test.ts.snap
@@ -6,7 +6,7 @@ Array [
     "action": "click",
     "event": Object {
       "isTrusted": true,
-      "name": "mousedown",
+      "name": "click",
       "page": 0,
       "selector": "text=Log in",
       "target": Object {
@@ -23,7 +23,7 @@ Array [
         "type": "tag",
         "voidElement": false,
       },
-      "time": 1594320817272,
+      "time": 1594320817350,
     },
     "index": 0,
   },
@@ -154,7 +154,7 @@ Array [
     "action": "click",
     "event": Object {
       "isTrusted": true,
-      "name": "mousedown",
+      "name": "click",
       "page": 0,
       "selector": "text=Log out",
       "target": Object {
@@ -177,7 +177,7 @@ Array [
         "type": "tag",
         "voidElement": false,
       },
-      "time": 1594320839676,
+      "time": 1594320839746,
     },
     "index": 6,
   },

--- a/test/create-code/CodeReconciler.test.ts
+++ b/test/create-code/CodeReconciler.test.ts
@@ -43,13 +43,19 @@ describe('CodeReconciler.reconcile', () => {
     const reconciler = new CodeReconciler();
 
     const originalCode = buildVirtualCode([steps[0]]);
+
+    const actualCode = reconciler.reconcile({
+      actualCode: PATCH_HANDLE,
+      virtualCode: originalCode,
+    });
+
     reconciler.update(originalCode);
 
     const newCode = buildVirtualCode([steps[1]]);
     expect(reconciler.hasChanges(newCode)).toBeTruthy();
 
     const reconciled = reconciler.reconcile({
-      actualCode: originalCode.code(),
+      actualCode,
       virtualCode: newCode,
     });
     expect(reconciled).toMatchSnapshot();
@@ -59,23 +65,31 @@ describe('CodeReconciler.reconcile', () => {
     const reconciler = new CodeReconciler();
 
     const originalCode = buildVirtualCode([steps[0]]);
+
+    const actualCode = reconciler.reconcile({
+      actualCode: PATCH_HANDLE,
+      virtualCode: originalCode,
+    });
+
     reconciler.update(originalCode);
 
     const removedStepCode = buildVirtualCode([]);
 
-    // we dont want it to do anything until a new step arrives
+    // we don't want it to do anything until a new step arrives
     expect(reconciler.hasChanges(removedStepCode)).toBeFalsy();
     let reconciled = reconciler.reconcile({
-      actualCode: originalCode.code(),
+      actualCode,
       virtualCode: removedStepCode,
     });
-    expect(reconciled).toEqual(originalCode.code());
+    expect(reconciled).toEqual(actualCode);
+
+    reconciler.update(removedStepCode);
 
     const stepAddedCode = buildVirtualCode([steps[1]]);
     expect(reconciler.hasChanges(stepAddedCode)).toBeTruthy();
 
     reconciled = reconciler.reconcile({
-      actualCode: originalCode.code(),
+      actualCode,
       virtualCode: stepAddedCode,
     });
     expect(reconciled).toMatchSnapshot();

--- a/test/create-code/__snapshots__/CodeReconciler.test.ts.snap
+++ b/test/create-code/__snapshots__/CodeReconciler.test.ts.snap
@@ -7,10 +7,10 @@ exports[`CodeReconciler.reconcile inserts new expressions 1`] = `
 
 exports[`CodeReconciler.reconcile updates the last expression 1`] = `
 "await page.click(\\"#username\\");
-"
+// 🐺 create code here"
 `;
 
 exports[`CodeReconciler.reconcile updates the last expression after a step was removed (ex: paste) 1`] = `
 "await page.click(\\"#username\\");
-"
+// 🐺 create code here"
 `;

--- a/test/create-code/patchCode.test.ts
+++ b/test/create-code/patchCode.test.ts
@@ -19,9 +19,19 @@ describe('patchCode', () => {
   it('matches indentation', () => {
     const patched = patchCode({
       code: `  myMethod();\n  ${PATCH_HANDLE}`,
-      patch: 'myPatch();',
+      patchLines: ['myPatch();'],
+      replaceLines: [],
     });
-    expect(patched).toEqual('  myMethod();\n  myPatch();');
+    expect(patched).toEqual(`  myMethod();\n  myPatch();\n  ${PATCH_HANDLE}`);
+  });
+
+  it('replaces lines', () => {
+    const patched = patchCode({
+      code: `  myMethod();\n  ${PATCH_HANDLE}`,
+      patchLines: ['myPatch();'],
+      replaceLines: ['myMethod();'],
+    });
+    expect(patched).toEqual(`  myPatch();\n  ${PATCH_HANDLE}`);
   });
 });
 


### PR DESCRIPTION
Resolves #802 

## Changes
When a browser registers a 'dblclick', generated Playwright code will reflect this by calling `.dblclick` instead of two lines of `.click`.

## Testing
1. Double-click an element and verify that the generated code has one `dblclick` line rather than two `click` lines.
2. Click an element twice, slowly, and verify that the generated code has two `click` lines.