### PR TITLE
only reconnect browser on disconnect

### DIFF
--- a/app/components/Editor/Placeholder.tsx
+++ b/app/components/Editor/Placeholder.tsx
@@ -2,7 +2,6 @@ import { Box } from "grommet";
 import { Play } from "grommet-icons";
 import { ReactNode, useContext } from "react";
 
-import { state } from "../../lib/state";
 import { copy } from "../../theme/copy";
 import Paw from "../shared/icons/Paw";
 import Wolf from "../shared/icons/Wolf";
@@ -27,7 +26,7 @@ export default function Placeholder({
 }: Props): JSX.Element {
   const { isTestLoading, run } = useContext(TestContext);
   const { isUserLoading, user, wolf } = useContext(UserContext);
-  const { isRunnerConnected } = useContext(RunnerContext);
+  const { isRunnerConnected, shouldRequestRunner } = useContext(RunnerContext);
 
   // default to loading
   let message = copy.loading;
@@ -53,8 +52,8 @@ export default function Placeholder({
   else if (
     mode === "test" &&
     !isRunnerConnected &&
-    !state.pendingRun &&
-    !isTestLoading
+    !isTestLoading &&
+    !shouldRequestRunner
   ) {
     iconHtml = <Play {...iconProps} />;
     message = copy.placeholderRunTest;

--- a/app/components/Editor/Screencast.tsx
+++ b/app/components/Editor/Screencast.tsx
@@ -21,11 +21,11 @@ export default function Screencast({
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!browser || !containerRef.current || !wsUrl) return;
+    if (!browser || !containerRef.current) return;
 
     browser.connect(
       containerRef.current,
-      `${wsUrl}/websockify`,
+      wsUrl ? `${wsUrl}/websockify` : null,
       apiKey || "local"
     );
   }, [apiKey, browser, containerRef, wsUrl]);

--- a/app/components/Editor/contexts/RunnerContext.tsx
+++ b/app/components/Editor/contexts/RunnerContext.tsx
@@ -22,6 +22,7 @@ type RunnerContext = ConnectRunnerHook &
     isCreateTestLoading: boolean;
     progress: RunProgress | null;
     runTest: RunTest["runTest"];
+    shouldRequestRunner: boolean;
   };
 
 export const RunnerContext = createContext<RunnerContext>({
@@ -36,6 +37,7 @@ export const RunnerContext = createContext<RunnerContext>({
   runner: null,
   runTest: () => null,
   selection: null,
+  shouldRequestRunner: false,
   wsUrl: null,
 });
 
@@ -51,14 +53,14 @@ export const RunnerProvider: FC = ({ children }) => {
 
   const [createTest, { loading: isCreateTestLoading }] = useCreateTest();
 
-  const { isIdle, runTest } = useRunTest({
+  const { shouldRequestRunner, runTest } = useRunTest({
     env,
     resetProgress,
     runner,
   });
 
   const { apiKey, wsUrl } = useConnectRunner({
-    isIdle,
+    shouldRequestRunner,
     isRunnerConnected,
     runner,
   });
@@ -90,6 +92,7 @@ export const RunnerProvider: FC = ({ children }) => {
     runner,
     runTest,
     selection,
+    shouldRequestRunner,
     wsUrl,
   };
 

--- a/app/components/Editor/hooks/connectRunner.ts
+++ b/app/components/Editor/hooks/connectRunner.ts
@@ -11,15 +11,15 @@ export type ConnectRunnerHook = {
 };
 
 type UseConnectRunner = {
-  isIdle: boolean;
   isRunnerConnected: boolean;
   runner: RunnerClient | null;
+  shouldRequestRunner: boolean;
 };
 
 export const useConnectRunner = ({
-  isIdle,
   isRunnerConnected,
   runner: runnerClient,
+  shouldRequestRunner,
 }: UseConnectRunner): ConnectRunnerHook => {
   const { query } = useRouter();
 
@@ -32,7 +32,7 @@ export const useConnectRunner = ({
   const { data: runnerResult, loading, startPolling, stopPolling } = useRunner(
     {
       run_id,
-      should_request_runner: !isIdle,
+      should_request_runner: shouldRequestRunner,
       test_id,
     },
     {
@@ -62,8 +62,10 @@ export const useConnectRunner = ({
 
   // connect the runner to the ws url
   useEffect(() => {
+    if (loading) return;
+
     runnerClient?.connect({ apiKey, wsUrl });
-  }, [apiKey, runnerClient, wsUrl]);
+  }, [apiKey, loading, runnerClient, wsUrl]);
 
   return { apiKey, wsUrl };
 };

--- a/app/components/Editor/hooks/runTest.ts
+++ b/app/components/Editor/hooks/runTest.ts
@@ -16,8 +16,8 @@ type RunTestOptions = {
 };
 
 export type RunTest = {
-  isIdle: boolean;
   runTest: (options: RunTestOptions) => void;
+  shouldRequestRunner: boolean;
 };
 
 type UseRunTest = {
@@ -31,15 +31,15 @@ export const useRunTest = ({
   resetProgress,
   runner,
 }: UseRunTest): RunTest => {
-  const [isIdle, setIsIdle] = useState(!state.pendingRun);
+  const [shouldRequestRunner, setShouldRequestRunner] = useState(
+    !state.pendingRun
+  );
   const [ranAt, setRanAt] = useState<Date | null>(null);
 
   useEffect(() => {
     const interval = runAndSetInterval(() => {
-      const isActive =
-        !!state.pendingRun || ranAt >= new Date(minutesFromNow(-1));
-
-      setIsIdle(!isActive);
+      const value = !!state.pendingRun || ranAt >= new Date(minutesFromNow(-1));
+      setShouldRequestRunner(value);
     }, 10 * 1000);
 
     return () => clearInterval(interval);
@@ -74,5 +74,5 @@ export const useRunTest = ({
     runner.run(options);
   };
 
-  return { isIdle, runTest };
+  return { runTest, shouldRequestRunner };
 };

--- a/app/lib/runner.ts
+++ b/app/lib/runner.ts
@@ -66,6 +66,7 @@ export class RunnerClient extends EventEmitter {
       this._socket.removeAllListeners();
       this._socket.close();
       this._socket = null;
+      this.emit("disconnect");
     }
 
     if (!wsUrl) return;


### PR DESCRIPTION
Relates to #912

Fixes an issue if it takes longer to connect then the reconnect cycle allows

- remove framebufferupdate patch, we probably cannot trust this so just rely on connected as our ready signal
- rename isIdle to shouldRequestRunner for consistency
- disconnect runner client when the runner is null