### PR TITLE
Clearly delineate when to return a run vs test runner

### DIFF
--- a/app/components/Editor/Canvas/Placeholder.tsx
+++ b/app/components/Editor/Canvas/Placeholder.tsx
@@ -26,7 +26,7 @@ export default function Placeholder({
 }: Props): JSX.Element {
   const { isTestLoading } = useContext(TestContext);
   const { isUserLoading, wolf } = useContext(UserContext);
-  const { isRunnerConnected, shouldRequestRunner } = useContext(RunnerContext);
+  const { isRunnerConnected, requestTestRunner } = useContext(RunnerContext);
 
   // default to loading
   let message = copy.loading;
@@ -45,7 +45,7 @@ export default function Placeholder({
     mode === "test" &&
     !isRunnerConnected &&
     !isTestLoading &&
-    !shouldRequestRunner
+    !requestTestRunner
   ) {
     iconHtml = <WolfButton color={wolf?.variant} />;
     message = copy.placeholderRunTest;

--- a/app/components/Editor/contexts/RunnerContext.tsx
+++ b/app/components/Editor/contexts/RunnerContext.tsx
@@ -16,9 +16,9 @@ type RunnerContext = ConnectRunnerHook &
   RunnerHook &
   SelectionHook & {
     progress: RunProgress | null;
+    requestTestRunner: boolean;
     runTest: RunTest["runTest"];
     stopTest: RunTest["stopTest"];
-    shouldRequestRunner: boolean;
   };
 
 export const RunnerContext = createContext<RunnerContext>({
@@ -30,10 +30,10 @@ export const RunnerContext = createContext<RunnerContext>({
   mouseLineNumber: null,
   onSelectionChange: () => null,
   progress: null,
+  requestTestRunner: false,
   runner: null,
   runTest: () => null,
   selection: null,
-  shouldRequestRunner: false,
   startElementChooser: () => null,
   stopElementChooser: () => null,
   stopTest: () => null,
@@ -60,15 +60,15 @@ export const RunnerProvider: FC = ({ children }) => {
 
   const { progress, resetProgress } = useRunProgress({ run, runner });
 
-  const { shouldRequestRunner, runTest, stopTest } = useRunTest({
+  const { requestTestRunner, runTest, stopTest } = useRunTest({
     env,
     resetProgress,
     runner,
   });
 
   const { apiKey, isRunnerLoading, wsUrl } = useConnectRunner({
-    shouldRequestRunner,
     isRunnerConnected,
+    requestTestRunner,
     runner,
   });
 
@@ -85,10 +85,10 @@ export const RunnerProvider: FC = ({ children }) => {
     mouseLineNumber,
     onSelectionChange,
     progress,
+    requestTestRunner,
     runner,
     runTest,
     selection,
-    shouldRequestRunner,
     startElementChooser,
     stopElementChooser,
     stopTest,

--- a/app/components/Editor/hooks/connectRunner.ts
+++ b/app/components/Editor/hooks/connectRunner.ts
@@ -12,30 +12,27 @@ export type ConnectRunnerHook = {
 
 type UseConnectRunner = {
   isRunnerConnected: boolean;
+  requestTestRunner: boolean;
   runner: RunnerClient | null;
-  shouldRequestRunner: boolean;
 };
 
 export const useConnectRunner = ({
   isRunnerConnected,
+  requestTestRunner,
   runner: runnerClient,
-  shouldRequestRunner,
 }: UseConnectRunner): ConnectRunnerHook => {
   const { query } = useRouter();
 
   const useLocalRunner = query.local === "1";
-  const run_id = query.run_id as string;
-  const test_id = query.test_id as string;
 
   const { data: runnerResult, loading, startPolling, stopPolling } = useRunner(
-    {
-      run_id,
-      should_request_runner: shouldRequestRunner,
-      test_id,
-    },
-    {
-      skip: useLocalRunner,
-    }
+    query.run_id
+      ? { run_id: query.run_id as string }
+      : {
+          request_test_runner: requestTestRunner,
+          test_id: query.test_id as string,
+        },
+    { skip: useLocalRunner }
   );
 
   // manually poll instead of passing pollInterval

--- a/app/components/Editor/hooks/runTest.ts
+++ b/app/components/Editor/hooks/runTest.ts
@@ -16,9 +16,9 @@ type RunTestOptions = {
 };
 
 export type RunTest = {
+  requestTestRunner: boolean;
   runTest: (options: RunTestOptions) => void;
   stopTest: () => void;
-  shouldRequestRunner: boolean;
 };
 
 type UseRunTest = {
@@ -32,15 +32,17 @@ export const useRunTest = ({
   resetProgress,
   runner,
 }: UseRunTest): RunTest => {
-  const [shouldRequestRunner, setShouldRequestRunner] = useState(
+  const [requestTestRunner, setRequestTestRunner] = useState(
     !!state.pendingRun
   );
   const [ranAt, setRanAt] = useState<Date | null>(null);
 
   useEffect(() => {
+    // request a test runner when there is a pending run
+    // or "Run Test" was pressed recently
     const interval = runAndSetInterval(() => {
       const value = !!state.pendingRun || ranAt >= new Date(minutesFromNow(-1));
-      setShouldRequestRunner(value);
+      setRequestTestRunner(value);
     }, 10 * 1000);
 
     return () => clearInterval(interval);
@@ -80,5 +82,5 @@ export const useRunTest = ({
     runner.stop();
   };
 
-  return { runTest, shouldRequestRunner, stopTest };
+  return { requestTestRunner, runTest, stopTest };
 };

--- a/app/graphql/queries.ts
+++ b/app/graphql/queries.ts
@@ -94,10 +94,10 @@ export const runCountQuery = gql`
 `;
 
 export const runnerQuery = gql`
-  query runner($run_id: ID, $should_request_runner: Boolean, $test_id: ID) {
+  query runner($request_test_runner: Boolean, $run_id: ID, $test_id: ID) {
     runner(
+      request_test_runner: $request_test_runner
       run_id: $run_id
-      should_request_runner: $should_request_runner
       test_id: $test_id
     ) {
       ...RunnerFragment

--- a/app/hooks/queries.ts
+++ b/app/hooks/queries.ts
@@ -119,8 +119,8 @@ type RunnerData = {
 };
 
 type RunnerVariables = {
+  request_test_runner?: boolean;
   run_id?: string | null;
-  should_request_runner?: boolean;
   test_id?: string;
 };
 

--- a/app/server/models/runner.ts
+++ b/app/server/models/runner.ts
@@ -297,28 +297,16 @@ export const findRunner = async (
   { id, include_deleted, is_ready, locations, run_id, test_id }: FindRunner,
   { db }: ModelOptions
 ): Promise<Runner | null> => {
+  if (run_id && test_id) throw new Error("cannot provide run_id and test_id");
+
   const filter: Record<string, unknown> = {};
 
   if (!include_deleted) filter.deleted_at = null;
-
   if (id) filter.id = id;
+  if (run_id !== undefined) filter.run_id = run_id;
+  if (test_id !== undefined) filter.test_id = test_id;
 
-  let query = db("runners").select("*").from("runners");
-
-  if (run_id && test_id) {
-    // allow either
-    query = query
-      .where(function () {
-        this.where({ run_id }).orWhere({ test_id });
-      })
-      // prefer the run's runner
-      .orderBy("run_id", "asc");
-  } else {
-    if (run_id !== undefined) filter.run_id = run_id;
-    if (test_id !== undefined) filter.test_id = test_id;
-  }
-
-  query = query.where(filter);
+  let query = db("runners").select("*").from("runners").where(filter);
 
   if (is_ready) query = query.whereNotNull("ready_at");
 

--- a/app/server/schema.graphql
+++ b/app/server/schema.graphql
@@ -1390,17 +1390,17 @@ type Query {
   """
   runner(
     """
-    Run ID
+    Request a runner for editing the test
+    """
+    request_test_runner: Boolean
+
+    """
+    The current run ID.
     """
     run_id: ID
 
     """
-    Request a runner for the test
-    """
-    should_request_runner: Boolean
-
-    """
-    Test ID
+    The current test ID.
     """
     test_id: ID
   ): Runner

--- a/app/test/server/models/runner.test.ts
+++ b/app/test/server/models/runner.test.ts
@@ -226,25 +226,11 @@ describe("findRunner", () => {
   it("finds a runner by run_id", async () => {
     const result = await findRunner({ run_id: "runId" }, options);
     expect(result.id).toEqual("runnerId");
-
-    // check it prefers the runner for the run if the test id is also specified
-    const result2 = await findRunner(
-      { run_id: "runId", test_id: "testId" },
-      options
-    );
-    expect(result2.id).toEqual("runnerId");
   });
 
   it("finds a runner by test_id", async () => {
     const result = await findRunner({ test_id: "testId" }, options);
     expect(result.id).toEqual("runner2Id");
-
-    // check it finds the runner if the run id is also specified
-    const result2 = await findRunner(
-      { run_id: "fakeRunId", test_id: "testId" },
-      options
-    );
-    expect(result2.id).toEqual("runner2Id");
   });
 
   it("finds a runner in the closest location possible", async () => {
@@ -277,6 +263,12 @@ describe("findRunner", () => {
       options
     );
     expect(runner2.id).toEqual("runner4Id");
+  });
+
+  it("throws an error if run_id and test_id are specified", async () => {
+    await expect(
+      findRunner({ run_id: "runId", test_id: "testId" }, options)
+    ).rejects.toThrowError("cannot provide run_id and test_id");
   });
 });
 

--- a/app/test/server/resolvers/runner.test.ts
+++ b/app/test/server/resolvers/runner.test.ts
@@ -93,22 +93,22 @@ describe("runnerResolver", () => {
     expect(runnerModel.updateRunner).not.toBeCalled();
   });
 
-  it("extends the current runner's session when should_request_runner is specified", async () => {
+  it("extends the current runner's session when request_test_runner is specified", async () => {
     const initialExpiresAt = (
-      await findRunner({ run_id: "runId" }, { db, logger })
+      await findRunner({ test_id: "testId" }, { db, logger })
     ).session_expires_at;
 
     const runner = await runnerResolver(
       null,
-      { run_id: "runId", should_request_runner: true },
+      { request_test_runner: true, test_id: "testId" },
       context
     );
     expect(runner).toEqual({
       api_key: null,
-      ws_url: "wss://westus2.qawolf.com/runner/runnerId/.qawolf",
+      ws_url: "wss://westus2.qawolf.com/runner/runner2Id/.qawolf",
     });
 
-    const dbRunner = await findRunner({ run_id: "runId" }, options);
+    const dbRunner = await findRunner({ test_id: "testId" }, options);
     expect(dbRunner.session_expires_at).not.toBe(initialExpiresAt);
   });
 
@@ -127,7 +127,7 @@ describe("runnerResolver", () => {
 
     await runnerResolver(
       null,
-      { should_request_runner: true, test_id: "test2Id" },
+      { request_test_runner: true, test_id: "test2Id" },
       context
     );
 


### PR DESCRIPTION
- rename should_request_runner -> request_test_runner
- if request_test_runner is provided, only return a test runner
- return a run runner when only run_id is provided to runner query