### PR TITLE
fix: NOT IN issue setting test to pending

### DIFF
--- a/app/server/models/test.ts
+++ b/app/server/models/test.ts
@@ -421,7 +421,7 @@ export const updateTestToPending = async (
   SET runner_locations = ?, runner_requested_at = now(), runner_requested_branch = ?
   WHERE id = ? 
     AND runner_requested_at IS NULL 
-    AND id NOT IN (SELECT test_id FROM runners)`;
+    AND (id IN (SELECT test_id FROM runners)) IS NOT TRUE`;
 
   const result = await db.raw(sql, [
     runner_locations,

--- a/app/test/server/models/test.test.ts
+++ b/app/test/server/models/test.test.ts
@@ -416,6 +416,11 @@ describe("pending tests", () => {
     ]);
 
     await db("runners").insert(buildRunner({ test_id: "testId" }));
+    
+    // There was a bug causing update to pending to fail if any
+    // runner has `test_id: null`. Keep this here to ensure it
+    // does not reappear.
+    await db("runners").insert(buildRunner({ i: 2 }));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Issue
The `NOT IN (SELECT test_id FROM runners)` clause does not work as expected when some of the records have a null `test_id`.

There are numerous SOs about this such as https://stackoverflow.com/questions/19517899/not-in-in-postgresql-not-working

The effect of this bug for me locally was that `app` would repeatedly log the `skipped` message when attempting `updateTestToPending` and the test editor would spin indefinitely. It's unclear whether this ever happens in the prod setup.

## Solution
Update to `(id IN (SELECT test_id FROM runners)) IS NOT TRUE`, which handles it being either FALSE or NULL.