### PR TITLE
Fix click selector penalties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       }
     },
     "@qawolf/sandbox": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.21.tgz",
-      "integrity": "sha512-4uLawdQeTEWLM7kGzq45OJ3/oqsxMy2FoN4fyNllnl41e95hGjeD99xZobkdNmOTyeaYaHFJmB1e3Z5EYGUhAQ==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.22.tgz",
+      "integrity": "sha512-SAztrrrA/d3J27ug87N/KDoQpPMAnw8OvKdHyj6hW5IVSM3KOTi+OCi3V9LiDXVQl9iXem30Qs3aG+TS2UTNtA==",
       "dev": true,
       "requires": {
         "serve": "^11.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
-    "@qawolf/sandbox": "0.1.21",
+    "@qawolf/sandbox": "0.1.22",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.3",

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "files": [
     "bin",
     "build"

--- a/packages/sandbox/src/pages/Buttons/HtmlButtons.js
+++ b/packages/sandbox/src/pages/Buttons/HtmlButtons.js
@@ -42,7 +42,7 @@ function HtmlButtons() {
       <br />
       <br />
       <button>
-        <span>Better attribute on span</span>
+        <span data-for-test="selection">Better attribute on span</span>
       </button>
       <br />
       <br />

--- a/packages/sandbox/src/pages/Buttons/HtmlButtons.js
+++ b/packages/sandbox/src/pages/Buttons/HtmlButtons.js
@@ -41,6 +41,11 @@ function HtmlButtons() {
       </button>
       <br />
       <br />
+      <button>
+        <span>Better attribute on span</span>
+      </button>
+      <br />
+      <br />
       <input id="submit-input" type="submit" value="Submit Input" />
       <br />
       <br />

--- a/src/web/PageEventCollector.ts
+++ b/src/web/PageEventCollector.ts
@@ -1,7 +1,8 @@
 import { DEFAULT_ATTRIBUTE_LIST } from './attribute';
 import {
   getInputElementValue,
-  getMouseEventTarget,
+  getClickableGroup,
+  getTopmostEditableElement,
   isVisible,
 } from './element';
 import { buildSelector } from './selector';
@@ -53,22 +54,27 @@ export class PageEventCollector {
 
     const isClick = ['click', 'mousedown'].includes(eventName);
 
-    let target = event.target as HTMLElement;
+    const target = getTopmostEditableElement(event.target as HTMLElement);
+
+    let targetGroup: HTMLElement[];
     if (isClick) {
-      target = getMouseEventTarget(event as MouseEvent);
+      targetGroup = getClickableGroup(target);
     }
 
     const isTargetVisible = isVisible(target, window.getComputedStyle(target));
+
+    const selector = buildSelector({
+      attributes: this._attributes,
+      isClick,
+      target,
+      targetGroup,
+    });
 
     const elementEvent: types.ElementEvent = {
       isTrusted: event.isTrusted && isTargetVisible,
       name: eventName,
       page: -1, // set in ContextEventCollector
-      selector: buildSelector({
-        attributes: this._attributes,
-        isClick,
-        target,
-      }),
+      selector,
       target: nodeToDoc(target),
       time: Date.now(),
       value,

--- a/src/web/PageEventCollector.ts
+++ b/src/web/PageEventCollector.ts
@@ -1,8 +1,7 @@
 import { DEFAULT_ATTRIBUTE_LIST } from './attribute';
 import {
-  getClickableAncestor,
   getInputElementValue,
-  getTopmostEditableElement,
+  getMouseEventTarget,
   isVisible,
 } from './element';
 import { buildSelector } from './selector';
@@ -52,7 +51,13 @@ export class PageEventCollector {
     const eventCallback: EventCallback = (window as any).qawElementEvent;
     if (!eventCallback) return;
 
-    const target = event.target as HTMLElement;
+    const isClick = ['click', 'mousedown'].includes(eventName);
+
+    let target = event.target as HTMLElement;
+    if (isClick) {
+      target = getMouseEventTarget(event as MouseEvent);
+    }
+
     const isTargetVisible = isVisible(target, window.getComputedStyle(target));
 
     const elementEvent: types.ElementEvent = {
@@ -61,7 +66,7 @@ export class PageEventCollector {
       page: -1, // set in ContextEventCollector
       selector: buildSelector({
         attributes: this._attributes,
-        isClick: ['click', 'mousedown'].includes(eventName),
+        isClick,
         target,
       }),
       target: nodeToDoc(target),
@@ -81,22 +86,29 @@ export class PageEventCollector {
   }
 
   private collectEvents(): void {
+    //////// MOUSE EVENTS ////////
+
     this.listen('mousedown', (event) => {
       // only the main button (not right clicks/etc)
       // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
       if (event.button !== 0) return;
 
-      // getClickableAncestor chooses the top most clickable ancestor.
-      // The ancestor is likely a better target than the descendant.
-      // Ex. when you click on the i (button > i) or rect (a > svg > rect)
-      // chances are the ancestor (button, a) is a better target to find.
-      // XXX if anyone runs into issues with this behavior we can allow disabling it from a flag.
-      let target = getClickableAncestor(
-        event.target as HTMLElement,
-        this._attributes,
-      );
-      target = getTopmostEditableElement(target);
-      this.sendEvent('mousedown', { ...event, target });
+      this.sendEvent('mousedown', event);
+    });
+
+    this.listen('click', (event) => {
+      // only the main button (not right clicks/etc)
+      // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
+      if (event.button !== 0) return;
+
+      this.sendEvent('click', event);
+    });
+
+    //////// INPUT EVENTS ////////
+
+    this.listen('input', (event) => {
+      const target = event.target as HTMLInputElement;
+      this.sendEvent('input', event, getInputElementValue(target));
     });
 
     this.listen('change', (event) => {
@@ -104,21 +116,7 @@ export class PageEventCollector {
       this.sendEvent('change', event, getInputElementValue(target));
     });
 
-    this.listen('click', (event) => {
-      if (event.button !== 0) return;
-
-      let target = getClickableAncestor(
-        event.target as HTMLElement,
-        this._attributes,
-      );
-      target = getTopmostEditableElement(target);
-      this.sendEvent('click', { ...event, target });
-    });
-
-    this.listen('input', (event) => {
-      const target = event.target as HTMLInputElement;
-      this.sendEvent('input', event, getInputElementValue(target));
-    });
+    //////// KEYBOARD EVENTS ////////
 
     this.listen('keydown', (event) => {
       this.sendEvent('keydown', event, event.key);
@@ -127,6 +125,8 @@ export class PageEventCollector {
     this.listen('keyup', (event) => {
       this.sendEvent('keyup', event, event.key);
     });
+
+    //////// OTHER EVENTS ////////
 
     this.listen('paste', (event) => {
       if (!event.clipboardData) return;

--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -13,6 +13,7 @@ export type BuildCues = {
   attributes: string[];
   isClick: boolean;
   target: HTMLElement;
+  targetGroup?: HTMLElement[];
 };
 
 type CueTypeConfig = {

--- a/src/web/element.ts
+++ b/src/web/element.ts
@@ -96,23 +96,6 @@ export const getTopmostEditableElement = (
 };
 
 /**
- * @summary Returns the best target element for reproducing a mouse event.
- */
-export const getMouseEventTarget = (event: MouseEvent): HTMLElement => {
-  const originalTarget = event.target as HTMLElement;
-
-  const clickableGroup = getClickableGroup(originalTarget);
-
-  // If originalTarget wasn't part of a clickable group
-  if (clickableGroup.length === 0) {
-    return getTopmostEditableElement(originalTarget);
-  }
-
-  // For now, just return the topmost clickable element in the group
-  return clickableGroup[clickableGroup.length - 1];
-};
-
-/**
  * @summary Returns the current "value" of an element. Pass in an event `target`.
  *   For example, returns the `.value` or the `.innerText` of a content-editable.
  *   If no value can be determined, returns `null`.

--- a/src/web/optimizeCues.ts
+++ b/src/web/optimizeCues.ts
@@ -185,6 +185,7 @@ export const findBestCueGroup = (
   seedGroup: CueGroup,
   target: HTMLElement,
   maxSize: number,
+  targetGroup?: HTMLElement[],
 ): CueGroup => {
   let bestGroup = seedGroup;
 
@@ -218,7 +219,16 @@ export const findBestCueGroup = (
 
       const selectorParts = buildSelectorParts(cues);
 
-      if (isMatch({ selectorParts, target })) {
+      // If these selector parts match the `target` element or any element in the
+      // target group, if there is one, then it's currently the best group.
+      if (
+        (
+          targetGroup &&
+          targetGroup.length &&
+          targetGroup.some((groupElement) => isMatch({ selectorParts, target: groupElement }))
+        ) ||
+        isMatch({ selectorParts, target })
+      ) {
         bestGroup = {
           cues,
           penalty,
@@ -235,6 +245,7 @@ export const findBestCueGroup = (
 export const optimizeCues = (
   cues: Cue[],
   target: HTMLElement,
+  targetGroup?: HTMLElement[],
 ): CueGroup | null => {
   const cueSets = buildCueSets(cues);
 
@@ -250,7 +261,7 @@ export const optimizeCues = (
       // 16 cues, samples of 5 is ~7000 combinations which took ~100ms on my machine
       if (!cueGroup || cueGroup.cues.length > 16) return null;
 
-      return findBestCueGroup(cueGroup, target, 5);
+      return findBestCueGroup(cueGroup, target, 5, targetGroup);
     })
     // Ignore invalid groups
     .filter((a) => !!a)

--- a/src/web/qawolf.ts
+++ b/src/web/qawolf.ts
@@ -6,8 +6,9 @@ export {
   getCueTypesConfig,
 } from './cues';
 export {
-  getClickableAncestor,
+  getClickableGroup,
   getInputElementValue,
+  getMouseEventTarget,
   getTopmostEditableElement,
   isClickable,
   isVisible,

--- a/src/web/qawolf.ts
+++ b/src/web/qawolf.ts
@@ -8,7 +8,6 @@ export {
 export {
   getClickableGroup,
   getInputElementValue,
-  getMouseEventTarget,
   getTopmostEditableElement,
   isClickable,
   isVisible,

--- a/src/web/selector.ts
+++ b/src/web/selector.ts
@@ -28,7 +28,7 @@ export const toSelector = (selectorParts: SelectorPart[]): string => {
 };
 
 export const buildSelector = (options: BuildCues): string => {
-  const { isClick, target } = options;
+  const { isClick, target, targetGroup } = options;
 
   // To save looping, see if we have already figured out a unique
   // selector for this target.
@@ -52,7 +52,7 @@ export const buildSelector = (options: BuildCues): string => {
 
   const cues = buildCues(options);
 
-  const { selectorParts } = optimizeCues(cues, target) || {};
+  const { selectorParts } = optimizeCues(cues, target, targetGroup) || {};
   if (selectorParts) {
     // First cache it so that we don't need to do all the looping for this
     // same target next time. We cache `selectorParts` rather than `selector`

--- a/test/web/element.test.ts
+++ b/test/web/element.test.ts
@@ -16,49 +16,53 @@ beforeAll(async () => {
 
 afterAll(() => browser.close());
 
-describe('getClickableAncestor', () => {
+describe('getClickableGroup', () => {
   beforeAll(() => page.goto(`${TEST_URL}buttons`));
 
-  it('chooses the top most clickable ancestor', async () => {
-    const id = await page.evaluate(() => {
+  it('returns a clickable group', async () => {
+    const group = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
       const element = document.querySelector('#nested span') as HTMLElement;
       if (!element) throw new Error('element not found');
 
-      const ancestor = web.getClickableAncestor(element, []);
-      return ancestor.id;
+      return web.getClickableGroup(element).map((el) => el.tagName);
     });
 
-    expect(id).toEqual('nested');
+    expect(group).toMatchInlineSnapshot(`
+      Array [
+        "SPAN",
+        "DIV",
+        "BUTTON",
+      ]
+    `);
   });
 
-  it('chooses the original element when there is no clickable ancestor', async () => {
-    const id = await page.evaluate(() => {
+  it('group has only the original element when there is no clickable ancestor', async () => {
+    const group = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
       const element = document.querySelector('#nested') as HTMLElement;
       if (!element) throw new Error('element not found');
 
-      const ancestor = web.getClickableAncestor(element, []);
-      return ancestor.id;
+      return web.getClickableGroup(element).map((el) => el.tagName);
     });
 
-    expect(id).toEqual('nested');
+    expect(group).toMatchInlineSnapshot(`
+      Array [
+        "BUTTON",
+      ]
+    `);
   });
 
-  it('stops at an ancestor with a preferred attribute', async () => {
-    const attribute = await page.evaluate(() => {
+  it('returns empty array if the element is not clickable', async () => {
+    const groupLength = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
-
-      const element = document.querySelector(
-        '[data-qa="nested-attribute"] span',
-      ) as HTMLElement;
+      const element = document.querySelector('h3') as HTMLElement;
       if (!element) throw new Error('element not found');
 
-      const ancestor = web.getClickableAncestor(element, ['data-qa']);
-      return ancestor.getAttribute('data-qa');
+      return web.getClickableGroup(element).length;
     });
 
-    expect(attribute).toEqual('nested-attribute');
+    expect(groupLength).toBe(0);
   });
 });
 
@@ -68,7 +72,9 @@ describe('getInputElementValue', () => {
 
     const value = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
-      const element = document.querySelector('[data-qa="html-text-input"]') as HTMLInputElement;
+      const element = document.querySelector(
+        '[data-qa="html-text-input"]',
+      ) as HTMLInputElement;
       if (!element) throw new Error('element not found');
 
       element.value = 'I have value';
@@ -84,7 +90,9 @@ describe('getInputElementValue', () => {
 
     const value = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
-      const element = document.querySelector('[data-qa="content-editable"]') as HTMLInputElement;
+      const element = document.querySelector(
+        '[data-qa="content-editable"]',
+      ) as HTMLInputElement;
       if (!element) throw new Error('element not found');
 
       return web.getInputElementValue(element);
@@ -98,7 +106,9 @@ describe('getInputElementValue', () => {
 
     const value = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
-      const element = document.querySelector('[data-qa="html-text-input-content-editable"]') as HTMLInputElement;
+      const element = document.querySelector(
+        '[data-qa="html-text-input-content-editable"]',
+      ) as HTMLInputElement;
       if (!element) throw new Error('element not found');
 
       element.value = 'I have value';

--- a/test/web/selector.test.ts
+++ b/test/web/selector.test.ts
@@ -38,8 +38,13 @@ describe('buildSelector', () => {
     const builtSelector = await page.evaluate(
       ({ attributes, element, isClick }) => {
         const qawolf: QAWolfWeb = (window as any).qawolf;
-        let target = qawolf.getClickableGroup(element as HTMLElement).pop();
-        if (!target) target = element as HTMLElement;
+
+        const target = qawolf.getTopmostEditableElement(element as HTMLElement);
+
+        let targetGroup: HTMLElement[];
+        if (isClick) {
+          targetGroup = qawolf.getClickableGroup(target);
+        }
 
         qawolf.clearSelectorCache();
 
@@ -47,6 +52,7 @@ describe('buildSelector', () => {
           attributes,
           isClick,
           target,
+          targetGroup,
         });
       },
       { attributes, element, isClick },
@@ -102,6 +108,8 @@ describe('buildSelector', () => {
         [['#html-button-child', '[data-qa="html-button-with-children"]']],
         [['.MuiButton-label', '[data-qa="material-button"]']],
         ['.second-half.type-two'],
+        // selects the better selector for target despite having clickable ancestors
+        [['[data-for-test="selection"]', 'text="Better attribute on span"']],
       ])('builds expected selector %o', (selector) => expectSelector(selector));
     });
 

--- a/test/web/selector.test.ts
+++ b/test/web/selector.test.ts
@@ -38,7 +38,8 @@ describe('buildSelector', () => {
     const builtSelector = await page.evaluate(
       ({ attributes, element, isClick }) => {
         const qawolf: QAWolfWeb = (window as any).qawolf;
-        const target = qawolf.getClickableAncestor(element as HTMLElement, []);
+        let target = qawolf.getClickableGroup(element as HTMLElement).pop();
+        if (!target) target = element as HTMLElement;
 
         qawolf.clearSelectorCache();
 


### PR DESCRIPTION
Resolves #795 

## Changes

Previously, for "click" events, the generated selector would target the topmost element in the clickable group. For example, if "click" is received for `button > span > i` element, the selector would be generated for that `button`.

However, sometimes the original target or one of the in-between elements has a better attribute for selection. For example, maybe one of them has a `data-qa` attribute.

Now, all elements in the clickable group are considered when generating a selector, and the one with the lowest penalty will be used.

## Testing
1. Run sandbox website in this branch.
2. `DEBUG=qawolf:* qawolf create http://localhost:5000/buttons`
3. Click the "Better attribute on span" button
4. Verify that `await page.click('text="Better attribute on span"');` line is added to the generated test file.