### PR TITLE
Create environment on sign up

### DIFF
--- a/app/components/Modals/Triggers/CreateOrEditTrigger/Form.tsx
+++ b/app/components/Modals/Triggers/CreateOrEditTrigger/Form.tsx
@@ -69,7 +69,7 @@ export default function Form({
 
   // environment
   const [environmentId, setEnvironmentId] = useState<string>(
-    editTrigger?.environment_id || stateEnvironmentId || ""
+    editTrigger ? editTrigger.environment_id || "" : stateEnvironmentId || ""
   );
 
   // try to use a sensible default name

--- a/app/server/models/team.ts
+++ b/app/server/models/team.ts
@@ -6,7 +6,9 @@ import { ClientError } from "../errors";
 import { ModelOptions, Team, TeamPlan } from "../types";
 import { buildApiKey, cuid } from "../utils";
 import { decrypt, encrypt } from "./encrypt";
+import { createEnvironment } from "./environment";
 
+const DEFAULT_ENVIRONMENT_NAME = "Environment";
 const DEFAULT_NAME = "My Team";
 
 type UpdateTeam = {
@@ -70,6 +72,11 @@ export const createDefaultTeam = async ({
 
   await db("teams").insert(team);
   log.debug("created", team);
+
+  await createEnvironment(
+    { name: DEFAULT_ENVIRONMENT_NAME, team_id: team.id },
+    { db, logger }
+  );
 
   return formatTeam(team);
 };

--- a/app/test/server/models/team.test.ts
+++ b/app/test/server/models/team.test.ts
@@ -26,7 +26,10 @@ const options = { db, logger };
 beforeAll(() => db("users").insert(buildUser({})));
 
 describe("createDefaultTeam", () => {
-  afterAll(() => db("teams").del());
+  afterAll(async () => {
+    await db("environments").del();
+    return db("teams").del();
+  });
 
   it("creates a free team", async () => {
     await createDefaultTeam(options);
@@ -52,8 +55,16 @@ describe("createDefaultTeam", () => {
         stripe_subscription_id: null,
       },
     ]);
-
     expect(decrypt(teams[0].api_key)).toMatch("qawolf_");
+
+    const environments = await db("environments");
+
+    expect(environments).toMatchObject([
+      {
+        name: "Environment",
+        team_id: teams[0].id,
+      },
+    ]);
   });
 });
 

--- a/app/test/server/resolvers/user.test.ts
+++ b/app/test/server/resolvers/user.test.ts
@@ -373,10 +373,7 @@ describe("signInWithGitHubResolver", () => {
       wolf_variant: invite.wolf_variant,
     });
 
-    const teamUsers = await db
-      .select("*")
-      .from("team_users")
-      .where({ user_id: user.id });
+    const teamUsers = await db("team_users").where({ user_id: user.id });
     expect(teamUsers).toEqual([]);
 
     await db("users").where({ id: user.id }).del();


### PR DESCRIPTION
* Fix 🐛: Do not show environment as selected in edit trigger modal if not assigned to trigger
* Create an environment on sign up to avoid step of having to create one