### PR TITLE
pool: consider incomplete runs

### DIFF
--- a/app/server/jobs/orchestrateRunners.ts
+++ b/app/server/jobs/orchestrateRunners.ts
@@ -1,11 +1,10 @@
-import { minutesFromNow } from "../../shared/utils";
 import environment from "../environment";
 import { countIncompleteRuns } from "../models/run";
 import {
   createRunners,
   deleteUnhealthyRunners,
   findRunners,
-  updateRunner,
+  resetRunner,
 } from "../models/runner";
 import { countIncompleteTests, LocationCount } from "../models/test";
 import { ModelOptions } from "../types";
@@ -89,16 +88,7 @@ export const balanceRunnerPool = async ({
     });
 
     const deletePromises: Promise<unknown>[] = idsToDelete.map((id) =>
-      updateRunner(
-        {
-          // don't throw an error if the runner is not found since
-          // it could have already been deleted (for example it it was unhealthy)
-          allow_skip: true,
-          id,
-          deleted_at: minutesFromNow(),
-        },
-        { db: trx, logger }
-      )
+      resetRunner({ id, type: "delete_unassigned" }, { db: trx, logger })
     );
 
     await Promise.all([

--- a/app/server/jobs/orchestrateRunners.ts
+++ b/app/server/jobs/orchestrateRunners.ts
@@ -19,9 +19,9 @@ export const calculateRunnerPool = async (
   const log = options.logger.prefix("calculateRunnerPool");
 
   // Each location should have enough runners for the buffer and
-  // the incomplete (pending / in progress) tests and runs
-  const incompleteRuns = await countIncompleteRuns(options);
-  const pendingTests = await countIncompleteTests("eastus2", options);
+  // the incomplete (pending / in progress) incompleteTests and runs
+  const incompleteRunCount = await countIncompleteRuns(options);
+  const incompleteTests = await countIncompleteTests("eastus2", options);
 
   const pool: LocationCount[] = [];
 
@@ -30,12 +30,12 @@ export const calculateRunnerPool = async (
 
     const buffer = entry?.buffer || 0;
 
-    const { count: numPendingTests } = pendingTests.find(
+    const { count: incompleteTestCount } = incompleteTests.find(
       (c) => c.location === location
     ) || { count: 0 };
 
-    let count = buffer + numPendingTests;
-    if (location === "eastus2") count += incompleteRuns;
+    let count = buffer + incompleteTestCount;
+    if (location === "eastus2") count += incompleteRunCount;
 
     pool.push({ count, location });
   });

--- a/app/server/jobs/orchestrateRunners.ts
+++ b/app/server/jobs/orchestrateRunners.ts
@@ -11,8 +11,8 @@ import { countIncompleteTests, LocationCount } from "../models/test";
 import { ModelOptions } from "../types";
 
 /**
- * @summary Calculate the number of runners per location.
- *          Our goal is that the available runners matches our buffer.
+ * @summary Calculate the number of runners per location
+ *          to get available runners to equal the buffer.
  */
 export const calculateRunnerPool = async (
   options: ModelOptions
@@ -55,8 +55,6 @@ export const balanceRunnerPool = async ({
 }: ModelOptions): Promise<void> => {
   const pool = await calculateRunnerPool({ db, logger });
 
-  // this must be in a transaction because we do not
-  // want to delete runners that become assigned
   await db.transaction(async (trx) => {
     const runners = await findRunners({}, { db: trx, logger });
 

--- a/app/server/migrations/20210223110740_tests_not_deleted_and_runner_requested_at.ts
+++ b/app/server/migrations/20210223110740_tests_not_deleted_and_runner_requested_at.ts
@@ -1,0 +1,19 @@
+import * as Knex from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(
+    `UPDATE tests SET runner_requested_at = NULL WHERE deleted_at IS NOT NULL`
+  );
+
+  await knex.raw(
+    `ALTER TABLE tests ADD CONSTRAINT tests_not_deleted_and_runner_requested_at CHECK ( 
+        NOT ( deleted_at IS NOT NULL AND runner_requested_at IS NOT NULL ) 
+      )`
+  );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.raw(
+    "ALTER TABLE tests DROP CONSTRAINT tests_not_deleted_and_runner_requested_at"
+  );
+}

--- a/app/server/models/run.ts
+++ b/app/server/models/run.ts
@@ -139,10 +139,9 @@ export const findPendingRun = async (
 export const findRun = async (
   id: string,
   { db }: ModelOptions
-): Promise<Run> => {
+): Promise<Run | null> => {
   const run = await db.select("*").from("runs").where({ id }).first();
-  if (!run) throw new Error("run not found " + id);
-  return run;
+  return run || null;
 };
 
 export const findRunResult = async (
@@ -150,6 +149,8 @@ export const findRunResult = async (
   { db, logger }: ModelOptions
 ): Promise<RunResult> => {
   const run = await findRun(id, { db, logger });
+  if (!run) throw new Error("run not found");
+
   const environment_id = await findEnvironmentIdForRun(id, { db, logger });
 
   let logs_url: string | null = null;
@@ -279,6 +280,7 @@ export const updateRun = async (
   }
 
   const run = await findRun(id, { db, logger });
+  if (!run) throw new Error("run not found");
 
   if (["fail", "pass"].includes(options.status)) {
     updates.completed_at = timestamp;

--- a/app/server/models/run.ts
+++ b/app/server/models/run.ts
@@ -39,17 +39,16 @@ export type UpdateRun = {
   status?: RunStatus;
 };
 
-export const countPendingRuns = async ({
+export const countIncompleteRuns = async ({
   db,
   logger,
 }: ModelOptions): Promise<number> => {
-  const log = logger.prefix("countPendingRuns");
+  const log = logger.prefix("countIncompleteRuns");
 
   const result = await db("runs")
     .count("*", { as: "count" })
     .from("runs")
-    .leftJoin("runners", "runners.run_id", "runs.id")
-    .where({ "runners.id": null, started_at: null })
+    .where({ completed_at: null })
     .first();
 
   log.debug(result);

--- a/app/server/models/runner.ts
+++ b/app/server/models/runner.ts
@@ -246,6 +246,11 @@ export const deleteUnhealthyRunners = async ({
 
   const ids = rows.map((r) => r.id);
 
+  if (!ids.length) {
+    log.debug("skip: no unhealthy runners");
+    return;
+  }
+
   log.alert("delete unhealthy runners", ids.join(","));
 
   await Promise.all(

--- a/app/server/models/runner.ts
+++ b/app/server/models/runner.ts
@@ -168,6 +168,7 @@ export const resetRunner = async (
 
   return db.transaction(async (trx) => {
     if (run?.status === "created" && run.started_at) {
+      // deal with the assigned but incomplete run
       const runUpdates: UpdateRun = { id: run.id };
 
       if (type === "delete_unhealthy" && !run.retries) {
@@ -175,6 +176,7 @@ export const resetRunner = async (
         // retry once only, since it could be a malicious user
         runUpdates.retry_error = "unhealthy_runner";
       } else {
+        // for every other case expire the run
         log.alert("fail expired run", run.id);
         runUpdates.error = "expired";
         runUpdates.status = "fail";

--- a/app/server/models/test.ts
+++ b/app/server/models/test.ts
@@ -272,7 +272,7 @@ export const deleteTests = async (
 
   const tests = await db.transaction(async (trx) => {
     const tests = await trx.select("*").from("tests").whereIn("id", ids);
-    const updates = { deleted_at: minutesFromNow() };
+    const updates = { deleted_at: minutesFromNow(), runner_requested_at: null };
     await trx("tests").update(updates).whereIn("id", ids);
     return tests.map((test: Test) => ({ ...test, ...updates }));
   });

--- a/app/server/models/test.ts
+++ b/app/server/models/test.ts
@@ -61,18 +61,20 @@ export const buildTestName = async (
   return `My Test${testNumber === 1 ? "" : ` ${testNumber}`}`;
 };
 
-export const countPendingTests = async (
+export const countIncompleteTests = async (
   defaultLocation: string,
   { db, logger }: ModelOptions
 ): Promise<LocationCount[]> => {
-  const log = logger.prefix("countPendingTests");
+  const log = logger.prefix("countIncompleteTests");
 
   const countQuery = `SELECT COUNT(s.*), s.location
   FROM (
     SELECT coalesce(runner_locations::json->> 0, ?) as location
     FROM tests
-    WHERE runner_requested_at IS NOT NULL 
-      AND deleted_at IS NULL
+    WHERE runner_requested_at IS NOT NULL
+    UNION ALL
+    SELECT location FROM runners
+    WHERE test_id IS NOT NULL
   ) as s
   GROUP BY s.location`;
 

--- a/app/server/resolvers/run.ts
+++ b/app/server/resolvers/run.ts
@@ -116,18 +116,14 @@ export const updateRunResolver = async (
 
     await validateApiKey({ api_key, run }, { db: trx, logger });
 
-    const updates: UpdateRun = { error, id };
-
+    const updates: UpdateRun = { id };
     if (shouldRetry({ error, retries: run.retries, status })) {
-      updates.retries = (run.retries || 0) + 1;
-      updates.started_at = null;
-      updates.status = "created";
-      log.alert("retry error", error.substring(0, 100));
+      updates.retry_error = error;
     } else if (status === "created") {
       updates.started_at = minutesFromNow();
     } else {
       updates.current_line = current_line;
-      updates.error = error || null;
+      updates.error = status === "pass" ? null : error || null;
       updates.status = status;
     }
 

--- a/app/test/server/jobs/orchestrateRunners.test.ts
+++ b/app/test/server/jobs/orchestrateRunners.test.ts
@@ -9,14 +9,14 @@ import { buildRunner, logger } from "../utils";
 const db = prepareTestDb();
 
 describe("calculateRunnerPool", () => {
-  let countPendingRuns: jest.SpyInstance;
-  let countPendingTests: jest.SpyInstance;
+  let countIncompleteRuns: jest.SpyInstance;
+  let countIncompleteTests: jest.SpyInstance;
 
   beforeAll(() => {
-    countPendingRuns = jest
-      .spyOn(runModel, "countPendingRuns")
+    countIncompleteRuns = jest
+      .spyOn(runModel, "countIncompleteRuns")
       .mockResolvedValue(0);
-    countPendingTests = jest.spyOn(testModel, "countPendingTests");
+    countIncompleteTests = jest.spyOn(testModel, "countIncompleteTests");
   });
 
   afterAll(() => jest.restoreAllMocks());
@@ -27,7 +27,7 @@ describe("calculateRunnerPool", () => {
       japaneast: { buffer: 2, latitude: 0, longitude: 0, reserved: 2 },
     };
 
-    countPendingTests.mockResolvedValue([]);
+    countIncompleteTests.mockResolvedValue([]);
 
     const targets = await orchestrateRunners.calculateRunnerPool({
       db,
@@ -39,12 +39,12 @@ describe("calculateRunnerPool", () => {
     ]);
   });
 
-  it("includes the pending tests", async () => {
+  it("includes the incomplete tests", async () => {
     environment.RUNNER_LOCATIONS = {
       eastus2: { buffer: 0, latitude: 0, longitude: 0, reserved: 0 },
     };
 
-    countPendingTests.mockResolvedValue([{ count: 3, location: "eastus2" }]);
+    countIncompleteTests.mockResolvedValue([{ count: 3, location: "eastus2" }]);
 
     const targets = await orchestrateRunners.calculateRunnerPool({
       db,
@@ -53,13 +53,13 @@ describe("calculateRunnerPool", () => {
     expect(targets).toEqual([{ count: 3, location: "eastus2" }]);
   });
 
-  it("includes the pending runs", async () => {
+  it("includes the incomplete runs", async () => {
     environment.RUNNER_LOCATIONS = {
       eastus2: { buffer: 0, latitude: 0, longitude: 0, reserved: 0 },
     };
 
-    countPendingRuns.mockResolvedValue(3);
-    countPendingTests.mockResolvedValue([{ count: 1, location: "eastus2" }]);
+    countIncompleteRuns.mockResolvedValue(3);
+    countIncompleteTests.mockResolvedValue([{ count: 1, location: "eastus2" }]);
 
     const targets = await orchestrateRunners.calculateRunnerPool({
       db,

--- a/app/test/server/models/run.test.ts
+++ b/app/test/server/models/run.test.ts
@@ -199,10 +199,8 @@ describe("run model", () => {
       });
     });
 
-    it("throws an error if run does not exist", async () => {
-      await expect(findRun("fakeId", options)).rejects.toThrowError(
-        "not found"
-      );
+    it("returns null if run does not exist", async () => {
+      expect(await findRun("fakeId", options)).toEqual(null);
     });
   });
 

--- a/app/test/server/models/run.test.ts
+++ b/app/test/server/models/run.test.ts
@@ -1,6 +1,6 @@
 import { encrypt } from "../../../server/models/encrypt";
 import {
-  countPendingRuns,
+  countIncompleteRuns,
   createRunsForTests,
   findLatestRuns,
   findPendingRun,
@@ -118,10 +118,10 @@ describe("run model", () => {
 
   afterAll(() => jest.restoreAllMocks());
 
-  describe("countPendingRuns", () => {
-    it("counts the unassigned runs that have not started", async () => {
-      const result = await countPendingRuns(options);
-      expect(result).toEqual(4);
+  describe("countIncompleteRuns", () => {
+    it("counts the runs that have not completed", async () => {
+      const result = await countIncompleteRuns(options);
+      expect(result).toEqual(5);
     });
   });
 

--- a/app/test/server/models/run.test.ts
+++ b/app/test/server/models/run.test.ts
@@ -362,7 +362,50 @@ describe("run model", () => {
   });
 
   describe("updateRun", () => {
-    it("updates existing run", async () => {
+    afterEach(() => db("runs").update(buildRun({})).where({ id: "runId" }));
+
+    it("calls sendAlert when a suite run completes", async () => {
+      const sendAlertSpy = jest
+        .spyOn(alertService, "sendAlert")
+        .mockResolvedValue();
+
+      await updateRun(
+        {
+          id: "run5Id",
+          status: "pass",
+        },
+        options
+      );
+
+      expect(sendAlertSpy.mock.calls[0][0]).toEqual("suite2Id");
+    });
+
+    it("retries an error", async () => {
+      await updateRun({ id: "runId", retry_error: "retry me" }, options);
+
+      const updated = await findRun("runId", options);
+      expect(updated).toMatchObject({
+        completed_at: null,
+        error: "retry me",
+        retries: 1,
+        started_at: null,
+        status: "created",
+      });
+    });
+
+    it("throws an error if run does not exist", async () => {
+      await expect(
+        updateRun(
+          {
+            id: "fakeId",
+            status: "pass",
+          },
+          options
+        )
+      ).rejects.toThrowError("not found");
+    });
+
+    it("updates a run", async () => {
       const run = await findRun("runId", options);
       expect(run).toMatchObject({ completed_at: null, started_at: null });
 
@@ -393,7 +436,6 @@ describe("run model", () => {
         {
           error: "error".repeat(100),
           id: "runId",
-          retries: 1,
           status: "fail",
         },
         options
@@ -401,35 +443,6 @@ describe("run model", () => {
 
       const updated = await findRun("runId", options);
       expect(updated.error).toHaveLength(100);
-      expect(updated.retries).toEqual(1);
-    });
-
-    it("calls sendAlert when a suite run completes", async () => {
-      const sendAlertSpy = jest
-        .spyOn(alertService, "sendAlert")
-        .mockResolvedValue();
-
-      await updateRun(
-        {
-          id: "run5Id",
-          status: "pass",
-        },
-        options
-      );
-
-      expect(sendAlertSpy.mock.calls[0][0]).toEqual("suite2Id");
-    });
-
-    it("throws an error if run does not exist", async () => {
-      await expect(
-        updateRun(
-          {
-            id: "fakeId",
-            status: "pass",
-          },
-          options
-        )
-      ).rejects.toThrowError("not found");
     });
   });
 });

--- a/app/test/server/models/runner.test.ts
+++ b/app/test/server/models/runner.test.ts
@@ -1,5 +1,6 @@
 import environment from "../../../server/environment";
 import * as runModel from "../../../server/models/run";
+import { findRun } from "../../../server/models/run";
 import {
   assignRunner,
   countExcessRunners,
@@ -9,6 +10,7 @@ import {
   findRunner,
   findRunners,
   requestRunnerForTest,
+  resetRunner,
   updateRunner,
 } from "../../../server/models/runner";
 import * as runnerModel from "../../../server/models/runner";
@@ -405,43 +407,111 @@ describe("requestRunnerForTest", () => {
 });
 
 describe("resetRunner", () => {
-  // it("does not delete a runner if it is assigned", async () => {
-  //   await db("runners").update({ run_id: "runId", test_id: null });
-  //   const runner = await updateRunner(
-  //     { deleted_at: minutesFromNow(), id: "runnerId" },
-  //     options
-  //   );
-  //   expect(runner.deleted_at).toBeNull();
-  //   await db("runners").update({ run_id: null, test_id: null });
-  // });
-  // it("unassigns the test when the runner is deleted", async () => {
-  //   // TODO move this....
-  //   // if (updates.run_id === null && runner.run_id) {
-  //   // }
-  //   await db("runners").update({ run_id: null, test_id: "testId" });
-  //   const runner = await updateRunner(
-  //     { deleted_at: minutesFromNow(), id: "runnerId" },
-  //     options
-  //   );
-  //   expect(runner).toMatchObject({ test_id: null });
-  //   await db("runners").update({ deleted_at: null }).where({ id: "runnerId" });
-  // });
-  // it("fails a uncompleted run when the runner is unassigned", async () => {
-  //   await db("runners").update({ run_id: "runId", test_id: null });
-  //   // check it fails the run when it is unassigned since it was not completed
-  //   await updateRunner({ id: "runnerId", run_id: null }, options);
-  //   const run = await runModel.findRun("runId", options);
-  //   expect(run).toMatchObject({ error: "expired", status: "fail" });
-  // });
-  // it("unassigns the run when the runner is deleted", async () => {
-  //   await db("runners").update({ run_id: "runId", test_id: null });
-  //   const runner = await updateRunner(
-  //     { deleted_at: minutesFromNow(), id: "runnerId" },
-  //     options
-  //   );
-  //   expect(runner).toMatchObject({ run_id: null });
-  //   await db("runners").update({ deleted_at: null }).where({ id: "runnerId" });
-  // });
+  beforeEach(() => db("runners").insert(buildRunner({})));
+
+  afterEach(() => db("runners").del());
+
+  it("unassigns and expires the uncompleted run", async () => {
+    await db("runs")
+      .update(buildRun({ started_at: minutesFromNow() }))
+      .where({ id: "runId" });
+
+    await db("runners").update({ run_id: "runId" });
+    await resetRunner({ id: "runnerId", type: "expire" }, options);
+
+    const runner = await db("runners").where({ id: "runnerId" }).first();
+    expect(runner).toMatchObject({
+      api_key: null,
+      ready_at: null,
+      run_id: null,
+      test_id: null,
+    });
+
+    const run = await findRun("runId", options);
+    expect(run).toMatchObject({ error: "expired", status: "fail" });
+  });
+
+  it("unassigns the test", async () => {
+    await db("runners").update({ run_id: null, test_id: "testId" });
+    await resetRunner({ id: "runnerId", type: "expire" }, options);
+
+    const runner = await db("runners").where({ id: "runnerId" }).first();
+    expect(runner).toMatchObject({
+      api_key: null,
+      ready_at: null,
+      run_id: null,
+      test_id: null,
+    });
+  });
+
+  describe("delete_unassigned", () => {
+    it("deletes an unasssigned runner", async () => {
+      await resetRunner({ id: "runnerId", type: "delete_unassigned" }, options);
+
+      const runner = await db("runners").where({ id: "runnerId" }).first();
+      expect(runner.deleted_at).toBeTruthy();
+    });
+
+    it("does not delete a runner if it is assigned", async () => {
+      await db("runners")
+        .update({ run_id: "runId", test_id: null })
+        .where({ id: "runnerId" });
+
+      await resetRunner({ id: "runnerId", type: "delete_unassigned" }, options);
+
+      const runner = await db("runners").where({ id: "runnerId" }).first();
+      expect(runner.deleted_at).toBeNull();
+    });
+  });
+
+  describe("delete_unhealthy", () => {
+    it("retries the uncompleted run once", async () => {
+      await db("runs")
+        .update(buildRun({ started_at: minutesFromNow() }))
+        .where({ id: "runId" });
+
+      await db("runners").update({ run_id: "runId" }).where({ id: "runnerId" });
+      await resetRunner({ id: "runnerId", type: "delete_unhealthy" }, options);
+
+      const runner = await db("runners").where({ id: "runnerId" }).first();
+      expect(runner).toMatchObject({
+        api_key: null,
+        deleted_at: expect.any(Date),
+        ready_at: null,
+        run_id: null,
+        test_id: null,
+      });
+
+      const run = await findRun("runId", options);
+      expect(run).toMatchObject({
+        completed_at: null,
+        retries: 1,
+        started_at: null,
+        status: "created",
+      });
+    });
+  });
+
+  describe("expire", () => {
+    it("sets session_expires_at", async () => {
+      await resetRunner({ id: "runnerId", type: "expire" }, options);
+
+      const runner = await db("runners").where({ id: "runnerId" }).first();
+      expect(runner.session_expires_at).toBeTruthy();
+    });
+  });
+
+  describe("restart", () => {
+    it("sets health_checked_at and restarted_at", async () => {
+      await resetRunner({ id: "runnerId", type: "restart" }, options);
+
+      const runner = await db("runners").where({ id: "runnerId" }).first();
+      expect(runner).toMatchObject({
+        health_checked_at: expect.any(Date),
+        restarted_at: expect.any(Date),
+      });
+    });
+  });
 });
 
 describe("updateRunner", () => {

--- a/app/test/server/models/test.test.ts
+++ b/app/test/server/models/test.test.ts
@@ -17,7 +17,7 @@ import {
 const {
   buildTestName,
   createTestAndTestTriggers,
-  countPendingTests,
+  countIncompleteTests,
   deleteTests,
   findEnabledTestsForTrigger,
   findPendingTest,
@@ -270,12 +270,12 @@ describe("pending tests", () => {
     await db("tests").del();
   });
 
-  describe("countPendingTests", () => {
-    it("counts tests that requested a runner", async () => {
-      const result = await countPendingTests("eastus2", options);
+  describe("countIncompleteTests", () => {
+    it("counts tests assigned to and requesting a runner", async () => {
+      const result = await countIncompleteTests("eastus2", options);
       expect(result).toEqual([
         { count: 2, location: "eastus2" },
-        { count: 1, location: "westus2" },
+        { count: 2, location: "westus2" },
       ]);
     });
   });

--- a/app/test/server/models/test.test.ts
+++ b/app/test/server/models/test.test.ts
@@ -166,6 +166,11 @@ describe("deleteTests", () => {
       options
     );
 
+    // request a runner to make sure it gets cleared after deletion
+    await db("tests")
+      .update({ runner_requested_at: minutesFromNow() })
+      .where({ id: "deleteMe" });
+
     await createTestAndTestTriggers(
       {
         code: "code",
@@ -177,7 +182,8 @@ describe("deleteTests", () => {
     );
 
     const testToDelete = await findTest("deleteMe", options);
-    expect(testToDelete).toMatchObject({ id: "deleteMe" });
+    expect(testToDelete.id).toEqual("deleteMe");
+    expect(testToDelete.runner_requested_at).toBeTruthy();
 
     await deleteTests(["deleteMe", "deleteMe2"], options);
 
@@ -187,8 +193,8 @@ describe("deleteTests", () => {
       .whereIn("id", ["deleteMe", "deleteMe2"]);
 
     expect(tests).toMatchObject([
-      { deleted_at: expect.any(Date) },
-      { deleted_at: expect.any(Date) },
+      { deleted_at: expect.any(Date), runner_requested_at: null },
+      { deleted_at: expect.any(Date), runner_requested_at: null },
     ]);
   });
 });

--- a/app/test/server/resolvers/run.test.ts
+++ b/app/test/server/resolvers/run.test.ts
@@ -108,7 +108,7 @@ describe("testHistoryResolver", () => {
 describe("updateRunResolver", () => {
   beforeEach(() => {
     jest.spyOn(alertService, "sendAlert").mockResolvedValue();
-    jest.spyOn(runnerModel, "expireRunner").mockResolvedValue();
+    jest.spyOn(runnerModel, "resetRunner").mockResolvedValue();
     jest.spyOn(runResolver, "validateApiKey").mockResolvedValue();
   });
 
@@ -144,7 +144,7 @@ describe("updateRunResolver", () => {
     const run = await db("runs").select("*").where({ id: "run2Id" }).first();
 
     expect(run).toMatchObject({ current_line: 2, status: "fail" });
-    expect(runnerModel.expireRunner).toBeCalled();
+    expect(runnerModel.resetRunner).toBeCalled();
   });
 
   it("updates the run and expires the runner if run succeeded", async () => {
@@ -157,7 +157,7 @@ describe("updateRunResolver", () => {
     const run = await db("runs").select("*").where({ id: "run2Id" }).first();
 
     expect(run).toMatchObject({ current_line: 2, status: "pass" });
-    expect(runnerModel.expireRunner).toBeCalled();
+    expect(runnerModel.resetRunner).toBeCalled();
   });
 
   it("retries the run if shouldRetry is true", async () => {
@@ -174,7 +174,7 @@ describe("updateRunResolver", () => {
       started_at: null,
       status: "created",
     });
-    expect(runnerModel.expireRunner).toBeCalled();
+    expect(runnerModel.resetRunner).toBeCalled();
   });
 });
 

--- a/app/test/server/resolvers/runner.test.ts
+++ b/app/test/server/resolvers/runner.test.ts
@@ -242,16 +242,12 @@ describe("updateRunnerResolver", () => {
         id: "mockedSuiteRunForRunnerId",
       });
 
+      const now = minutesFromNow();
+
       // check it does not assign to an expired runner
-      await updateRunner(
-        {
-          id: "runnerId",
-          ready_at: minutesFromNow(),
-          session_expires_at: minutesFromNow(),
-          test_id: null,
-        },
-        options
-      );
+      await db("runners")
+        .update({ ready_at: now, session_expires_at: now, test_id: null })
+        .where({ id: "runnerId" });
 
       const result = await updateRunnerResolver(
         {},
@@ -264,7 +260,9 @@ describe("updateRunnerResolver", () => {
       expect(runner).toMatchObject({ run_id: null, test_id: null });
 
       // now check it assigns to a ready runner
-      await updateRunner({ id: "runnerId", session_expires_at: null }, options);
+      await db("runners")
+        .update({ session_expires_at: null })
+        .where({ id: "runnerId" });
 
       const result2 = await updateRunnerResolver(
         {},

--- a/app/test/server/utils.ts
+++ b/app/test/server/utils.ts
@@ -293,6 +293,7 @@ export const buildRun = ({
     created_at: created_at || undefined,
     current_line: 1,
     id: `run${finalI === 1 ? "" : i}Id`,
+    retries: null,
     started_at: started_at || undefined,
     status: status || "created",
     suite_id: suite_id || null,


### PR DESCRIPTION
Resolves #1071 

- Include in progress tests and runs in pool calculations
- Fix a potential race condition where an assigned runners could be deleted during rebalancing
- Retry in progress runs for deleted unhealthy runners once
- Alert us to unhealthy runners
- Add db constraint to ensure tests are not pending after deleted
- Consolidated reset runner logic (delete, expire, restart)