### PR TITLE
feat: ignore some dynamic-value attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       }
     },
     "@qawolf/sandbox": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.24.tgz",
-      "integrity": "sha512-227dB8Lrxx84ZCvrAM2wH+oRKk3/Gu+lkNKf+D8JpCRCeRi2vZGQLS/IwS2FgSM2PhIbaT13S8g4KGE9MBByUQ==",
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.25.tgz",
+      "integrity": "sha512-K29FucwbDAKLkzZqxvymuYycQxVaaFL1suxt3VQWVS0VI/xxPfS9SWNCNJlSVbCXQYZSNzh4KHLuq5SGjcRXoA==",
       "dev": true,
       "requires": {
         "serve": "^11.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4999,6 +4999,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       }
     },
     "@qawolf/sandbox": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.25.tgz",
-      "integrity": "sha512-K29FucwbDAKLkzZqxvymuYycQxVaaFL1suxt3VQWVS0VI/xxPfS9SWNCNJlSVbCXQYZSNzh4KHLuq5SGjcRXoA==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@qawolf/sandbox/-/sandbox-0.1.26.tgz",
+      "integrity": "sha512-2Zl/gXkluyF2direyJNHNLCN4ZypAZxPd5pzVVxOClomjzC9+sAFLh42TA3QywvxCv9ommOzk1iIGA8SY9i2XQ==",
       "dev": true,
       "requires": {
         "serve": "^11.3.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
-    "@qawolf/sandbox": "0.1.24",
+    "@qawolf/sandbox": "0.1.25",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.0.20",
-    "@qawolf/sandbox": "0.1.25",
+    "@qawolf/sandbox": "0.1.26",
     "@types/debug": "^4.1.5",
     "@types/fs-extra": "^9.0.1",
     "@types/glob": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "create-qawolf": "^1.2.0",
     "debug": "*",
     "glob": "^7.1.6",
+    "html-tags": "^3.1.0",
     "inquirer": "^7.3.3",
     "kleur": "^4.0.3",
     "open": "^7.1.0",

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sandbox/package-lock.json
+++ b/packages/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "files": [
     "bin",
     "build"

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/sandbox",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "files": [
     "bin",
     "build"

--- a/packages/sandbox/src/pages/CheckboxInputs/HtmlCheckboxInputs.js
+++ b/packages/sandbox/src/pages/CheckboxInputs/HtmlCheckboxInputs.js
@@ -16,11 +16,17 @@ function HtmlCheckboxInputs() {
       <input id="sadovh89r" type="checkbox" name="nonDynamicInput" />
       <label htmlFor="sadovh89r"> Checkbox with non-dynamic name</label>
       <br />
-      <input id="sdf980ergm" type="checkbox" name="input-bu32879fDi" />
-      <label htmlFor="sdf980ergm"> Checkbox with half-dynamic name</label>
-      <br />
       <input id="b98joifbon" type="checkbox" name="bu32879fDi" />
       <label htmlFor="b98joifbon"> Checkbox with dynamic name</label>
+      <br />
+      <input id="v9eonirh894" type="checkbox" name="input-bu32879fDi" />
+      <label htmlFor="v9eonirh894"> Checkbox with dynamic ending of name</label>
+      <br />
+      <input id="ern84j8g0" type="checkbox" name="bu32879fDi-check" />
+      <label htmlFor="ern84j8g0"> Checkbox with dynamic beginning of name</label>
+      <br />
+      <input id="fdg8e9v4" type="checkbox" name="f89ndrn4-blue-5" />
+      <label htmlFor="fdg8e9v4"> Checkbox with dynamic beginning and ending of name</label>
       <br />
       <input id="y908drgun4" type="checkbox" name="" />
       <label htmlFor="y908drgun4"> Checkbox with empty name</label>

--- a/packages/sandbox/src/pages/CheckboxInputs/HtmlCheckboxInputs.js
+++ b/packages/sandbox/src/pages/CheckboxInputs/HtmlCheckboxInputs.js
@@ -13,6 +13,18 @@ function HtmlCheckboxInputs() {
       <input className="special:class" id="special:id" type="checkbox" />
       <label htmlFor="special:id"> Another checkbox</label>
       <br />
+      <input id="sadovh89r" type="checkbox" name="nonDynamicInput" />
+      <label htmlFor="sadovh89r"> Checkbox with non-dynamic name</label>
+      <br />
+      <input id="sdf980ergm" type="checkbox" name="input-bu32879fDi" />
+      <label htmlFor="sdf980ergm"> Checkbox with half-dynamic name</label>
+      <br />
+      <input id="b98joifbon" type="checkbox" name="bu32879fDi" />
+      <label htmlFor="b98joifbon"> Checkbox with dynamic name</label>
+      <br />
+      <input id="y908drgun4" type="checkbox" name="" />
+      <label htmlFor="y908drgun4"> Checkbox with empty name</label>
+      <br />
       <input
         checked={isChecked}
         data-qa="html-checkbox-hidden"

--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -2,6 +2,8 @@ import { getAttribute } from './attribute';
 import { getElementText } from './selectorEngine';
 import { isDynamic } from './isDynamic';
 
+const DYNAMIC_VALUE_OK_ATTRIBUTES = ['href', 'src'];
+
 export type Cue = {
   level: number; // 0 is target, 1 is parent, etc.
   penalty: number; // Cue type penalty plus PENALTY_PER_LEVEL
@@ -242,12 +244,14 @@ export const buildCuesForElement = ({
         });
         if (attributeValuePair) {
           const { name, value } = attributeValuePair;
-          list.push({
-            level,
-            penalty,
-            type: 'attribute',
-            value: `[${name}="${value}"]`,
-          });
+          if (value.length && (DYNAMIC_VALUE_OK_ATTRIBUTES.includes(name) || !isDynamic(value))) {
+            list.push({
+              level,
+              penalty,
+              type: 'attribute',
+              value: `[${name}="${value}"]`,
+            });
+          }
         }
         break;
       }

--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -2,7 +2,7 @@ import { getAttribute } from './attribute';
 import { getElementText } from './selectorEngine';
 import { getValueMatches, isDynamic } from './isDynamic';
 
-const DYNAMIC_VALUE_OK_ATTRIBUTES = ['href', 'src', 'value'];
+const DYNAMIC_VALUE_OK_ATTRIBUTES = ['placeholder', 'href', 'src', 'value'];
 
 export type Cue = {
   level: number; // 0 is target, 1 is parent, etc.

--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -1,6 +1,6 @@
 import { getAttribute } from './attribute';
 import { getElementText } from './selectorEngine';
-import { getValueMatchSelector, isDynamic } from './isDynamic';
+import { getValueMatches, isDynamic } from './isDynamic';
 
 const DYNAMIC_VALUE_OK_ATTRIBUTES = ['href', 'src', 'value'];
 
@@ -254,15 +254,14 @@ export const buildCuesForElement = ({
               value: `[${name}="${value}"]`,
             });
           } else {
-            const { match, operator } = getValueMatchSelector(value) || {};
-            if (match) {
+            getValueMatches(value).forEach(({ match, operator }) => {
               list.push({
                 level,
                 penalty,
                 type: 'attribute',
                 value: `[${name}${operator}"${match}"]`,
               });
-            }
+            });
           }
         }
         break;

--- a/src/web/isDynamic.ts
+++ b/src/web/isDynamic.ts
@@ -182,12 +182,14 @@ export const getValueMatches = (
       addMatchToList();
     } else if (tokenType === 'static' && lastTokenType === 'dynamic') {
       // When we start a new static block after a dynamic block, reset the current
-      // block string, and potentially add the previous split character to it.
-      const lastCharOfPreviousBlock = value[currentPosition - 1];
-      if (SPLIT_CHARACTERS.includes(lastCharOfPreviousBlock)) {
-        currentStaticBlock = lastCharOfPreviousBlock;
-      } else {
-        currentStaticBlock = '';
+      // block string, and potentially add all preceding split characters to it.
+      currentStaticBlock = '';
+      let backwardPosition = currentPosition - 1;
+      let previousCharacter = value[backwardPosition];
+      while (SPLIT_CHARACTERS.includes(previousCharacter)) {
+        if (tokenType === 'static') currentStaticBlock = previousCharacter + currentStaticBlock;
+        backwardPosition -= 1;
+        previousCharacter = value[backwardPosition];
       }
     }
 
@@ -201,11 +203,12 @@ export const getValueMatches = (
     // Keep track of where we are in the original value string
     currentPosition += token.length;
 
-    // Add back in the split-by character
-    const nextCharacter = value[currentPosition];
-    if (SPLIT_CHARACTERS.includes(nextCharacter)) {
+    // Add back in any split-by characters
+    let nextCharacter = value[currentPosition];
+    while (SPLIT_CHARACTERS.includes(nextCharacter)) {
       if (tokenType === 'static') currentStaticBlock += nextCharacter;
       currentPosition += 1;
+      nextCharacter = value[currentPosition];
     }
 
     lastTokenType = tokenType;

--- a/src/web/isDynamic.ts
+++ b/src/web/isDynamic.ts
@@ -187,7 +187,7 @@ export const getValueMatches = (
       let backwardPosition = currentPosition - 1;
       let previousCharacter = value[backwardPosition];
       while (SPLIT_CHARACTERS.includes(previousCharacter)) {
-        if (tokenType === 'static') currentStaticBlock = previousCharacter + currentStaticBlock;
+        currentStaticBlock = previousCharacter + currentStaticBlock;
         backwardPosition -= 1;
         previousCharacter = value[backwardPosition];
       }

--- a/test/web/cues.test.ts
+++ b/test/web/cues.test.ts
@@ -106,6 +106,74 @@ describe('buildCuesForElement', () => {
       },
     ]);
   });
+
+  it('ignores dynamic attr values when building cues', async () => {
+    const cues = await buildCuesForElement('[name="bu32879fDi"]');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(5)",
+        },
+      ]
+    `);
+  });
+
+  it('ignores empty attr values when building cues', async () => {
+    const cues = await buildCuesForElement('#y908drgun4');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(6)",
+        },
+      ]
+    `);
+  });
+
+  it('uses half-dynamic attr values when building cues', async () => {
+    const cues = await buildCuesForElement('[name="input-bu32879fDi"]');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 10,
+          "type": "attribute",
+          "value": "[name=\\"input-bu32879fDi\\"]",
+        },
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(4)",
+        },
+      ]
+    `);
+  });
+
+  it('uses non-dynamic attr values when building cues', async () => {
+    const cues = await buildCuesForElement('[name="nonDynamicInput"]');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 10,
+          "type": "attribute",
+          "value": "[name=\\"nonDynamicInput\\"]",
+        },
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(3)",
+        },
+      ]
+    `);
+  });
 });
 
 describe('buildCueValueForTag', () => {

--- a/test/web/cues.test.ts
+++ b/test/web/cues.test.ts
@@ -135,26 +135,6 @@ describe('buildCuesForElement', () => {
     `);
   });
 
-  it('uses half-dynamic attr values when building cues', async () => {
-    const cues = await buildCuesForElement('[name="input-bu32879fDi"]');
-    expect(cues).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "level": 1,
-          "penalty": 10,
-          "type": "attribute",
-          "value": "[name=\\"input-bu32879fDi\\"]",
-        },
-        Object {
-          "level": 1,
-          "penalty": 40,
-          "type": "tag",
-          "value": "input:nth-of-type(4)",
-        },
-      ]
-    `);
-  });
-
   it('uses non-dynamic attr values when building cues', async () => {
     const cues = await buildCuesForElement('[name="nonDynamicInput"]');
     expect(cues).toMatchInlineSnapshot(`

--- a/test/web/cues.test.ts
+++ b/test/web/cues.test.ts
@@ -115,7 +115,7 @@ describe('buildCuesForElement', () => {
           "level": 1,
           "penalty": 40,
           "type": "tag",
-          "value": "input:nth-of-type(5)",
+          "value": "input:nth-of-type(4)",
         },
       ]
     `);
@@ -129,7 +129,7 @@ describe('buildCuesForElement', () => {
           "level": 1,
           "penalty": 40,
           "type": "tag",
-          "value": "input:nth-of-type(6)",
+          "value": "input:nth-of-type(8)",
         },
       ]
     `);
@@ -150,6 +150,66 @@ describe('buildCuesForElement', () => {
           "penalty": 40,
           "type": "tag",
           "value": "input:nth-of-type(3)",
+        },
+      ]
+    `);
+  });
+
+  it('builds cues with attributes that have dynamic beginning', async () => {
+    const cues = await buildCuesForElement('#ern84j8g0');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 10,
+          "type": "attribute",
+          "value": "[name$=\\"-check\\"]",
+        },
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(6)",
+        },
+      ]
+    `);
+  });
+
+  it('builds cues with attributes that have dynamic ending', async () => {
+    const cues = await buildCuesForElement('#v9eonirh894');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 10,
+          "type": "attribute",
+          "value": "[name^=\\"input-\\"]",
+        },
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(5)",
+        },
+      ]
+    `);
+  });
+
+  it('builds cues with attributes that have dynamic beginning and ending', async () => {
+    const cues = await buildCuesForElement('#fdg8e9v4');
+    expect(cues).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "level": 1,
+          "penalty": 10,
+          "type": "attribute",
+          "value": "[name*=\\"-blue-\\"]",
+        },
+        Object {
+          "level": 1,
+          "penalty": 40,
+          "type": "tag",
+          "value": "input:nth-of-type(7)",
         },
       ]
     `);

--- a/test/web/isDynamic.test.ts
+++ b/test/web/isDynamic.test.ts
@@ -1,4 +1,4 @@
-import { getTokens, isDynamic } from '../../src/web/isDynamic';
+import { getValueMatches, getTokens, isDynamic } from '../../src/web/isDynamic';
 
 describe('getTokens', () => {
   it('splits space, dash, underscore, colon', () => {
@@ -78,5 +78,94 @@ describe('isDynamic', () => {
     'tnt__zipInput',
   ])('is not dynamic: %s', (example) => {
     expect(isDynamic(example)).toBe(false);
+  });
+});
+
+describe('getValueMatches', () => {
+  test('all dynamic', () => {
+    const matches = getValueMatches('bj84jd9');
+    expect(matches.length).toBe(0);
+  });
+
+  test('all static', () => {
+    const matches = getValueMatches('firstName');
+    expect(matches).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "match": "firstName",
+          "operator": "=",
+          "startPosition": 0,
+          "type": "equals",
+        },
+      ]
+    `);
+  });
+
+  test('starts with static', () => {
+    const matches = getValueMatches('input-bj84jd9');
+    expect(matches).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "match": "input-",
+          "operator": "^=",
+          "startPosition": 0,
+          "type": "startsWith",
+        },
+      ]
+    `);
+  });
+
+  test('ends with static', () => {
+    const matches = getValueMatches('bj84jd9-input');
+    expect(matches).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "match": "-input",
+          "operator": "$=",
+          "startPosition": 7,
+          "type": "endsWith",
+        },
+      ]
+    `);
+  });
+
+  test('contains static', () => {
+    const matches = getValueMatches('25-input-bj84jd9');
+    expect(matches).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "match": "-input-",
+          "operator": "*=",
+          "startPosition": 2,
+          "type": "contains",
+        },
+      ]
+    `);
+  });
+
+  test('multiple matches', () => {
+    const matches = getValueMatches('input-25-red-bj84jd9-lastName');
+    expect(matches).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "match": "input-",
+          "operator": "^=",
+          "startPosition": 0,
+          "type": "startsWith",
+        },
+        Object {
+          "match": "-red-",
+          "operator": "*=",
+          "startPosition": 8,
+          "type": "contains",
+        },
+        Object {
+          "match": "-lastName",
+          "operator": "$=",
+          "startPosition": 20,
+          "type": "endsWith",
+        },
+      ]
+    `);
   });
 });

--- a/test/web/isDynamic.test.ts
+++ b/test/web/isDynamic.test.ts
@@ -144,7 +144,7 @@ describe('getValueMatches', () => {
   });
 
   test('multiple matches', () => {
-    const matches = getValueMatches('input-25-red-bj84jd9-lastName');
+    const matches = getValueMatches('input-25-red-bj84jd9-_-lastName');
     expect(matches).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/test/web/isDynamic.test.ts
+++ b/test/web/isDynamic.test.ts
@@ -144,7 +144,7 @@ describe('getValueMatches', () => {
   });
 
   test('multiple matches', () => {
-    const matches = getValueMatches('input-25-red-bj84jd9-_-lastName');
+    const matches = getValueMatches('input-25-red--bj84jd9-_-lastName');
     expect(matches).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -154,15 +154,15 @@ describe('getValueMatches', () => {
           "type": "startsWith",
         },
         Object {
-          "match": "-red-",
+          "match": "-red--",
           "operator": "*=",
           "startPosition": 8,
           "type": "contains",
         },
         Object {
-          "match": "-lastName",
+          "match": "-_-lastName",
           "operator": "$=",
-          "startPosition": 20,
+          "startPosition": 21,
           "type": "endsWith",
         },
       ]


### PR DESCRIPTION
Resolves #829 

When building cues for an element, attributes that have a value that is either an empty string or appears to be dynamic (machine-generated) are now not used as cues. There are two exceptions: `href` and `src` which would frequently have dynamic values as part of the URL. Other attributes can be made exempt if you can think of reasons, or we could try to make `isDynamic` smarter.

Note that currently a half-dynamic value such as `input-d8sdgjk3` will be used. This is up for debate.

**Update**

Above is the original description, but here's how this actually works at the point of merging it.

- I left `isDynamic` pretty much the same
- But instead of running attribute values through `isDynamic`, I created a new function `getValueMatches` that attempts to find all the static portions of the value string that we can match on
- And then it will use the appropriate CSS selector operator based on what it finds (starts with, ends with, contains, or equals)
- And it still skips this for all `DYNAMIC_VALUE_OK` attributes, and now also for all preferred attributes.
- Also, rather than trying to specifically list HTML tags in the `words` list, I added the `html-tags` package and merged in the array provided by that package, which fixed some existing tests that were otherwise failing

So for example you now get selectors like this:

```js
await page.click('[name="nonDynamicInput"]'); // name="nonDynamicInput"
await page.click('[name^="input-"]'); // name="input-bu32879fDi"
await page.click('[name$="-check"]'); // name="bu32879fDi-check"
await page.click('[name*="-blue-"]'); // name="f89ndrn4-blue-5"
```