### PR TITLE
fix: handle more nested button group cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       }
     },
     "@qawolf/sandbox": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.23.tgz",
-      "integrity": "sha512-54O5/Pjgbruj5vAW85aUzHyu9AbQtKvWnDeQbPNVRieAzmOJd+UImkwtYu5TgP63qDXDd0NmQijm8XrQUiipYA==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.24.tgz",
+      "integrity": "sha512-227dB8Lrxx84ZCvrAM2wH+oRKk3/Gu+lkNKf+D8JpCRCeRi2vZGQLS/IwS2FgSM2PhIbaT13S8g4KGE9MBByUQ==",
       "dev": true,
       "requires": {
         "serve": "^11.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
-    "@qawolf/sandbox": "0.1.23",
+    "@qawolf/sandbox": "0.1.24",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.3",

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "files": [
     "bin",
     "build"

--- a/packages/sandbox/src/pages/Buttons/HtmlButtons.js
+++ b/packages/sandbox/src/pages/Buttons/HtmlButtons.js
@@ -63,7 +63,7 @@ function HtmlButtons() {
       </button>
       <br />
       <br />
-      <button data-qa="nested-svg" type="button" style={{ display: 'inline-flex', alignItems: 'center' }}>
+      <button data-for-test="nested-svg" type="button" style={{ display: 'inline-flex', alignItems: 'center' }}>
         <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" style={{ marginRight: 6 }}>
           <circle cx="5" cy="5" r="5" stroke="black" strokeWidth="0" fill="red"></circle>
         </svg>
@@ -73,7 +73,7 @@ function HtmlButtons() {
       </button>
       <br />
       <br />
-      <button data-qa="nested-svg-with-nested-link" type="button" style={{ display: 'inline-flex', alignItems: 'center' }}>
+      <button data-for-test="nested-svg-with-nested-link" type="button" style={{ display: 'inline-flex', alignItems: 'center' }}>
         <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" style={{ marginRight: 6 }}>
           <circle cx="5" cy="5" r="5" stroke="black" strokeWidth="0" fill="red"></circle>
         </svg>

--- a/packages/sandbox/src/pages/Buttons/HtmlButtons.js
+++ b/packages/sandbox/src/pages/Buttons/HtmlButtons.js
@@ -1,6 +1,15 @@
 import React from 'react';
 
+const buttonImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAjCAYAAADWtVmPAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMqADAAQAAAABAAAAIwAAAADbcXyaAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAAIwklEQVRYCdVZ3W8dRxU/s7v3+vomdhwTNdSE2HkoTaBtILclKhLgPgCVUEUl5IjyD/AGEhLwzFMfQLRS8oIqVQUFqaoBtYRKfUAkaoLUKnGStqSUoIqU5tPYjhPf73t3ht/vzI69dtz42uahHXt3Zs6eOd/nzOxeI1k7U6kUHp6a6nB6ef/ez7muPBgZGbEinzLGbTNOBkTMFjGuLOL6RaI+J9JnxBXQF4xI4pwkYiTGOMI4MgbYWESauDnAHGAWMCtOUoy7gHetmC5Q2qDVBmYTiE3M68CrAee2ceYWns2ZSK62rL0w9vd//YM03fh4Yk6c4FrPxE1MxGZyMv3wgfsfAuwXuL4xGEeGUoGQNggB3l4C9nplMMjncTI4J8RfrQWt2GekyUXH5BXgUQ5GOiSXgujtlDaQE1D2p7svXDztJmC4SRgleOLyA/d92zrz5+EklptpSuQubnDIUnNLepGhykEjE8OLogrofGnV6iMIraoGI2B90D2Dg2Z4GEgYeBmeH4pjWYBCHSuHRt/956R6hjhX9+0b7UTpe/2RKTWsrUO2EiTjojWbcl0T6+4IvfAhBfKCcrC3a/aZqNyCW2wkn9/zzsX3IiK0jP3xcByX6tY1nDNlLGCM+2BeoyfeZi9NmjX4EEdlgmwwdBmJ1Ngex8ak7ifUwVytjJRbja3vlowZxUMkuyvwwce9ORSIkpEEXpmO4tbepF0r7y9EMoqQgs6oOp+Y5uIWKl9/FN1T65YqSVeiBwdQ11o2ZektbkqPCJFqUx+TSMiPLF2bYrK4mKU9LYqJa849lIDZbiYbyxN7uqXX5APq8tbGNrBtCERArVpFNGsKLsf5P8yCjOzZkPO7E1S4T1tkESYeyAc68regXA6kwzvgWG/KZUmnzqkhokcqIp2OuGZDjEXtDxsSVucNledFwnm6d8MjLtdyb6EONNkOTtjY6XBFH2BcGXAWe6bW4DZJL74vhW8+LveePyfJj34ondNTYs+/LbJ1QBwuoTK4KOri2hV88vTz48A/3ysNEOtigHq8I4Ic27sgiJ4xx/UaZqEn65XjMGdPT7oYEcoxiAzu/6KM/uoZGT5+XOT7T0l65qzYs+fFDQ2LlMpi4SXSDFee1kpYmIc+j6v8WLowgARDCcJqQN0DoILAZN2N1sYiZQRB40JBdo6Py8CBAzL7vaek9tvfiP39HzRsTOWAuEYdYYcjEs2aj591MxZsI1DDua0ot67fTyzOZqpL7+QoBIVhl12G1YpjHHPKg4NSeuIJuVWpyPzEIWn97qikfzomZmufmPv2KY7UUBT0kLU+3jwYadlSRaQEj5giXccjkxeJkx5bkB7oi8NMMVYs5gSPwNtHRqT/ySdVoRoUar/4oqSvvorCiRNW5RFxt+ZxsoOHcgVhTQnAEP+GKYrWR48YHKMBpIto4g00EKMxPE2/Ximx/FIxXKViUQpje6S0Y4dUEXKtiQlpPv+8dF9/XaJdnxEpb4Ey2Mqwp/XaKDV2LfIuJCwkLmLmA6Lp3iuZDC/zgFcir0r2PLMyi0IcR7IN4VZMElkYHpbSwYPSOndOar/Em8P0tMgWKIMc69kztBHY0AXYR9RgatGN6BHc4Almwq/SGSjky69IPwTmNdNsSh0Xqx2k91It9qsQWQHiKvUfBnyrY3poBKzA631KGsD+yNAEEyoRCkEHu/4cQmrm6aelfeqUxGNjiPIS3hHX4Y1MOvJleEEROoZC4KaBnWH02pESnbt49ws556sS6RrkCpXo1usye/KkTD/7rLRee01Y36IvoRzP34Q0EEf5K0FPZK07UJUvLMgjCraSrGJlD4I+ROKYPduqYwiKFMsU8Xh6Z/JBeIZU2mrJDCw/ffiwNF95RRUoPPqouJvzYpEbBvuO8soY6ThHKgMrJMgQZCQQzzssvx1KSIdkwEXBw9w/WVJoJZwVi5d6F5al9XlxF5994w25fviINCZfUgWSysOa0OmHV+AOMC4UfTRwPQlnLT8OMPZ5OMbZNi4teqShewijgwrlV/UyxgJNZOJGsUQos8yHGShw47nnpPrCC/qSkxzAIbLeEDs758MIimoLFvSzdd01bBlNTppM9gWtkAho0ly3ImBNy3OdTbsy8+abcuPoUbl95Ih6oPjlg9jwbou9dh1vO3j5JCIZbkKBoC0zEJRwt1Vz+rNjLw/E0XcWrMXLhBQ3oogKReFg5fTf7yufBElMod0N7A/YP+gtjxfE2FyvCiBI8VJYqDr3lwTnq//ikKUbYvZwAxywkhZA+Yz3fQG1MBGLRNZyirG24IENWWp1kWgn2g9nxVkku71OVzNFAq/Vl/UA5fmqWvOWJ3o4ovSwdEMoWbGF6Ne5j/yHp19adNPG2rQleldHZUV5YmJTh8S46J0ajgj452cgPmeEfRIaZU0aEBx/byXWdN9KbXwJ37XGcOph+aFCH/sG4VN8baQiN9rFaCr6yuXLDXyCfBmf1ekivDne+cf3P/6xz193Ym4cEnjk+dyNGizd6afM4o49dunSvD/8u+4zN1Nbx3tbP0Kujovv9Aw/XwByPVb6AMxgAWezPekGGoFHmIeeh2SM+dGnXoCsc6lNnUnxDoB8OCP4XUSmOifv3fU4jivH8KU7Yc5AE546cN4IZJdyB4RY9bSBtg55C+PsUVgQUAmmTMsaHiqMX+OVAp+GarQMExP/m0vCD4pViAfhvvv1ax/88dfQQZmAAn+cSU+N7Lk/td2fg/K3+iIz1Adx+TtFaN7VnjMFCkItH3to/llYv0TJax9+iiB82YWJn/PuG3mnIFrD+Qf7+V+j2Pzsa1c/OPsSZD8E2RcxqdUP4Bku+9vOnfd0o+JeGH4USbELv1gNw0kDYBx+sSpBWehpcLCSAvbTAuzJX65wWnT4NmR4kOJWjld2w8MxPYhQdRY01NPYyVLUTsrWwUMUGdcGvzY0aIJWA2N8anFVzBfA4xZw5kD7Why5C1+9cuUi5Twu48lj4n+x+h+6c1B46JQBvQAAAABJRU5ErkJggg==';
+
 function HtmlButtons() {
+  const inputButtonsStyle = {
+    alignItems: 'end',
+    display: 'inline-flex',
+    justifyContent: 'space-between',
+    width: 380,
+  };
+
   return (
     <div className="container">
       <h3>Native HTML</h3>
@@ -46,7 +55,41 @@ function HtmlButtons() {
       </button>
       <br />
       <br />
-      <input id="submit-input" type="submit" value="Submit Input" />
+      <button type="button">
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" style={{ marginRight: 6 }}>
+          <circle cx="5" cy="5" r="5" stroke="black" strokeWidth="0" fill="red"></circle>
+        </svg>
+        <span>SVG text button</span>
+      </button>
+      <br />
+      <br />
+      <button data-qa="nested-svg" type="button" style={{ display: 'inline-flex', alignItems: 'center' }}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" style={{ marginRight: 6 }}>
+          <circle cx="5" cy="5" r="5" stroke="black" strokeWidth="0" fill="red"></circle>
+        </svg>
+        <div>
+          <span>Nested SVG text button</span>
+        </div>
+      </button>
+      <br />
+      <br />
+      <button data-qa="nested-svg-with-nested-link" type="button" style={{ display: 'inline-flex', alignItems: 'center' }}>
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" style={{ marginRight: 6 }}>
+          <circle cx="5" cy="5" r="5" stroke="black" strokeWidth="0" fill="red"></circle>
+        </svg>
+        <div>
+          <span>Nested SVG text button&nbsp;</span>
+        </div>
+        <a href="#"><span>with nested link</span></a>
+      </button>
+      <br />
+      <br />
+      <div style={inputButtonsStyle}>
+        <input id="submit-input" type="submit" value="Submit Input" />
+        <input id="button-input" type="button" value="Button Input" />
+        <input id="image-input" type="image" src={buttonImage} alt="Play" width="30" />
+        <input id="reset-input" type="reset" value="Reset Input" />
+      </div>
       <br />
       <br />
       <button data-qa="reload-top" onClick={() => window.top.location.reload()}>

--- a/src/web/PageEventCollector.ts
+++ b/src/web/PageEventCollector.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_ATTRIBUTE_LIST } from './attribute';
 import {
   getInputElementValue,
-  getClickableGroup,
   getTopmostEditableElement,
   isVisible,
 } from './element';
@@ -40,7 +39,11 @@ export class PageEventCollector {
     });
 
     this._onDispose.push(() =>
-      document.removeEventListener(eventName, handler),
+      document.removeEventListener(eventName, handler, {
+        // `capture` value must match for proper removal
+        // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#Matching_event_listeners_for_removal
+        capture: true,
+      }),
     );
   }
 
@@ -56,18 +59,12 @@ export class PageEventCollector {
 
     const target = getTopmostEditableElement(event.target as HTMLElement);
 
-    let targetGroup: HTMLElement[];
-    if (isClick) {
-      targetGroup = getClickableGroup(target);
-    }
-
     const isTargetVisible = isVisible(target, window.getComputedStyle(target));
 
     const selector = buildSelector({
       attributes: this._attributes,
       isClick,
       target,
-      targetGroup,
     });
 
     const elementEvent: types.ElementEvent = {

--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -13,7 +13,6 @@ export type BuildCues = {
   attributes: string[];
   isClick: boolean;
   target: HTMLElement;
-  targetGroup?: HTMLElement[];
 };
 
 type CueTypeConfig = {

--- a/src/web/element.ts
+++ b/src/web/element.ts
@@ -72,14 +72,15 @@ const traverseClickableElements = (
   if (direction === 'down' && depth > 0 && isLikelyTopOfClickGroup(element)) return;
 
   const newDepth = depth + 1;
-  if (newDepth > maxDepth) return;
-
   const lowerTagName = element.tagName.toLowerCase();
 
   if (direction === 'up') {
     // Call self for the parent element, incrementing depth
     traverseClickableElements(element.parentElement, group, direction, maxDepth, newDepth, [lowerTagName, ...ancestorChain]);
   } else {
+    // Respect max depth only when going down
+    if (newDepth > maxDepth) return;
+
     // If we make it this far, this element should be part of the current group.
     // We add elements to the group only on the way down to avoid adding any twice.
     group.push(element);

--- a/src/web/element.ts
+++ b/src/web/element.ts
@@ -1,5 +1,8 @@
 import { getXpath } from './serialize';
 
+const BUTTON_INPUT_TYPES = ['button', 'image', 'reset', 'submit'];
+const MAX_CLICKABLE_ELEMENT_TRAVERSE_DEPTH = 10;
+
 export const isVisible = (
   element: Element,
   computedStyle?: CSSStyleDeclaration,
@@ -22,12 +25,77 @@ export const isVisible = (
 
 export const isClickable = (
   element: HTMLElement,
-  computedStyle: CSSStyleDeclaration,
+  computedStyle: CSSStyleDeclaration = window.getComputedStyle(element),
 ): boolean => {
   // assume it is clickable if the cursor is a pointer
   const clickable = computedStyle.cursor === 'pointer';
 
   return clickable && isVisible(element, computedStyle);
+};
+
+export const isLikelyTopOfClickGroup = (element: HTMLElement): boolean => {
+  const tagName = element.tagName.toLowerCase();
+  return (
+    ['a', 'button'].includes(tagName) ||
+    element.getAttribute('role') === 'button' ||
+    (tagName === 'input' && BUTTON_INPUT_TYPES.includes(element.getAttribute('type'))) ||
+    !element.parentElement ||
+    !isClickable(element.parentElement)
+  );
+};
+
+/**
+ * @summary Traverse the DOM in both directions, adding clickable elements to the array
+ *   until we've determined the full set of elements that are in the clickable area.
+ *   This is not foolproof because we can't know where exactly click handlers might
+ *   be attached, but we can do a pretty good job of guessing.
+ */
+const traverseClickableElements = (
+  element: HTMLElement,
+  group: HTMLElement[],
+  direction: 'up' | 'down' = 'up',
+  maxDepth: number = MAX_CLICKABLE_ELEMENT_TRAVERSE_DEPTH,
+  depth = 0,
+  ancestorChain: string[] = [],
+): void => {
+  // Regardless of which direction we're moving, stop if we hit a non-clickable element
+  if (!isClickable(element)) return;
+
+  // When moving up, when we reach the topmost clickable element, we
+  // stop traversing up and begin traversing down from there.
+  if (direction === 'up' && isLikelyTopOfClickGroup(element)) {
+    traverseClickableElements(element, group, 'down', maxDepth);
+    return;
+  }
+
+  // When moving down, stop if we hit the top of another click group (nested buttons)
+  if (direction === 'down' && depth > 0 && isLikelyTopOfClickGroup(element)) return;
+
+  const newDepth = depth + 1;
+  if (newDepth > maxDepth) return;
+
+  const lowerTagName = element.tagName.toLowerCase();
+
+  if (direction === 'up') {
+    // Call self for the parent element, incrementing depth
+    traverseClickableElements(element.parentElement, group, direction, maxDepth, newDepth, [lowerTagName, ...ancestorChain]);
+  } else {
+    // If we make it this far, this element should be part of the current group.
+    // We add elements to the group only on the way down to avoid adding any twice.
+    group.push(element);
+
+    const newAncestorChain = [...ancestorChain, lowerTagName];
+    console.debug('qawolf: added %s to click group', newAncestorChain.join(' > '));
+
+    // For now, let's skip going down into SVG descendants to keep this fast. If anyone
+    // finds a situation in which this causes problems, we can remove this.
+    if (lowerTagName !== 'svg') {
+      for (const child of element.children) {
+        // Call self for each child element, incrementing depth
+        traverseClickableElements(child as HTMLElement, group, direction, maxDepth, newDepth, newAncestorChain);
+      }
+    }
+  }
 };
 
 /**
@@ -45,21 +113,10 @@ export const getClickableGroup = (element: HTMLElement): HTMLElement[] => {
   console.debug('qawolf: get clickable ancestor for', getXpath(element));
 
   const clickableElements = [];
-  let checkElement = element;
 
-  while (isClickable(checkElement, window.getComputedStyle(checkElement))) {
-    clickableElements.push(checkElement);
-
-    if (['a', 'button', 'input'].includes(checkElement.tagName.toLowerCase())) {
-      // stop crawling when the checkElement is a good clickable tag
-      break;
-    }
-
-    checkElement = checkElement.parentElement;
-
-    // stop crawling at the root
-    if (!checkElement) break;
-  }
+  // Recursive function that will mutate clickableElements array. A recursive
+  // function is better than loops to avoid blocking UI paint.
+  traverseClickableElements(element, clickableElements);
 
   return clickableElements;
 };

--- a/src/web/qawolf.ts
+++ b/src/web/qawolf.ts
@@ -9,7 +9,6 @@ export {
   getClickableGroup,
   getInputElementValue,
   getTopmostEditableElement,
-  isClickable,
   isVisible,
 } from './element';
 export { formatArgument, interceptConsoleLogs } from './interceptConsoleLogs';

--- a/test/web/element.test.ts
+++ b/test/web/element.test.ts
@@ -59,7 +59,7 @@ describe('getClickableGroup', () => {
     const group = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
       const element = document.querySelector(
-        '[data-qa="nested-svg"] > svg > circle',
+        '[data-for-test="nested-svg"] > svg > circle',
       ) as HTMLElement;
       if (!element) throw new Error('element not found');
 
@@ -80,7 +80,7 @@ describe('getClickableGroup', () => {
     const group = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
       const element = document.querySelector(
-        '[data-qa="nested-svg-with-nested-link"]',
+        '[data-for-test="nested-svg-with-nested-link"]',
       ) as HTMLElement;
       if (!element) throw new Error('element not found');
 
@@ -101,7 +101,7 @@ describe('getClickableGroup', () => {
     const group = await page.evaluate(() => {
       const web: QAWolfWeb = (window as any).qawolf;
       const element = document.querySelector(
-        '[data-qa="nested-svg-with-nested-link"] > a > span',
+        '[data-for-test="nested-svg-with-nested-link"] > a > span',
       ) as HTMLElement;
       if (!element) throw new Error('element not found');
 
@@ -269,32 +269,5 @@ describe('isVisible', () => {
     });
 
     expect(isElementVisible).toBe(false);
-  });
-});
-
-describe('isClickable', () => {
-  beforeAll(() => page.goto(`${TEST_URL}login`));
-
-  it('returns true if element is clickable', async () => {
-    const isClickable = await page.evaluate(() => {
-      const web: QAWolfWeb = (window as any).qawolf;
-
-      const loginButton = document.getElementsByTagName('button')[0];
-      return web.isClickable(loginButton);
-    });
-
-    expect(isClickable).toBe(true);
-  });
-
-  it('returns false if element is not clickable', async () => {
-    const isClickable = await page.evaluate(() => {
-      const web: QAWolfWeb = (window as any).qawolf;
-      const element = document.getElementById('username');
-      if (!element) throw new Error('element not found');
-
-      return web.isClickable(element);
-    });
-
-    expect(isClickable).toBe(false);
   });
 });

--- a/test/web/optimizeCues.test.ts
+++ b/test/web/optimizeCues.test.ts
@@ -1,4 +1,4 @@
-import { buildCueSets, combine } from '../../src/web/optimizeCues';
+import { buildCueSets, combine, pickBestCueGroup } from '../../src/web/optimizeCues';
 
 describe('buildCueSets', () => {
   const penalty = 1;
@@ -49,5 +49,38 @@ describe('combine', () => {
       [1, 3, 4],
       [2, 3, 4],
     ]);
+  });
+});
+
+describe('pickBestCueGroup', () => {
+  const baseCueGroup = {
+    cues: [],
+    penalty: 0,
+    selectorParts: [],
+    valueLength: 0
+  };
+
+  const penalty1Value1 = { ...baseCueGroup, penalty: 1, valueLength: 1 };
+  const penalty1Value2 = { ...baseCueGroup, penalty: 1, valueLength: 2 };
+  const penalty2Value1 = { ...baseCueGroup, penalty: 2, valueLength: 1 };
+
+  it('returns null if there are no groups', () => {
+    const group = pickBestCueGroup([]);
+    expect(group).toBe(null);
+  });
+
+  it('returns only group', () => {
+    const group = pickBestCueGroup([penalty1Value1]);
+    expect(group).toBe(penalty1Value1);
+  });
+
+  it('picks lowest penalty group', () => {
+    const group = pickBestCueGroup([penalty2Value1, penalty1Value1]);
+    expect(group).toBe(penalty1Value1);
+  });
+
+  it('picks shortest value group among groups with equal penalty', () => {
+    const group = pickBestCueGroup([penalty2Value1, penalty1Value1, penalty1Value2]);
+    expect(group).toBe(penalty1Value1);
   });
 });

--- a/test/web/selector.test.ts
+++ b/test/web/selector.test.ts
@@ -41,18 +41,12 @@ describe('buildSelector', () => {
 
         const target = qawolf.getTopmostEditableElement(element as HTMLElement);
 
-        let targetGroup: HTMLElement[];
-        if (isClick) {
-          targetGroup = qawolf.getClickableGroup(target);
-        }
-
         qawolf.clearSelectorCache();
 
         return qawolf.buildSelector({
           attributes,
           isClick,
           target,
-          targetGroup,
         });
       },
       { attributes, element, isClick },


### PR DESCRIPTION
Resolves #827 

## Changes

When finding the nicest selector for a click event:
- Other descendants of the topmost clickable element will be considered, even if they are not ancestors of the original click `target`. This currently goes to a maximum depth of 10 elements down from the topmost element
- `svg` elements will be considered but none of their descendants are considered because there could be many
- There is a boundary between clickable groups nested within other clickable groups. For example, if there is an `<a>` within a `<button>` and you click on the `<button>` outside of the `<a>`, neither the `<a>` nor any of its descendants are considered as possible selectors for the click event. Conversely, if you click on the `<button>` within the `<a>`, then the `<a>` and all its descendants are considered, but the `<button>` ancestor and its group elements are not considered.
- An element is deemed to be the topmost element of a clickable group if ANY of the following are true (see `isLikelyTopOfClickGroup` function):
    - is `a`, `button`, `input[type=button]`, `input[type=image]`, `input[type=reset]`, `input[type=submit]`
    - has `role="button"` attribute
    - has no parent
    - has a non-clickable parent

Also optimized the final picking (sorting) of the best cue group in a new function, `pickBestCueGroup`, not to be confused with the existing `findBestCueGroup`.