### PR TITLE
Refactor buildSelector to be speedier

### DIFF
--- a/src/web/cues.ts
+++ b/src/web/cues.ts
@@ -12,7 +12,7 @@ export type Cue = {
 };
 
 export type BuildCues = {
-  attributes: string[];
+  cueTypesConfig: CueTypesConfig;
   isClick: boolean;
   target: HTMLElement;
 };
@@ -275,12 +275,10 @@ export const buildCuesForElement = ({
 };
 
 export const buildCues = ({
-  attributes,
+  cueTypesConfig,
   isClick,
   target,
 }: BuildCues): Cue[] => {
-  const cueTypesConfig = getCueTypesConfig(attributes);
-
   const cues: Cue[] = [];
   let element: HTMLElement = target;
   let level = 0;

--- a/src/web/optimizeCues.ts
+++ b/src/web/optimizeCues.ts
@@ -28,6 +28,10 @@ type CueLevel = {
   text: Cue[];
 };
 
+const TRIM_EXCESS_CUES_GOAL_SIZE = 8;
+const CUE_GROUP_CUES_MAX_SIZE = 10;
+const FINAL_CUE_GROUP_MAX_SIZE = 3;
+
 /**
  * Build the cue sets.
  * There are multiple since each level of cues
@@ -258,14 +262,13 @@ export const findOptimalCueGroups = (input: FindOptimalCueGroupsInput): void => 
 
     const cueSet = cueSets[index];
 
-    // Trim down the cue group to 10 if possible
-    // 10 cues, samples of 5 is ~700 combinations which took ~20ms on my machine
-    const cueGroup = trimExcessCues(cueSet, target, 5);
+    // Trim down the cue group before exhaustively trying the combinations
+    const cueGroup = trimExcessCues(cueSet, target, TRIM_EXCESS_CUES_GOAL_SIZE);
 
-    // Skip if we cannot trim the group to <= 16 cues (this should rarely happen)
-    // 16 cues, samples of 5 is ~7000 combinations which took ~100ms on my machine
-    if (cueGroup && cueGroup.cues.length <= 16) {
-      onFound(findBestCueGroup(cueGroup, 3, targetGroup));
+    // Skip if we cannot trim the group (this should rarely happen)
+    // Then exhaustively try all combinations
+    if (cueGroup && cueGroup.cues.length <= CUE_GROUP_CUES_MAX_SIZE) {
+      onFound(findBestCueGroup(cueGroup, FINAL_CUE_GROUP_MAX_SIZE, targetGroup));
     }
   }
 };

--- a/src/web/optimizeCues.ts
+++ b/src/web/optimizeCues.ts
@@ -4,7 +4,7 @@ import {
   getPenalty,
   getValueLength,
 } from './cues';
-import { buildSelectorParts, isMatch } from './selectorEngine';
+import { buildSelectorParts, getElementMatchingSelectorParts, isMatch } from './selectorEngine';
 import { SelectorPart } from './types';
 
 export type CueGroup = {
@@ -220,7 +220,8 @@ export const findBestCueGroup = (
 
       // If these selector parts match any element that we are targeting,
       // then it's currently the best group.
-      if (targetGroup.some((target) => isMatch({ selectorParts, target }))) {
+      const matchedElement = getElementMatchingSelectorParts(selectorParts, targetGroup[0].ownerDocument);
+      if (targetGroup.includes(matchedElement)) {
         bestGroup = {
           cues,
           penalty,

--- a/src/web/selector.ts
+++ b/src/web/selector.ts
@@ -1,17 +1,34 @@
 import {
   buildCues,
-  BuildCues,
+  buildCuesForElement,
+  Cue,
+  getCueTypesConfig,
 } from './cues';
 import { getClickableGroup } from './element';
-import { buildCueSets, CueGroup, optimizeCues, pickBestCueGroup } from './optimizeCues';
+import {
+  CueGroup,
+  findOptimalCueGroups,
+  pickBestCueGroup,
+} from './optimizeCues';
 import { getXpath } from './serialize';
 import { getElementMatchingSelectorParts, isMatch } from './selectorEngine';
 import { SelectorPart } from './types';
+
+type BuildSelectorOptions = {
+  attributes: string[];
+  isClick: boolean;
+  target: HTMLElement;
+};
 
 type CachedSelectorInfo = {
   matchedTarget: HTMLElement;
   selector: string;
   selectorParts: SelectorPart[];
+};
+
+type CuesForLevel = {
+  cues: Cue[],
+  level: number;
 };
 
 const selectorCache = new Map<HTMLElement, CachedSelectorInfo>();
@@ -37,8 +54,8 @@ export const toSelector = (selectorParts: SelectorPart[]): string => {
   return selectorParts.map(({ body, name }) => `${name}=${body}`).join(' >> ');
 };
 
-export const buildSelector = (options: BuildCues): string => {
-  const { isClick, target } = options;
+export const buildSelector = (options: BuildSelectorOptions): string => {
+  const { attributes, isClick, target } = options;
 
   // To save looping, see if we have already figured out a unique
   // selector for this target.
@@ -60,27 +77,77 @@ export const buildSelector = (options: BuildCues): string => {
     }
   }
 
-  let targetGroup: HTMLElement[];
+  const cuesByTarget = new Map<HTMLElement, CuesForLevel>();
+  const cueTypesConfig = getCueTypesConfig(attributes);
+
+  let targetGroup: HTMLElement[] = [];
   if (isClick) {
-    targetGroup = getClickableGroup(target);
-    if (targetGroup.length === 0) targetGroup = [target];
-  } else {
+    // For a click, we consider the entire potential block of elements that we can
+    // reasonably assume would call the same click handler when clicked.
+    targetGroup = getClickableGroup(target, (element: HTMLElement, depth: number) => {
+      let elementCues: Cue[];
+
+      // For the level, we temporarily use negatives, which we'll fix later
+      const level = 0 - depth;
+
+      if (depth === 0) {
+        // For the topmost element in the group, we build cues
+        // for every ancestor element to the document root.
+        elementCues = buildCues({ cueTypesConfig, isClick, target: element });
+      } else {
+        // For lower elements, start with the parent cues and then
+        // add cues for this element to the beginning of the list
+        const { cues: parentCues } = cuesByTarget.get(element.parentElement) || {};
+        elementCues = [...buildCuesForElement({ cueTypesConfig, element, isClick, level }), ...parentCues];
+      }
+
+      cuesByTarget.set(element, { cues: elementCues, level });
+    });
+  }
+
+  // getClickableGroup may have returned an empty array or it may not have been a click.
+  // In either case, fall back to building a selector using only cues from the event target.
+  if (targetGroup.length === 0) {
     targetGroup = [target];
+    const targetCues = buildCues({ cueTypesConfig, isClick, target });
+    cuesByTarget.set(target, { cues: targetCues, level: 0 });
   }
 
   const cueGroups: CueGroup[] = [];
 
   targetGroup.forEach((targetElement) => {
-    const cues = buildCues({ ...options, target: targetElement });
-    const cueSets = buildCueSets(cues);
-    cueGroups.push(
-      ...optimizeCues(cueSets, targetElement, targetGroup)
-    );
+    const { cues, level } = cuesByTarget.get(targetElement);
+
+    // First, if we have negative levels due to there being a target group,
+    // fix them all to be zero-based.
+    let rebasedCues: Cue[];
+    if (level < 0) {
+      rebasedCues = cues.map((cue) => ({
+        ...cue,
+        level: cue.level + (0 - level),
+      }));
+    } else {
+      rebasedCues = cues;
+    }
+
+    // Examine the cues in the context of this potential target element, trying to
+    // find any acceptable cue groups.
+    findOptimalCueGroups({
+      cues: rebasedCues,
+      // This is called once for each acceptable cue group, which we then add to our
+      // list of potential "best groups"
+      onFound(cueGroup: CueGroup) {
+        cueGroups.push(cueGroup);
+      },
+      target: targetElement,
+      targetGroup,
+    });
   });
 
+  // Now pick the one best of the best possible cue groups and build a selector from it
   const { selectorParts } = pickBestCueGroup(cueGroups) || {};
   if (selectorParts) {
-    // Now convert selectorParts (a Playwright thing) to a string selector
+    // Convert selectorParts (a Playwright thing) to a string selector
     selector = toSelector(selectorParts);
 
     // This selector should match one of the elements in `targetGroup`, but it

--- a/src/web/selectorEngine.ts
+++ b/src/web/selectorEngine.ts
@@ -60,3 +60,7 @@ export const isMatch = ({ selectorParts, target }: IsMatch): boolean => {
 
   return result === target;
 };
+
+export const getElementMatchingSelectorParts = (selectorParts: SelectorPart[], root: Node): HTMLElement => {
+  return querySelector({ parts: selectorParts }, root);
+};

--- a/test/web/cues.test.ts
+++ b/test/web/cues.test.ts
@@ -25,9 +25,10 @@ describe('buildCues', () => {
       ({ attributes, selector }) => {
         const qawolf: QAWolfWeb = (window as any).qawolf;
         const target = document.querySelector(selector) as HTMLElement;
+        const cueTypesConfig = qawolf.getCueTypesConfig(attributes);
 
         return qawolf.buildCues({
-          attributes,
+          cueTypesConfig,
           isClick: true,
           target,
         });


### PR DESCRIPTION
## Performance Changes
- Fixes an issue that prevented cached selectors from being used when the chosen selector is a part of a click group and not the original target.
    - On a click, this roughly cuts in half the amount of time it takes to add the click step because the `click` event can reuse the selector built for the nearly simultaneous `mousedown`
- Reduces the number of loops and consolidates some handling for `buildCues` and `optimizeCues`
    - One big help was: in `findBestCueGroup`, now uses `getElementMatchingSelectorParts` and `targetGroup.includes` rather than running `isMatch` multiple times.
    - On a click, this roughly reduces the amount of time it takes to add the click step by a factor equal to the number of elements in the click group. For example, a click group that has 4 elements and previously took 4 seconds might now take 1 second.

## Notes
Of the remaining time, most is spent in the `createTextSelector` function (getting element text). We will look at improving that in the future if necessary.

## Testing
Verify that clicks on click groups don't hang or hang for much less time, but that otherwise nothing about the generated code has changed.