### PR TITLE
remove stale code

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -26,9 +26,4 @@ program.allowUnknownOption(false);
 
 export const runCli = (): void => {
   program.parse(process.argv);
-
-  if (!process.argv.slice(2).length) {
-    console.log('\n');
-    program.outputHelp();
-  }
 };


### PR DESCRIPTION
From [v5.0.0](https://github.com/tj/commander.js/releases/tag/v5.0.0), Commander.js displays an error message for a missing subcommand by default.