### PR TITLE
Prefer input name attribute over type attribute

### DIFF
--- a/recorder/src/getCues.ts
+++ b/recorder/src/getCues.ts
@@ -37,7 +37,8 @@ const PENALTY_MAP = {
   tagnth: 31,
   text: 10,
   title: 10,
-  type: 10,
+  // `name` should be preferred over `type` for inputs, but `type` is better than `tag`
+  type: 14,
   value: 10,
   // prefer not to use it but sometimes we need to
   visible: 100,

--- a/recorder/src/isDynamic.ts
+++ b/recorder/src/isDynamic.ts
@@ -80,7 +80,9 @@ export const isDynamic = (value: string): boolean => {
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
 
-    if (allWords.has(token)) {
+    // This double word check is to prevent the "mark letter and number combinations as dynamic"
+    // check from catching a valid word followed by a single number, such as `address1` or `phone1`
+    if (allWords.has(token) || allWords.has(token.substr(0, token.length - 1))) {
       words += 1;
     } else if (!isNaN(Number(token))) {
       numbers += 1;

--- a/recorder/test/generateSelectors.test.ts
+++ b/recorder/test/generateSelectors.test.ts
@@ -29,7 +29,7 @@ describe("generateSelectors", () => {
         const qawolf: QAWolfWeb = (window as any).qawolf;
 
         const generator = qawolf.generateSelectors(element as HTMLElement, 0);
-        for (let value of generator) {
+        for (const value of generator) {
           result.push(value);
           if (result.length >= limit) break;
         }
@@ -97,16 +97,19 @@ describe("getSelector", () => {
       await expectSelector("x-child-element", expected);
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it("targets the better selector on the descendant despite having likely ancestor", async () => {
       await setBody(page, '<a><div><img id="child"></div></a>');
       await expectSelector("img", "#child");
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it("targets the iframe always despite having likely ancestor", async () => {
       await setBody(page, "<a><iframe></iframe><a>");
       await expectSelector("iframe", "iframe");
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it("targets a contenteditable/input/textarea despite having a likely ancestor", async () => {
       await setBody(page, '<a><div contenteditable="true"></div></a>');
       await expectSelector(
@@ -121,6 +124,7 @@ describe("getSelector", () => {
       await expectSelector("textarea", "textarea");
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it("uses ancestor cues when required", async () => {
       await setBody(page, `<li><input></li><li><input></li>`);
       await expectSelector("li:nth-of-type(2) input");
@@ -128,11 +132,13 @@ describe("getSelector", () => {
   });
 
   describe("descendant cues", () => {
+    // eslint-disable-next-line jest/expect-expect
     it("does not pick a descendant across a click boundary", async () => {
       await setBody(page, `<div><button data-qa="hello">hello</button></div>`);
       await expectSelector("div");
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it("picks a descendant with a better selector", async () => {
       await setBody(
         page,
@@ -142,11 +148,13 @@ describe("getSelector", () => {
     });
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it("escapes special characters", async () => {
     await setBody(page, `<div id="special:id"></div>`);
     await expectSelector("#special\\:id");
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it("includes :visible modifier when needed", async () => {
     // make the visible element untargetable by nth-of-type
     await setBody(
@@ -189,6 +197,7 @@ describe("getSelector", () => {
     expect(result2).toEqual("input");
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it("short circuits to html and body", async () => {
     await page.evaluate(() => {
       document.querySelector("html").setAttribute("data-qa", "main");
@@ -199,6 +208,7 @@ describe("getSelector", () => {
     await expectSelector("body");
   });
 
+  // eslint-disable-next-line jest/expect-expect
   it("targets label and checkbox input", async () => {
     await setBody(
       page,
@@ -208,7 +218,27 @@ describe("getSelector", () => {
     await expectSelector('[value="dog"]', "#dog");
   });
 
+  // eslint-disable-next-line jest/expect-expect
+  it("always prefers input name over type attribute", async () => {
+    await setBody(
+      page,
+      `<input type="text" class="form-control" name="first_name" value="">
+       <input type="text" class="form-control" name="last_name" value="">
+       <input type="tel" class="form-control" name="phone1" value="">
+       <input type="tel" class="form-control" name="phone2" value="">
+       <input type="email" class="form-control" name="email1" value="">
+       <input type="email" class="form-control" name="email2" value="">`
+    );
+    await expectSelector('[name="first_name"]');
+    await expectSelector('[name="last_name"]');
+    await expectSelector('[name="phone1"]');
+    await expectSelector('[name="phone2"]');
+    await expectSelector('[name="email1"]');
+    await expectSelector('[name="email2"]');
+  });
+
   describe("test attributes", () => {
+    // eslint-disable-next-line jest/expect-expect
     it("includes ancestor test attributes", async () => {
       await setBody(
         page,
@@ -218,6 +248,7 @@ describe("getSelector", () => {
       await expectSelector('[data-qa="my-radio-group"] [value="cat"]');
     });
 
+    // eslint-disable-next-line jest/expect-expect
     it("prefers test attributes", async () => {
       await setBody(page, `<button data-qa="html-button">Submit</button>`);
       await expectSelector('[data-qa="html-button"]');

--- a/recorder/test/isDynamic.test.ts
+++ b/recorder/test/isDynamic.test.ts
@@ -88,6 +88,7 @@ describe("isDynamic", () => {
     "svg",
     "toggle",
     "tnt__zipInput",
+    "address1"
   ])("is not dynamic: %s", (example) => {
     expect(isDynamic(example)).toBe(false);
   });


### PR DESCRIPTION
Fixes #1331 

Primary fix: When choosing a selector for an input, the `name` attribute will be preferred over the `type` attribute.

Secondary fix: To ensure `name` is used for common fields like `address1` or `phone1`, a valid word followed by a single number is no longer considered to be dynamic, and thus is not ignored as a possible good selector.