### PR TITLE
Fix URL validation

### DIFF
--- a/app/components/Modals/CreateTest.tsx
+++ b/app/components/Modals/CreateTest.tsx
@@ -39,6 +39,7 @@ export default function CreateTest({ closeModal }: Props): JSX.Element {
   };
 
   const handleCreate = (): void => {
+    if (isLoading) return;
     setIsLoading(true);
 
     if (!url) {

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -102,9 +102,15 @@ export const formatTimestamp = (timestamp: string): string => {
 
 export const isValidURL = (url: string): boolean => {
   try {
-    const parsed = new URL(url).href;
+    const parsed = new URL(url);
+
+    if (!["https:", "http:"].includes(parsed.protocol)) {
+      return false;
+    }
     // https://stackoverflow.com/a/49185442
-    return /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/.test(parsed);
+    return /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/.test(
+      parsed.href
+    );
   } catch (error) {
     return false;
   }

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -108,6 +108,7 @@ export const isValidURL = (url: string): boolean => {
       return false;
     }
     // https://stackoverflow.com/a/49185442
+    // eslint-disable-next-line no-useless-escape
     return /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/.test(
       parsed.href
     );

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -102,9 +102,9 @@ export const formatTimestamp = (timestamp: string): string => {
 
 export const isValidURL = (url: string): boolean => {
   try {
-    const parsed = new URL(url);
-
-    return ["https:", "http:"].includes(parsed.protocol);
+    const parsed = new URL(url).href;
+    // https://stackoverflow.com/a/49185442
+    return /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/.test(parsed);
   } catch (error) {
     return false;
   }

--- a/app/test/lib/helpers.test.ts
+++ b/app/test/lib/helpers.test.ts
@@ -67,6 +67,7 @@ describe("isValidURL", () => {
     expect(isValidURL("javascript:void(0)")).toBe(false);
     expect(isValidURL("www.example.com")).toBe(false);
     expect(isValidURL("https://login")).toBe(false);
+    expect(isValidURL("wss://www.example.com/socketserver")).toBe(false);
   });
 });
 

--- a/app/test/lib/helpers.test.ts
+++ b/app/test/lib/helpers.test.ts
@@ -66,6 +66,7 @@ describe("isValidURL", () => {
     expect(isValidURL("invalid")).toBe(false);
     expect(isValidURL("javascript:void(0)")).toBe(false);
     expect(isValidURL("www.example.com")).toBe(false);
+    expect(isValidURL("https://login")).toBe(false);
   });
 });
 


### PR DESCRIPTION
* before, URLs like `login` were considered valid. now they are not