### PR TITLE
Do not show loading incorrectly

### DIFF
--- a/app/components/Editor/Canvas/Placeholder.tsx
+++ b/app/components/Editor/Canvas/Placeholder.tsx
@@ -40,7 +40,7 @@ export default function Placeholder({
   }
 
   // ask the user to run the test if there is no runner connected or pending
-  else if (
+  if (
     mode === "test" &&
     !isRunnerConnected &&
     !isTestLoading &&


### PR DESCRIPTION
I added an assertion to our e2e test for this.

Broken commit: https://github.com/qawolf/qawolf/commit/e115d8e1b6d1cf9aadb5f31b24050931af376168