### PR TITLE
Allow emitting actions for invisible targets

### DIFF
--- a/recorder/src/resolveAction.ts
+++ b/recorder/src/resolveAction.ts
@@ -1,4 +1,4 @@
-import { getTopmostEditableElement, isVisible } from "./element";
+import { getTopmostEditableElement } from "./element";
 import { nodeToDoc } from "./serialize";
 import { shouldTrackKeyPress } from "./shouldTrackKeyPress";
 import { shouldTrackFill } from "./shouldTrackFill";
@@ -31,12 +31,6 @@ export const resolveAction = (
   const target = getTopmostEditableElement(
     possibleAction.target as HTMLElement
   );
-
-  // Never emit actions on invisible targets
-  if (!isVisible(target, window.getComputedStyle(target))) {
-    console.debug("resolveAction: ignoring action on invisible target");
-    return;
-  }
 
   const targetDoc = nodeToDoc(target);
   let action = possibleAction.action as Action;

--- a/recorder/test/resolveAction.test.ts
+++ b/recorder/test/resolveAction.test.ts
@@ -95,29 +95,6 @@ it("returns undefined for clicks on selects", async () => {
   expect(result).toBe(undefined);
 });
 
-it("returns undefined for actions on invisible targets", async () => {
-  const page = await getFreshPage();
-
-  const result = await page.evaluate(() => {
-    const qawolf: QAWolfWeb = (window as any).qawolf;
-    const target = document.querySelector(
-      'input[type="hidden"]'
-    ) as HTMLElement;
-
-    const mockAction: PossibleAction = {
-      action: "click",
-      isTrusted: false,
-      target,
-      time: Date.now(),
-      value: null,
-    };
-
-    return qawolf.resolveAction(mockAction, undefined);
-  });
-
-  expect(result).toBe(undefined);
-});
-
 it("returns 'selectInput' for 'fill' action on a select", async () => {
   const page = await getFreshPage();
 


### PR DESCRIPTION
If a dropdown closes on mousedown before the click event is fired and we resolve the action, we still want to create code for the click.

This *could* create extra code a user does not want however they could always delete it. However I cannot think of a scenario where this would be the case off the top of my head.