### PR TITLE
use chrome channel for chrome

### DIFF
--- a/runner/src/environment/launch.ts
+++ b/runner/src/environment/launch.ts
@@ -32,6 +32,7 @@ const BROWSER_CONTEXT_OPTIONS = [
 
 const LAUNCH_OPTIONS = [
   "args",
+  "channel",
   "devtools",
   "env",
   "executablePath",
@@ -82,7 +83,7 @@ export const getBrowserLaunchOptions = (
   };
 
   if (name === "chrome") {
-    launchOptions.executablePath = "/opt/google/chrome/chrome";
+    launchOptions.channel = "chrome";
   }
 
   return launchOptions;

--- a/runner/test/environment/launch.test.ts
+++ b/runner/test/environment/launch.test.ts
@@ -28,9 +28,9 @@ describe("getBrowserLaunchOptions", () => {
     ).toMatchObject({ args });
   });
 
-  it("sets executablePath for chrome", () => {
+  it("sets channel for chrome", () => {
     expect(getBrowserLaunchOptions("chrome", {})).toMatchObject({
-      executablePath: "/opt/google/chrome/chrome",
+      channel: "chrome",
     });
   });
 });


### PR DESCRIPTION
This feature from playwright 1.10 auto-handles the executablePath