### PR TITLE
create bash CLI script for most common dev env tasks

### DIFF
--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,9 @@
+.env
+.git
+.next
+.storybook
+*.md
+Dockerfile
+netlify.toml
+node_modules
+vercel.json

--- a/app/.env.example
+++ b/app/.env.example
@@ -24,7 +24,7 @@ AZURE_SUBSCRIPTION_ID=SUBCRIPTION_ID
 AZURE_WORKSPACE_ID=
 AZURE_WORKSPACE_KEY=
 
-DATABASE_URL=postgres://user:pass@localhost:5432/dbname
+DATABASE_URL=postgres://qawolf:qawolf@localhost:5432/qawolf
 
 EMAIL_DOMAIN=dev.qawolf.email
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:14.16.1-alpine as builder
+
+LABEL maintainer="QA Wolf Inc. <hello@qawolf.com>"
+
+RUN apk update && apk add --no-cache build-base python
+RUN npm i -g node-gyp npm@7
+
+WORKDIR /app
+
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+COPY . .
+
+ENV WEBPACK_IGNORE_KNEX_PLUGINS="1"
+ENV NODE_OPTIONS="--max-old-space-size=8192" 
+
+RUN npm run build
+
+
+FROM node:14.16.1-alpine
+
+RUN apk --no-cache upgrade && apk add --no-cache su-exec
+
+WORKDIR /app
+
+COPY --from=builder --chown=node /app .
+
+EXPOSE 3000
+
+ENTRYPOINT ["./scripts/docker-entrypoint.sh"]
+
+CMD ["npm", "start"]

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -11,7 +11,7 @@ const config = withMDX({
       loader: "@graphql-tools/webpack-loader",
     });
 
-    if (process.env.NETLIFY) {
+    if (process.env.NETLIFY || process.env.WEBPACK_IGNORE_KNEX_PLUGINS) {
       // https://github.com/knex/knex/issues/1446#issuecomment-253245823
       config.plugins.push(
         ...[

--- a/app/scripts/docker-entrypoint.sh
+++ b/app/scripts/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -ex
+
+# root user will be dropped to the 'node' user by default
+if [[ "$1" == npm ]] && [ "$(id -u)" = '0' ]; then
+  echo "Running process as 'node' user..."
+
+  if [[ "$SKIP_MIGRATIONS" != "true" ]]; then
+    su-exec node npm run migrate:run
+  fi
+
+	su-exec node "$@"
+fi
+
+echo "Running process as user: $(whoami)"
+
+if [[ "$SKIP_MIGRATIONS" != "true" ]]; then
+  su-exec node npm run migrate:run
+fi
+
+exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.6'
+
+services:
+  app:
+    build: ./app
+    image: qawolf/app:latest
+    depends_on:
+      - postgres
+    links:
+      - postgres
+    ports:
+      - 3000:3000
+    env_file:
+      - ./app/.env
+    environment:
+      DATABASE_URL: postgres://qawolf:qawolf@postgres:5432/qawolf
+      NODE_ENV: production
+
+  postgres:
+    image: postgres:13-alpine
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: qawolf
+      POSTGRES_PASSWORD: qawolf
+      POSTGRES_DB: qawolf
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+
+  runner:
+    build: ./runner
+    image: qawolf/runner:latest
+    environment:
+      DEBUG: "qawolf:*"
+      QAWOLF_API_URL: "http://host.docker.internal:7071"
+    ports:
+      - 26367:26367
+
+volumes:
+  pg-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: qawolf/runner:latest
     environment:
       DEBUG: "qawolf:*"
-      QAWOLF_API_URL: "http://host.docker.internal:7071"
+      QAWOLF_API_URL: "http://app:3000"
     ports:
       - 26367:26367
 

--- a/runner/.dockerignore
+++ b/runner/.dockerignore
@@ -1,4 +1,5 @@
-node_modules/
 .eslintignore
 .gitignore
+bin
 eslintrc.json
+node_modules

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,5 +1,10 @@
 FROM ubuntu:20.04
 
+LABEL maintainer="QA Wolf Inc. <hello@qawolf.com>"
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y curl gnupg2 && \
@@ -72,6 +77,8 @@ RUN apt-get update && \
 # upgrade npm to support lockfile v2
 RUN npm i -g npm@7
 
+WORKDIR /opt/runner
+
 COPY package.json package-lock.json ./
 RUN npm i
 
@@ -84,6 +91,8 @@ RUN npm run build:tsc
 COPY files/ /root/files
 COPY scripts/ scripts/
 
+RUN chown -R node:node /opt/runner
+
 # need to set DEBUG=pw:api to capture verbose logs
 ENV DEBUG=pw:api*,qawolf* \
   HOME=/root \
@@ -93,7 +102,9 @@ ENV DEBUG=pw:api*,qawolf* \
   QAWOLF_DISPLAY_WIDTH=1288 \
   QAWOLF_DISPLAY_HEIGHT=804
 
-CMD ["/scripts/entrypoint.sh"]
-
 EXPOSE 80
 EXPOSE 443
+
+ENTRYPOINT ["./scripts/entrypoint.sh"]
+
+CMD ["supervisord", "-c", "./scripts/supervisord.conf"]

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,88 +1,14 @@
-FROM ubuntu:20.04
+FROM qawolf/runner-base:1.0.0
 
 LABEL maintainer="QA Wolf Inc. <hello@qawolf.com>"
-
-RUN groupadd --gid 1000 node \
-  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y curl gnupg2 && \
-  # use latest nginx
-  curl http://nginx.org/keys/nginx_signing.key --output nginx_signing.key && apt-key add nginx_signing.key &&\
-  # use node 14
-  curl -sL https://deb.nodesource.com/setup_14.x | bash - &&\
-  # chrome stable
-  curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
-  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
-
-COPY scripts/nginx.list /etc/apt/sources.list.d/nginx.list
-
-RUN apt-get update && \ 
-  # node
-  apt-get install -y nodejs \
-  # webkit \
-  libwoff1 \
-  libopus0 \
-  libwebp6 \
-  libwebpdemux2 \
-  libenchant1c2a \
-  libgudev-1.0-0 \
-  libsecret-1-0 \
-  libhyphen0 \
-  libgdk-pixbuf2.0-0 \
-  libegl1 \
-  libnotify4 \
-  libxslt1.1 \
-  libevent-2.1-7 \
-  libgles2 \
-  libxcomposite1 \
-  libatk1.0-0 \
-  libatk-bridge2.0-0 \
-  libepoxy0 \
-  libgtk-3-0 \
-  libharfbuzz-icu0 \
-  # support video playback in WebKit
-  libgstreamer-gl1.0-0 \
-  libgstreamer-plugins-bad1.0-0 \
-  gstreamer1.0-plugins-good \
-  gstreamer1.0-libav \
-  # chrome
-  google-chrome-stable \
-  # chromium
-  libnss3 \
-  libxss1 \
-  libasound2 \
-  fonts-noto-color-emoji \
-  fonts-wqy-zenhei \
-  libxtst6 \
-  # firefox
-  libdbus-glib-1-2 \
-  libxt6 \
-  # nginx
-  gettext \
-  nginx \
-  # server
-  supervisor \
-  # vnc
-  novnc \
-  tigervnc-standalone-server \
-  # ffmpeg
-  ffmpeg \
-  # ssl
-  openssl && \
-  apt-get clean && \
-  apt-get autoclean
-
-# upgrade npm to support lockfile v2
-RUN npm i -g npm@7
 
 WORKDIR /opt/runner
 
 COPY package.json package-lock.json ./
 RUN npm i
 
-COPY tsconfig.json qawolf.recorder.js ./
+COPY tsconfig.json ./
+COPY qawolf.recorder.js ./
 COPY src/ src/
 
 RUN npm run build:tsc
@@ -90,17 +16,18 @@ RUN npm run build:tsc
 # under the user so it shows in the file shortcut
 COPY files/ /root/files
 COPY scripts/ scripts/
+COPY scripts/nginx.list /etc/apt/sources.list.d/nginx.list
 
 RUN chown -R node:node /opt/runner
 
 # need to set DEBUG=pw:api to capture verbose logs
-ENV DEBUG=pw:api*,qawolf* \
-  HOME=/root \
-  LANG=en_US.UTF-8 \
-  LANGUAGE=en_US.UTF-8 \
-  LC_ALL=C.UTF-8 \
-  QAWOLF_DISPLAY_WIDTH=1288 \
-  QAWOLF_DISPLAY_HEIGHT=804
+ENV DEBUG=pw:api*,qawolf*
+ENV HOME=/root
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV QAWOLF_DISPLAY_WIDTH=1288
+ENV QAWOLF_DISPLAY_HEIGHT=804
 
 EXPOSE 80
 EXPOSE 443

--- a/runner/Dockerfile.base
+++ b/runner/Dockerfile.base
@@ -1,0 +1,78 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="QA Wolf Inc. <hello@qawolf.com>"
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y curl gnupg2 gosu && \
+  # use latest nginx
+  curl http://nginx.org/keys/nginx_signing.key --output nginx_signing.key && apt-key add nginx_signing.key &&\
+  # use node 14
+  curl -sL https://deb.nodesource.com/setup_14.x | bash - &&\
+  # chrome stable
+  curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&\
+  echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+
+COPY scripts/nginx.list /etc/apt/sources.list.d/nginx.list
+
+RUN apt-get update && \ 
+  # node
+  apt-get install -y nodejs \
+  # webkit \
+  libwoff1 \
+  libopus0 \
+  libwebp6 \
+  libwebpdemux2 \
+  libenchant1c2a \
+  libgudev-1.0-0 \
+  libsecret-1-0 \
+  libhyphen0 \
+  libgdk-pixbuf2.0-0 \
+  libegl1 \
+  libnotify4 \
+  libxslt1.1 \
+  libevent-2.1-7 \
+  libgles2 \
+  libxcomposite1 \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libepoxy0 \
+  libgtk-3-0 \
+  libharfbuzz-icu0 \
+  # support video playback in WebKit
+  libgstreamer-gl1.0-0 \
+  libgstreamer-plugins-bad1.0-0 \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-libav \
+  # chrome
+  google-chrome-stable \
+  # chromium
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  fonts-noto-color-emoji \
+  fonts-wqy-zenhei \
+  libxtst6 \
+  # firefox
+  libdbus-glib-1-2 \
+  libxt6 \
+  # nginx
+  gettext \
+  nginx \
+  # server
+  supervisor \
+  # vnc
+  novnc \
+  tigervnc-standalone-server \
+  # ffmpeg
+  ffmpeg \
+  # ssl
+  openssl && \
+  apt-get clean && \
+  apt-get autoclean
+
+# upgrade npm to support lockfile v2
+RUN npm i -g npm@7

--- a/runner/scripts/entrypoint.sh
+++ b/runner/scripts/entrypoint.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+
 set -ex
 
-exec supervisord -c ./scripts/supervisord.conf
+# TODO: remove nginx so we can run this container as non-root.
+
+# # root user will be dropped to the 'node' user by default
+# if [[ "$1" == supervisord ]] && [ "$(id -u)" == '0' ]; then
+#   echo "Running process as 'node' user..."
+# 	gosu node "$@"
+# fi
+
+echo "Running process as user: $(whoami)"
+exec "$@"

--- a/runner/scripts/nginx.sh
+++ b/runner/scripts/nginx.sh
@@ -2,13 +2,13 @@
 
 if [[ -v QAWOLF_RUNNER_ID ]]
 then
-    . /scripts/ssl/nginx.sh
+    . /opt/runner/scripts/ssl/nginx.sh
 else
   echo "configure local nginx"
 
   # Replace DNS_SERVER and set up config
   export DNS_SERVER=$(cat /etc/resolv.conf |grep -i '^nameserver'|head -n1|cut -d ' ' -f2)
-  envsubst '${DNS_SERVER}' < /scripts/nginx.conf > /etc/nginx/nginx.conf
+  envsubst '${DNS_SERVER}' < /opt/runner/scripts/nginx.conf > /etc/nginx/nginx.conf
 fi
 
 # Start nginx with daemon off

--- a/runner/scripts/supervisord.conf
+++ b/runner/scripts/supervisord.conf
@@ -19,7 +19,7 @@ command=Xtigervnc -geometry 1288x804x24 -rfbauth /root/.vnc/passwd -rfbport 2637
 autorestart=true
 
 [program:node]
-command=node /dist/index.js
+command=node /opt/runner/dist/index.js
 autorestart=true
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
@@ -27,7 +27,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:nginx]
-command=bash /scripts/nginx.sh
+command=bash /opt/runner/scripts/nginx.sh
 autorestart=true
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0

--- a/wolf
+++ b/wolf
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -e
+
+
+showHelp() {
+  printf "\nUsage: \n\n ./wolf [OPTION] \n"
+  printf "\nOptions:\n
+  init      Install deps in all projects, build the runner container, and run app migrations
+  build     Build all containers (or specify a container to build with an additional argument)
+  dev       Start postgres and runner containers, then start app in dev mode
+  start     Run production builds in docker containers and tail logs app/runner logs
+  stop      Stop all running containers
+  clean     Clean up all containers, volumes, and node_modules (full reset)
+  "
+}
+
+# if no arg was provided, show help
+if [ -z "$1" ] || [ "$1" == "help" ]; then
+  showHelp
+  exit 1
+fi
+
+
+# confirm docker 
+if ! command -v docker &> /dev/null; then
+  printf "\nDocker must be installed!\n"
+  printf "More info: https://docs.docker.com/engine/install/\n\n"
+  exit 1
+fi
+
+# confirm node/npm
+if ! command -v npm &> /dev/null; then
+  printf "\nNode and npm must be installed!\n"
+  printf "More info: https://nodejs.org/en/download/\n\n"
+  exit 1
+fi
+
+# ensure a .env file exists for the app and docker-compose file
+ensureDotenv() {
+  if [ ! -f ./app/.env ]; then
+    printf "\nCreating .env file...\n\n"
+    cp ./app/.env.example ./app/.env
+  fi
+}
+
+
+# install deps in all projects, run migrations, and build the runner container
+if [[ $1 == "init" ]]; then
+  ensureDotenv
+
+  # postgres
+  printf "\nStarting postgres...\n\n"
+  docker-compose up -d postgres
+
+  # app
+  printf "\nInstalling node_modules for app...\n\n"
+  cd app
+  npm i
+  
+  # qawolf
+  printf "\nInstalling node_modules for qawolf...\n\n"
+  cd ../qawolf && npm i
+  
+  # recorder
+  printf "\nInstalling node_modules for recorder...\n\n"
+  cd ../recorder && npm i 
+
+  # runner
+  printf "\nInstalling node_modules for runner...\n\n"
+  cd ../runner && npm i 
+  printf "\nBuilding recorder script for runner container...\n\n"
+  npm run build:recorder-script
+  printf "\nBuilding runner image...\n\n"
+  docker-compose build runner
+  
+  # run migrations
+  printf "\nRunning migrations...\n\n"
+  cd ../app && npm run migrate:run:dev
+
+  exit 0
+fi
+
+
+# build all containers (or specify a container to build with an additional argument)
+if [[ $1 == "build" ]]; then  
+  # if we're rebuilding the runner container, 
+  # make sure to build the recorder script first
+  if [[ -z "$2" ]] || [[ "$2" == "runner" ]]; then
+    printf "\nBuilding recorder script for runner container...\n\n"
+    cd runner && npm run build:recorder-script
+  fi
+
+  printf "\nBuilding docker containers...\n\n"
+  docker-compose build $2
+  
+  exit 0
+fi
+
+
+# start postgres and runner containers, then start app in dev mode
+if [[ $1 == "dev" ]]; then
+  ensureDotenv
+  docker-compose stop app
+  docker-compose up -d postgres runner
+  cd app 
+  npm run dev
+  exit 0
+fi
+
+
+# run production builds in docker containers and tail logs
+if [[ $1 == "start" ]]; then
+  ensureDotenv
+  docker-compose up -d
+  docker-compose logs -f app runner
+  exit 0
+fi
+
+
+# kill all running containers
+if [[ $1 == "stop" ]]; then
+  docker-compose stop
+  exit 0
+fi
+
+
+# clean up all containers, volumes, and node_modules
+# this is essentially like a fresh checkout, except it preserves your ./app/.env
+if [[ $1 == "clean" ]]; then
+  printf "\nCleaning up docker containers...\n\n"
+  docker-compose stop
+  docker-compose rm -f
+
+  printf "\nCleaning up docker volumes...\n"
+  docker volume rm -f qawolf_pg-data
+  
+  printf "\nCleaning up node_modules in all projects...\n"
+  rm -rf ./{app,qawolf,recorder,runner}/node_modules
+  
+  printf "\nDone!"
+  exit 0
+fi
+
+
+# if the provided command arg didn't match any of the options above,
+# show the help message
+showHelp
+exit 1

--- a/wolf
+++ b/wolf
@@ -74,7 +74,7 @@ if [[ $1 == "init" ]]; then
   printf "\nBuilding recorder script for runner container...\n\n"
   npm run build:recorder-script
   printf "\nBuilding runner image...\n\n"
-  docker build -f Dockerfile.base -t qawolf/runner-base:$DOCKER_BASE_VERSION .
+  docker pull qawolf/runner-base:$DOCKER_BASE_VERSION
   docker-compose build runner
   
   # run migrations

--- a/wolf
+++ b/wolf
@@ -15,6 +15,8 @@ showHelp() {
   "
 }
 
+DOCKER_BASE_VERSION=1.0.0
+
 # if no arg was provided, show help
 if [ -z "$1" ] || [ "$1" == "help" ]; then
   showHelp
@@ -72,6 +74,7 @@ if [[ $1 == "init" ]]; then
   printf "\nBuilding recorder script for runner container...\n\n"
   npm run build:recorder-script
   printf "\nBuilding runner image...\n\n"
+  docker build -f Dockerfile.base -t qawolf/runner-base:$DOCKER_BASE_VERSION .
   docker-compose build runner
   
   # run migrations
@@ -89,6 +92,8 @@ if [[ $1 == "build" ]]; then
   if [[ -z "$2" ]] || [[ "$2" == "runner" ]]; then
     printf "\nBuilding recorder script for runner container...\n\n"
     cd runner && npm run build:recorder-script
+    printf "\nBuilding base image for runner container...\n\n"
+    docker build -f Dockerfile.base -t qawolf/runner-base:$DOCKER_BASE_VERSION .
   fi
 
   printf "\nBuilding docker containers...\n\n"


### PR DESCRIPTION
The updates/changes...

- Dockerize the NextJS app
- set a dedicated location for `WORKDIR` in the runner build so that files aren't all mixed in with root OS dirs in the container
- updated entrypoint script for the runner container
- created a bash CLI script for most common dev env tasks

## How-to

Since the script help message is fairly self explanatory, here's the summary...

```
./wolf help


Usage:

 ./wolf [OPTION]

Options:

  init      Install deps in all projects, build the runner container, and run app migrations
  build     Build all containers (or specify a container to build with an additional argument)
  dev       Start postgres and runner containers, then start app in dev mode
  start     Run production builds in docker containers and tail logs app/runner logs
  stop      Stop all running containers
  clean     Clean up all containers, volumes, and node_modules (full reset)
```

## To Test

```sh
git clone  -b jer-dev-scripts --single-branch git@github.com:qawolf/qawolf.git dev-script-test
cd dev-script-test

# install all deps, create a .env, start postgres, and run migrations
./wolf init

# start postgres and runner, start app in dev mode
./wolf dev

# start postgres, runner, and app in containers in production mode
./wolf start

# stop all running containers
./wolf stop

# stop all running containers, delete docker volumes, delete all node_modules
# repo should be back to the same state as a fresh checkout (except your .env stays intact)
./wolf clean
```

Also note that `./wolf init` is pretty handy for any time you do a `git pull`.  It's a nice quick way to make sure all of your dependencies are up to date and the local runner image is a fresh build.

Let me know what you think!  Any feedback welcome.
