### PR TITLE
feat: (experiment) embed code line chapters in video files

### DIFF
--- a/.github/workflows/test_runner.yml
+++ b/.github/workflows/test_runner.yml
@@ -34,6 +34,10 @@ jobs:
         run: npm install @ffmpeg-installer/ffmpeg
         working-directory: ./runner
 
+      - name: Install ffprobe
+        run: npm install @ffprobe-installer/ffprobe
+        working-directory: ./runner
+
       - name: Build and copy recorder script
         run: npm run build:recorder-script
         working-directory: ./runner
@@ -50,5 +54,6 @@ jobs:
       - name: Test runner
         run: |
           export FFMPEG_PATH=$(node -e "console.log(require('@ffmpeg-installer/ffmpeg').path)")
+          export FFPROBE_PATH=$(node -e "console.log(require('@ffprobe-installer/ffprobe').path)")
           DEBUG=spirit* npm run test
         working-directory: ./runner

--- a/runner/src/config.ts
+++ b/runner/src/config.ts
@@ -17,6 +17,7 @@ const config = {
   DISPLAY_HEIGHT: process.env.QAWOLF_DISPLAY_HEIGHT || 804,
   // 1280 viewport + 8 scrollbar
   DISPLAY_WIDTH: process.env.QAWOLF_DISPLAY_WIDTH || 1288,
+  FFPROBE_PATH: process.env.FFMPEG_PATH || "/usr/bin/ffprobe",
   FFMPEG_PATH: process.env.FFMPEG_PATH || "/usr/bin/ffmpeg",
   GROUP_ID: process.env.QAWOLF_GROUP_ID,
   INTERNAL_SERVER_PORT: 26368,

--- a/runner/src/config.ts
+++ b/runner/src/config.ts
@@ -17,7 +17,7 @@ const config = {
   DISPLAY_HEIGHT: process.env.QAWOLF_DISPLAY_HEIGHT || 804,
   // 1280 viewport + 8 scrollbar
   DISPLAY_WIDTH: process.env.QAWOLF_DISPLAY_WIDTH || 1288,
-  FFPROBE_PATH: process.env.FFMPEG_PATH || "/usr/bin/ffprobe",
+  FFPROBE_PATH: process.env.FFPROBE_PATH || "/usr/bin/ffprobe",
   FFMPEG_PATH: process.env.FFMPEG_PATH || "/usr/bin/ffmpeg",
   GROUP_ID: process.env.QAWOLF_GROUP_ID,
   INTERNAL_SERVER_PORT: 26368,

--- a/runner/src/environment/Run.ts
+++ b/runner/src/environment/Run.ts
@@ -63,6 +63,12 @@ export class Run extends EventEmitter {
     try {
       await Promise.all(hooks.map((hook) => hook.before && hook.before()));
 
+      this.on("runprogress", async () => {
+        await Promise.all(
+          hooks.map((hook) => hook.progress && hook.progress(this.progress))
+        );
+      });
+
       this._emitProgress();
 
       if (this._runOptions.env) this._vm.setEnv(this._runOptions.env);

--- a/runner/src/runner/Runner.ts
+++ b/runner/src/runner/Runner.ts
@@ -81,6 +81,7 @@ export class Runner extends EventEmitter {
       this._environment = await this._createEnvironment();
       // create hooks for fresh runs
       hooks = createHooks(options, this._environment);
+      this._hooks = hooks;
     }
 
     return this._environment.run(options, hooks);

--- a/runner/src/runner/VideoArtifactsHook.ts
+++ b/runner/src/runner/VideoArtifactsHook.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Debug from "debug";
-import { RunHook, RunProgress } from "../types";
 import { intersection, noop } from "lodash";
 
 import { uploadFile } from "../services/aws";
 import { VideoCapture } from "../services/VideoCapture";
+import { RunHook, RunProgress } from "../types";
 import { Artifacts } from "../types";
 
 const debug = Debug("qawolf:VideoArtifactsHook");

--- a/runner/src/services/VideoCapture.ts
+++ b/runner/src/services/VideoCapture.ts
@@ -21,7 +21,7 @@ export class VideoCapture {
   _rejectStopped?: (reason: string) => void;
   _resolveStarted?: () => void;
   _resolveStopped?: () => void;
-  _startedAt: number = 0;
+  _startedAt = 0;
   _startedPromise: Promise<void>;
   _stopped = false;
   _stoppedPromise: Promise<void>;
@@ -81,7 +81,7 @@ export class VideoCapture {
     return this._gifPath;
   }
 
-  markChapter(lineNum: number, lineCode: string) {
+  markChapter(lineNum: number, lineCode: string): void {
     // Setting by index rather than .push in case this is called
     // multiple times for the same line number, which it seems to be.
     this._chapters[lineNum] = {
@@ -102,9 +102,10 @@ export class VideoCapture {
       showFormat: true,
     });
 
-    const videoLengthMS = videoMetadata.format.duration * 1000;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const videoLengthMS = videoMetadata.format!.duration * 1000;
 
-    let metadata = `;FFMETADATA1
+    const metadata = `;FFMETADATA1
 title=Test Run
 artist=QA Wolf, Inc.
 ${this._chapters.reduce(

--- a/runner/src/services/api.ts
+++ b/runner/src/services/api.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import Debug from "debug";
 
 import config from "../config";
-import { Run, Suite } from "../types";
+import { Run } from "../types";
 
 type GraphQLRequestData = {
   query: string;

--- a/runner/src/services/ffprobe.ts
+++ b/runner/src/services/ffprobe.ts
@@ -1,0 +1,34 @@
+import { execFile as execFileWithCallback } from "child_process";
+import util from "util";
+
+import config from "../config";
+
+const execFile = util.promisify(execFileWithCallback);
+
+export type ProbeVideoFileOptions = {
+  showChapters?: boolean;
+  showFormat?: boolean;
+};
+
+export const probeVideoFile = async (
+  videoPath: string,
+  options: ProbeVideoFileOptions = {}
+) => {
+  const args = [];
+
+  if (options.showChapters === true) {
+    args.push("-show_chapters");
+  }
+  if (options.showFormat === true) {
+    args.push("-show_format");
+  }
+
+  const { stdout } = await execFile(config.FFPROBE_PATH, [
+    ...args,
+    "-print_format",
+    "json",
+    videoPath,
+  ]);
+
+  return JSON.parse(stdout);
+};

--- a/runner/src/services/ffprobe.ts
+++ b/runner/src/services/ffprobe.ts
@@ -2,6 +2,7 @@ import { execFile as execFileWithCallback } from "child_process";
 import util from "util";
 
 import config from "../config";
+import { VideoMetadata } from "../types";
 
 const execFile = util.promisify(execFileWithCallback);
 
@@ -13,7 +14,7 @@ export type ProbeVideoFileOptions = {
 export const probeVideoFile = async (
   videoPath: string,
   options: ProbeVideoFileOptions = {}
-) => {
+): Promise<VideoMetadata> => {
   const args = [];
 
   if (options.showChapters === true) {

--- a/runner/src/types.ts
+++ b/runner/src/types.ts
@@ -66,6 +66,25 @@ export type VideoChapter = {
   start: number;
 };
 
+export type VideoMetadataChapter = {
+  end: number;
+  end_time: string;
+  id: number;
+  start: number;
+  start_time: string;
+  tags: Record<string, string>;
+  time_base: string;
+};
+
+export type VideoMetadataFormat = {
+  duration: number;
+};
+
+export type VideoMetadata = {
+  chapters?: VideoMetadataChapter[];
+  format?: VideoMetadataFormat;
+};
+
 export type BrowserName = "chromium" | "firefox" | "webkit";
 
 export type Callback<S = void, T = void> = (data?: S) => T;

--- a/runner/src/types.ts
+++ b/runner/src/types.ts
@@ -38,6 +38,7 @@ export type RunOptions = {
 
 export type RunHook = {
   after?(result: RunProgress): Promise<void>;
+  progress?(progress: RunProgress): Promise<void>;
   before?(): Promise<void>;
 };
 
@@ -57,6 +58,12 @@ export type RunProgress = {
 export type Suite = {
   env?: Record<string, string>;
   runs: Run[];
+};
+
+export type VideoChapter = {
+  lineCode: string;
+  lineNum: number;
+  start: number;
 };
 
 export type BrowserName = "chromium" | "firefox" | "webkit";

--- a/runner/test/runner/Runner.test.ts
+++ b/runner/test/runner/Runner.test.ts
@@ -1,3 +1,6 @@
+// Xvfb :0 -screen 0 1288x804x24 -listen tcp &
+// DEBUG=qawolf* npm run test Runner.test.ts
+import { probeVideoFile } from "../../src/services/ffprobe";
 import { Environment } from "../../src/environment/Environment";
 import { LogArtifactHook } from "../../src/runner/LogArtifactHook";
 import { createHooks, Runner } from "../../src/runner/Runner";
@@ -91,5 +94,69 @@ describe("Runner", () => {
     });
 
     expect(initialEnvironment === runner._environment).toBe(false);
+  });
+
+  it("saves a video of the run with step chapter metadata", async () => {
+    const multiLineCode = `console.log("Line 1");
+console.log("Line 2");`;
+
+    await runner.run({
+      artifacts: {
+        gifUrl: "local-only",
+        logsUrl: "logsUrl",
+        videoUrl: "local-only",
+      },
+      code: multiLineCode,
+      helpers: "",
+      restart: true,
+      test_id: "",
+      version: 1,
+    });
+
+    const videoHook = runner._hooks[1] as VideoArtifactsHook;
+
+    await videoHook.waitForUpload();
+    const videoMetadata = await probeVideoFile(
+      videoHook._videoCapture.videoWithMetadataPath,
+      {
+        showChapters: true,
+      }
+    );
+
+    expect(videoMetadata).toEqual({
+      chapters: [
+        {
+          end: expect.any(Number),
+          end_time: expect.any(String),
+          id: 0,
+          start: expect.any(Number),
+          start_time: expect.any(String),
+          tags: {
+            title: 'console.log("Line 1");',
+          },
+          time_base: "1/1000",
+        },
+        {
+          end: expect.any(Number),
+          end_time: expect.any(String),
+          id: 1,
+          start: expect.any(Number),
+          start_time: expect.any(String),
+          tags: {
+            title: 'console.log("Line 2");',
+          },
+          time_base: "1/1000",
+        },
+      ],
+    });
+
+    // Exact start and end times will vary, but we can do some simple sanity checks
+    const [chapter1, chapter2] = videoMetadata.chapters;
+
+    expect(chapter1.end).toBe(chapter2.start);
+    expect(chapter1.end_time).toBe(chapter2.start_time);
+    expect(chapter1.start).toBeLessThan(chapter2.start);
+    expect(chapter1.start).toBeLessThan(chapter1.end);
+    expect(chapter2.start).toBeLessThan(chapter2.end);
   });
 });

--- a/runner/test/runner/Runner.test.ts
+++ b/runner/test/runner/Runner.test.ts
@@ -1,11 +1,11 @@
 // Xvfb :0 -screen 0 1288x804x24 -listen tcp &
 // DEBUG=qawolf* npm run test Runner.test.ts
-import { probeVideoFile } from "../../src/services/ffprobe";
 import { Environment } from "../../src/environment/Environment";
 import { LogArtifactHook } from "../../src/runner/LogArtifactHook";
 import { createHooks, Runner } from "../../src/runner/Runner";
 import { StatusReporterHook } from "../../src/runner/StatusReporterHook";
 import { VideoArtifactsHook } from "../../src/runner/VideoArtifactsHook";
+import { probeVideoFile } from "../../src/services/ffprobe";
 
 describe("createHooks", () => {
   const artifacts = {
@@ -151,7 +151,8 @@ console.log("Line 2");`;
     });
 
     // Exact start and end times will vary, but we can do some simple sanity checks
-    const [chapter1, chapter2] = videoMetadata.chapters;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const [chapter1, chapter2] = videoMetadata.chapters!;
 
     expect(chapter1.end).toBe(chapter2.start);
     expect(chapter1.end_time).toBe(chapter2.start_time);


### PR DESCRIPTION
Disclaimer: This may not work correctly yet (specifically, we need to see how well the chapters actually align with test steps across many varied test runs).

This updates the `VideoCapture` service and the `VideoArtifactsHook` to keep track of step start and end times during a run, and then save that information as chapter metadata in the video file that gets uploaded. When you download the video file and play it with any player that supports chapters, you should then be able to skip directly to any step of the test run using the chapter menu.