### PR TITLE
Do not mark test as pending if it already assigned

### DIFF
--- a/app/server/models/runner.ts
+++ b/app/server/models/runner.ts
@@ -234,10 +234,23 @@ export const findRunner = async (
   if (!include_deleted) filter.deleted_at = null;
 
   if (id) filter.id = id;
-  if (run_id !== undefined) filter.run_id = run_id;
-  else if (test_id !== undefined) filter.test_id = test_id;
 
-  let query = (trx || db)("runners").select("*").from("runners").where(filter);
+  let query = (trx || db)("runners").select("*").from("runners");
+
+  if (run_id && test_id) {
+    // allow either
+    query = query
+      .where(function () {
+        this.where({ run_id }).orWhere({ test_id });
+      })
+      // prefer the run's runner
+      .orderBy("run_id", "asc");
+  } else {
+    if (run_id !== undefined) filter.run_id = run_id;
+    if (test_id !== undefined) filter.test_id = test_id;
+  }
+
+  query = query.where(filter);
 
   if (is_ready) query = query.whereNotNull("ready_at");
 

--- a/app/server/models/runner.ts
+++ b/app/server/models/runner.ts
@@ -4,7 +4,7 @@ import { rankLocations } from "../services/location";
 import { ModelOptions, Runner, Test } from "../types";
 import { cuid, minutesFromNow } from "../utils";
 import { findPendingRun, findRun, updateRun } from "./run";
-import { findPendingTest, updateTest } from "./test";
+import { findPendingTest, updateTest, updateTestToPending } from "./test";
 
 type AssignRunner = {
   runner: Runner;
@@ -310,13 +310,8 @@ export const requestRunnerForTest = async (
   }
 
   if (!test.runner_requested_at) {
-    // mark the test as pending a runner
-    await updateTest(
-      {
-        id: test.id,
-        runner_locations: locations.slice(0, 2),
-        runner_requested_at: minutesFromNow(),
-      },
+    await updateTestToPending(
+      { id: test.id, runner_locations: locations },
       options
     );
   }

--- a/app/server/resolvers/runner.ts
+++ b/app/server/resolvers/runner.ts
@@ -74,19 +74,12 @@ export const runnerResolver = async (
     const test = await findTest(testId, { logger, trx });
     await ensureTestAccess({ logger, teams, test });
 
-    let runner: Runner;
+    let runner = await findRunner(
+      { run_id: run_id, test_id: testId },
+      { logger, trx }
+    );
 
-    // find the runner for the run
-    if (run) {
-      runner = await findRunner({ run_id: run.id }, { logger, trx });
-    }
-
-    // otherwise find the runner for the test
-    if (!runner) {
-      runner = await findRunner({ test_id: test.id }, { logger, trx });
-    }
-
-    // fallback to requesting a runner for the test
+    // if there is no runner, request one for the test
     if (!runner && should_request_runner) {
       runner = await requestRunnerForTest({ ip, test }, { logger, trx });
     }

--- a/app/server/resolvers/runner.ts
+++ b/app/server/resolvers/runner.ts
@@ -14,7 +14,6 @@ import {
 import { findTest } from "../models/test";
 import {
   Context,
-  Runner,
   RunnerResult,
   RunnerRun,
   UpdateRunnerMutation,

--- a/app/test/server/models/runner.test.ts
+++ b/app/test/server/models/runner.test.ts
@@ -208,13 +208,27 @@ describe("findRunner", () => {
   });
 
   it("finds a runner by run_id", async () => {
-    const runner = await findRunner({ run_id: "runId" }, options);
-    expect(runner.id).toEqual("runnerId");
+    const result = await findRunner({ run_id: "runId" }, options);
+    expect(result.id).toEqual("runnerId");
+
+    // check it prefers the runner for the run if the test id is also specified
+    const result2 = await findRunner(
+      { run_id: "runId", test_id: "testId" },
+      options
+    );
+    expect(result2.id).toEqual("runnerId");
   });
 
   it("finds a runner by test_id", async () => {
-    const runner = await findRunner({ test_id: "testId" }, options);
-    expect(runner.id).toEqual("runner2Id");
+    const result = await findRunner({ test_id: "testId" }, options);
+    expect(result.id).toEqual("runner2Id");
+
+    // check it finds the runner if the run id is also specified
+    const result2 = await findRunner(
+      { run_id: "fakeRunId", test_id: "testId" },
+      options
+    );
+    expect(result2.id).toEqual("runner2Id");
   });
 
   it("finds a runner in the closest location possible", async () => {

--- a/app/test/server/models/runner.test.ts
+++ b/app/test/server/models/runner.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../server/models/runner";
 import * as runnerModel from "../../../server/models/runner";
 import * as testModel from "../../../server/models/test";
-import { findTest, updateTest } from "../../../server/models/test";
+import { findTest, updateTestToPending } from "../../../server/models/test";
 import * as locationService from "../../../server/services/location";
 import { Runner } from "../../../server/types";
 import { minutesFromNow } from "../../../server/utils";
@@ -63,8 +63,8 @@ describe("assignRunner", () => {
   });
 
   it("assigns a test to the runner", async () => {
-    await updateTest(
-      { id: "testId", runner_requested_at: minutesFromNow() },
+    await updateTestToPending(
+      { id: "testId", runner_locations: ["westus2"] },
       { logger }
     );
     await assignRunner({ runner, test_id: "testId" }, { logger });
@@ -384,7 +384,7 @@ describe("requestRunnerForTest", () => {
     jest.spyOn(runnerModel, "findRunner").mockResolvedValue(null);
 
     const assignRunner = jest.spyOn(runnerModel, "assignRunner").mockReset();
-    const updateTest = jest.spyOn(testModel, "updateTest");
+    const updateTestToPending = jest.spyOn(testModel, "updateTestToPending");
 
     const result = await requestRunnerForTest(
       { ip: "", test: buildTest({}) },
@@ -394,11 +394,10 @@ describe("requestRunnerForTest", () => {
 
     expect(assignRunner).not.toBeCalled();
 
-    expect(updateTest).toBeCalledWith(
+    expect(updateTestToPending).toBeCalledWith(
       {
         id: "testId",
-        runner_locations: ["eastus2", "westus2"],
-        runner_requested_at: expect.any(String),
+        runner_locations: ["eastus2", "westus2", "centralindia"],
       },
       options
     );


### PR DESCRIPTION
- merge findRunner into one query to reduce db queries
- do not mark runner_requested_at when there is a runner assigned (this can happen during a concurrent assignment)

Relates to #912