### PR TITLE
docs: update install.mdx

### DIFF
--- a/docs/docs/install.mdx
+++ b/docs/docs/install.mdx
@@ -23,7 +23,7 @@ In this guide we explain how to set up your environment and get started with QA 
 
 ## Understand the command line
 
-QA Wolf uses the command line interface (CLI) to create and run browser tests. Before moving on, make sure you:
+QA Wolf uses a command line interface (CLI) to create and run browser tests. Before moving on, make sure you:
 
 - have a [basic understanding of the command line](https://guide.freecodecamp.org/linux/the-command-prompt)
 - have found and opened up the CLI for your computer (instructions for [Mac](https://www.idownloadblog.com/2019/04/19/ways-open-terminal-mac/), [Windows](https://www.lifewire.com/how-to-open-command-prompt-2618089), and [Linux](https://www.howtogeek.com/140679/beginner-geek-how-to-start-using-the-linux-terminal/))


### PR DESCRIPTION
- "the" CLI doesn't make sense, as we don't specify _which_ CLI is it. Is it the QA Wolf CLI? Your system's CLI e.g bash or zsh? 
- Using "a" CLI, it's clear what we mean: the QA Wolf CLI
- On line 29 however, it makes perfect sense as we specify _which._