### PR TITLE
Support element choosing on multiple tabs and iframes

### DIFF
--- a/app/components/Editor/Sidebar/Snippet/Action.tsx
+++ b/app/components/Editor/Sidebar/Snippet/Action.tsx
@@ -2,8 +2,9 @@ import { Box } from "grommet";
 
 import { copy } from "../../../../theme/copy";
 import Text from "../../../shared/Text";
-import { ActionType, buildActionOptions, labelProps } from "./helpers";
+import { ActionType, buildActionOptions } from "./helpers";
 import Select from "./Select";
+import { labelProps } from "./styleHelpers";
 
 type Props = {
   hasText: boolean;

--- a/app/components/Editor/Sidebar/Snippet/ChooseElement.tsx
+++ b/app/components/Editor/Sidebar/Snippet/ChooseElement.tsx
@@ -3,7 +3,7 @@ import { Box } from "grommet";
 import { copy } from "../../../../theme/copy";
 import BrowserElement from "../../../shared/icons/BrowserElement";
 import Text from "../../../shared/Text";
-import { labelProps } from "./helpers";
+import { labelProps } from "./styleHelpers";
 
 export default function ChooseElement(): JSX.Element {
   return (

--- a/app/components/Editor/Sidebar/Snippet/Selector.tsx
+++ b/app/components/Editor/Sidebar/Snippet/Selector.tsx
@@ -3,8 +3,8 @@ import { useEffect } from "react";
 
 import { copy } from "../../../../theme/copy";
 import Text from "../../../shared/Text";
-import { labelProps } from "./helpers";
 import Select from "./Select";
+import { labelProps } from "./styleHelpers";
 
 type Props = {
   onSelectOption: (option: string) => void;

--- a/app/components/Editor/Sidebar/Snippet/helpers.ts
+++ b/app/components/Editor/Sidebar/Snippet/helpers.ts
@@ -1,5 +1,3 @@
-import { edgeSize } from "../../../../theme/theme";
-
 const ClickActions = [
   "Assert element",
   "Assert element text",
@@ -100,10 +98,4 @@ export const formatArgument = (value: string | null): string => {
   if (!escaped.includes(`'`)) return `'${escaped}'`;
 
   return "`" + escaped.replace(/`/g, "\\`") + "`";
-};
-
-export const labelProps = {
-  color: "gray0",
-  margin: { bottom: edgeSize.xxsmall },
-  size: "componentBold" as const,
 };

--- a/app/components/Editor/Sidebar/Snippet/helpers.ts
+++ b/app/components/Editor/Sidebar/Snippet/helpers.ts
@@ -43,42 +43,43 @@ export const buildActionOptions = (
 export const buildCode = (
   action: ActionType,
   selector: string,
-  text: string
+  text: string,
+  variable = "page"
 ): string => {
   if (action === "Assert element") {
-    return `await assertElement(page, ${formatArgument(selector)});`;
+    return `await assertElement(${variable}, ${formatArgument(selector)});`;
   }
 
   if (action === "Assert element text") {
-    return `await assertText(page, ${formatArgument(
+    return `await assertText(${variable}, ${formatArgument(
       text
     )}, { selector: ${formatArgument(selector)} });`;
   }
 
   if (action === "Assert page text") {
-    return `await assertText(page, ${formatArgument(text)});`;
+    return `await assertText(${variable}, ${formatArgument(text)});`;
   }
 
   const selectorArgument = formatArgument(selector);
 
-  if (action === "Click") return `await page.click(${selectorArgument});`;
+  if (action === "Click") return `await ${variable}.click(${selectorArgument});`;
 
   if (action === "Fill") {
-    return `await page.fill(${selectorArgument}, ${formatArgument(text)});`;
+    return `await ${variable}.fill(${selectorArgument}, ${formatArgument(text)});`;
   }
 
   if (action === "Fill test email") {
-    return `const { email, waitForMessage } = getInbox();\nawait page.fill(${selectorArgument}, email);\n// send the email then wait for the message\n// const message = await waitForMessage();`;
+    return `const { email, waitForMessage } = getInbox();\nawait ${variable}.fill(${selectorArgument}, email);\n// send the email then wait for the message\n// const message = await waitForMessage();`;
   }
 
   if (action === "Get element value") {
-    return `var value = await getValue(page, ${formatArgument(selector)});`;
+    return `var value = await getValue(${variable}, ${formatArgument(selector)});`;
   }
 
-  if (action === "Hover") return `await page.hover(${selectorArgument});`;
+  if (action === "Hover") return `await ${variable}.hover(${selectorArgument});`;
 
   if (action === "Upload image") {
-    return `page.once('filechooser', (chooser) => chooser.setFiles('/root/files/avatar.png'));\nawait page.click(${selectorArgument});`;
+    return `${variable}.once('filechooser', (chooser) => chooser.setFiles('/root/files/avatar.png'));\nawait ${variable}.click(${selectorArgument});`;
   }
 
   return "";

--- a/app/components/Editor/Sidebar/Snippet/index.tsx
+++ b/app/components/Editor/Sidebar/Snippet/index.tsx
@@ -26,26 +26,21 @@ export default function Snippet({ isVisible }: Props): JSX.Element {
 
   const hasChosenElement = !!elementChooserValue.selectors;
 
-  const snippetCode = buildCode(
+  let snippetCode = buildCode(
     action,
     selector,
     elementChooserValue?.text || "",
     elementChooserValue?.variable
   );
 
+  if (typeof elementChooserValue?.initializeCode === 'string' && elementChooserValue?.initializeCode.length > 0) {
+    snippetCode = elementChooserValue?.initializeCode + snippetCode;
+  }
+
   const addRunSnippet = () => {
     if (!hasChosenElement || !testModel) return;
 
-    // Combine initialize code with snippet. We don't show
-    // init code in the snippet box but we do insert it.
-    let codeToInsert: string | undefined;
-    if (typeof elementChooserValue?.initializeCode === 'string' && elementChooserValue?.initializeCode.length > 0) {
-      codeToInsert = elementChooserValue?.initializeCode + snippetCode;
-    } else {
-      codeToInsert = snippetCode;
-    }
-
-    const selection = insertSnippet(testModel, codeToInsert);
+    const selection = insertSnippet(testModel, snippetCode);
 
     // this will enable code generation so make sure to call it before
     // run test which will disable code generation

--- a/app/components/Editor/Sidebar/Snippet/index.tsx
+++ b/app/components/Editor/Sidebar/Snippet/index.tsx
@@ -29,7 +29,8 @@ export default function Snippet({ isVisible }: Props): JSX.Element {
   const snippetCode = buildCode(
     action,
     selector,
-    elementChooserValue?.text || ""
+    elementChooserValue?.text || "",
+    elementChooserValue?.variable
   );
 
   const addRunSnippet = () => {

--- a/app/components/Editor/Sidebar/Snippet/index.tsx
+++ b/app/components/Editor/Sidebar/Snippet/index.tsx
@@ -36,7 +36,16 @@ export default function Snippet({ isVisible }: Props): JSX.Element {
   const addRunSnippet = () => {
     if (!hasChosenElement || !testModel) return;
 
-    const selection = insertSnippet(testModel, snippetCode);
+    // Combine initialize code with snippet. We don't show
+    // init code in the snippet box but we do insert it.
+    let codeToInsert: string | undefined;
+    if (typeof elementChooserValue?.initializeCode === 'string' && elementChooserValue?.initializeCode.length > 0) {
+      codeToInsert = elementChooserValue?.initializeCode + snippetCode;
+    } else {
+      codeToInsert = snippetCode;
+    }
+
+    const selection = insertSnippet(testModel, codeToInsert);
 
     // this will enable code generation so make sure to call it before
     // run test which will disable code generation

--- a/app/components/Editor/Sidebar/Snippet/styleHelpers.ts
+++ b/app/components/Editor/Sidebar/Snippet/styleHelpers.ts
@@ -1,0 +1,7 @@
+import { edgeSize } from "../../../../theme/theme";
+
+export const labelProps = {
+  color: "gray0",
+  margin: { bottom: edgeSize.xxsmall },
+  size: "componentBold" as const,
+};

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -298,6 +298,7 @@ export interface ElementChooserValue {
   isFillable?: boolean;
   selectors?: string[];
   text?: string;
+  variable?: string;
 }
 
 export type Log = {

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -294,6 +294,7 @@ export type Wolf = {
 
 // Runner Types
 export interface ElementChooserValue {
+  initializeCode?: string;
   isActive: boolean;
   isFillable?: boolean;
   selectors?: string[];

--- a/app/test/lib/buildCode.test.ts
+++ b/app/test/lib/buildCode.test.ts
@@ -1,0 +1,65 @@
+import { buildCode } from "../../components/Editor/Sidebar/Snippet/helpers";
+
+it("assertElement", () => {
+  expect(buildCode("Assert element", ".selector", "text")).toBe(
+    "await assertElement(page, \".selector\");"
+  )
+});
+
+it("assertText - element", () => {
+  expect(buildCode("Assert element text", ".selector", "text")).toBe(
+    "await assertText(page, \"text\", { selector: \".selector\" });"
+  )
+});
+
+it("assertText - page", () => {
+  expect(buildCode("Assert page text", ".selector", "text")).toBe(
+    "await assertText(page, \"text\");"
+  )
+});
+
+it("click", () => {
+  expect(buildCode("Click", ".selector", "text")).toBe(
+    "await page.click(\".selector\");"
+  )
+});
+
+it("fill", () => {
+  expect(buildCode("Fill", ".selector", "text")).toBe(
+    "await page.fill(\".selector\", \"text\");"
+  )
+});
+
+it("fill test email", () => {
+  expect(buildCode("Fill test email", ".selector", "text")).toBe(
+    `const { email, waitForMessage } = getInbox();
+await page.fill(".selector", email);
+// send the email then wait for the message
+// const message = await waitForMessage();`
+  )
+});
+
+it("get element value", () => {
+  expect(buildCode("Get element value", ".selector", "text")).toBe(
+    "var value = await getValue(page, \".selector\");"
+  )
+});
+
+it("hover", () => {
+  expect(buildCode("Hover", ".selector", "text")).toBe(
+    "await page.hover(\".selector\");"
+  )
+});
+
+it("upload image", () => {
+  expect(buildCode("Upload image", ".selector", "text")).toBe(
+    `page.once('filechooser', (chooser) => chooser.setFiles('/root/files/avatar.png'));
+await page.click(".selector");`
+  )
+});
+
+it("alternative variable", () => {
+  expect(buildCode("Click", ".selector", "text", "page2")).toBe(
+    "await page2.click(\".selector\");"
+  )
+});

--- a/runner/src/code/ContextEventCollector.ts
+++ b/runner/src/code/ContextEventCollector.ts
@@ -9,8 +9,8 @@ import {
 } from "playwright";
 import { Protocol } from "playwright/types/protocol";
 
-import { buildFrameSelector } from '../playwright'
 import { forEachPage } from "../environment/forEach";
+import { buildFrameSelector } from '../playwright'
 import { ElementEvent, WindowAction, WindowEvent } from "../types";
 
 const debug = Debug("qawolf:ContextEventCollector");

--- a/runner/src/code/ContextEventCollector.ts
+++ b/runner/src/code/ContextEventCollector.ts
@@ -9,6 +9,7 @@ import {
 } from "playwright";
 import { Protocol } from "playwright/types/protocol";
 
+import { buildFrameSelector } from '../playwright'
 import { forEachPage } from "../environment/forEach";
 import { ElementEvent, WindowAction, WindowEvent } from "../types";
 
@@ -46,44 +47,13 @@ export class ContextEventCollector extends EventEmitter {
     this._context = context;
   }
 
-  async _buildFrameSelector(frame: Frame): Promise<string | null> {
-    // only build the frame selector if it is one frame down from the parent
-    // skip building the frame for the main frame and nested frames
-    const parentFrame = frame.parentFrame();
-    if (!parentFrame || parentFrame.parentFrame()) return null;
-
-    const name = frame.name();
-
-    const fallbackSelector = name
-      ? `[name="${name}"]`
-      : `[url="${frame.url()}"`;
-
-    try {
-      const frameElement = await frame.frameElement();
-      const selector = await parentFrame.evaluate(
-        ({ frameElement }) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const qawolf: any = (window as any).qawolf;
-          return qawolf.getSelector(frameElement);
-        },
-        { frameElement }
-      );
-      return selector || fallbackSelector;
-    } catch (error) {
-      // Due to timing, there's a possibility that `frameElement()`
-      // throws due to the frame's parent having been closed/disposed.
-    }
-
-    return fallbackSelector;
-  }
-
   async _create(): Promise<void> {
     await this._context.exposeBinding(
       "qawElementAction",
       async ({ frame, page }: BindingOptions, elementEvent: ElementEvent) => {
         const event: ElementEvent = { ...elementEvent, page };
 
-        const frameSelector = await this._buildFrameSelector(frame);
+        const frameSelector = await buildFrameSelector(frame);
         if (frameSelector) {
           event.frame = frame;
           event.frameSelector = frameSelector;

--- a/runner/src/code/formatArgument.ts
+++ b/runner/src/code/formatArgument.ts
@@ -1,0 +1,15 @@
+export const formatArgument = (value: string | null): string => {
+  if (value === null) return '""';
+
+  // serialize newlines etc
+  let escaped = JSON.stringify(value);
+  // remove wrapper quotes
+  escaped = escaped.substring(1, escaped.length - 1);
+  // allow unescaped quotes
+  escaped = escaped.replace(/\\"/g, '"');
+
+  if (!escaped.includes(`"`)) return `"${escaped}"`;
+  if (!escaped.includes(`'`)) return `'${escaped}'`;
+
+  return "`" + escaped.replace(/`/g, "\\`") + "`";
+};

--- a/runner/src/code/insertEvent.ts
+++ b/runner/src/code/insertEvent.ts
@@ -1,31 +1,11 @@
-import { Frame, Page } from "playwright";
-
-import { ElementEvent, TextOperation, Variables, WindowEvent } from "../types";
-import { ActionExpression } from "./parseCode";
+import { ElementEvent, TextOperation, WindowEvent } from "../types";
+import { formatArgument } from "./formatArgument";
 import { insertBeforeHandle } from "./patchUtils";
-
-type PrepareSourceVariable = {
-  declare?: boolean;
-  pageOrFrame: Frame | Page;
-  variables: Variables;
-};
-
-export type PrepareSourceVariables = {
-  declare?: boolean;
-  expressions: (ActionExpression | null)[];
-  event: ElementEvent | WindowEvent;
-  variables: Variables;
-};
+import { PrepareSourceVariables,prepareSourceVariables } from './prepareSourceVariables';
 
 export type PatchEventOptions = PrepareSourceVariables & {
   code: string;
-};
-
-export type SourceVariables = {
-  pageVariable: string;
-  frameVariable?: string;
-  initializeCode: string;
-  variable: string;
+  event: ElementEvent | WindowEvent
 };
 
 export const buildEventCode = (
@@ -47,134 +27,17 @@ export const buildEventCode = (
   return line;
 };
 
-export const findLastPageVariable = (
-  expressions: (ActionExpression | null)[],
-  variables: Variables
-): string | null => {
-  for (let i = expressions.length - 1; i >= 0; i--) {
-    // find the last page
-    const variable = expressions[i]?.variable;
-    if (!variable) continue;
-
-    const maybePage = variables[variable] as Page | undefined;
-    // it is a page if it has bringToFront
-    if (maybePage?.bringToFront) return variable;
-  }
-
-  return null;
-};
-
-export const prepareSourceVariable = ({
-  declare,
-  pageOrFrame,
-  variables,
-}: PrepareSourceVariable): string => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const prefix = (pageOrFrame as any).bringToFront ? "page" : "frame";
-
-  let index = 1;
-  let key: string;
-
-  do {
-    key = `${prefix}${index === 1 ? "" : index}`;
-    index += 1;
-  } while (Object.keys(variables).includes(key));
-
-  if (declare) {
-    // store it to prevent re-declaring it for future actions during code gen
-    variables[key] = pageOrFrame;
-  }
-
-  return key;
-};
-
-export const prepareSourceVariables = ({
-  declare,
-  event,
-  expressions,
-  variables,
-}: PrepareSourceVariables): SourceVariables => {
-  let pageVariable = Object.keys(variables).find(
-    (name) => variables[name] === event.page
-  );
-
-  let initializeCode = "";
-
-  if (!pageVariable && event.action === "goto") {
-    pageVariable = prepareSourceVariable({
-      declare,
-      pageOrFrame: event.page,
-      variables,
-    });
-    initializeCode = `const ${pageVariable} = await context.newPage();\n`;
-  } else if (!pageVariable) {
-    throw new Error("No matching page found");
-  }
-
-  let frameVariable: string | undefined = undefined;
-
-  const elementEvent = event as ElementEvent;
-  if (elementEvent.frameSelector) {
-    if (!elementEvent.frame) throw new Error("No frame provided");
-
-    frameVariable = Object.keys(variables).find(
-      (name) => variables[name] === elementEvent.frame
-    );
-
-    if (!frameVariable) {
-      frameVariable = prepareSourceVariable({
-        declare,
-        pageOrFrame: elementEvent.frame,
-        variables,
-      });
-
-      const selector = formatArgument(elementEvent.frameSelector);
-      initializeCode = `const ${frameVariable} = await (await ${pageVariable}.waitForSelector(${selector})).contentFrame();\n`;
-    }
-  }
-
-  // if the page changed, bring the page to front
-  const lastPageVariable = findLastPageVariable(expressions, variables);
-  if (
-    lastPageVariable &&
-    lastPageVariable !== pageVariable &&
-    !["goto", "popup"].includes(event.action)
-  ) {
-    initializeCode = `await ${pageVariable}.bringToFront();\n` + initializeCode;
-  }
-
-  return {
-    frameVariable,
-    pageVariable,
-    initializeCode,
-    variable: frameVariable || pageVariable,
-  };
-};
-
-export const formatArgument = (value: string | null): string => {
-  if (value === null) return '""';
-
-  // serialize newlines etc
-  let escaped = JSON.stringify(value);
-  // remove wrapper quotes
-  escaped = escaped.substring(1, escaped.length - 1);
-  // allow unescaped quotes
-  escaped = escaped.replace(/\\"/g, '"');
-
-  if (!escaped.includes(`"`)) return `"${escaped}"`;
-  if (!escaped.includes(`'`)) return `'${escaped}'`;
-
-  return "`" + escaped.replace(/`/g, "\\`") + "`";
-};
-
 export const insertEvent = (options: PatchEventOptions): TextOperation[] => {
+  const { event } = options;
   const { initializeCode, variable } = prepareSourceVariables({
     ...options,
+    shouldBringPageToFront: event.action !== "goto",
     // we will patch the initialize code so we want to declare the variable
     // to prevent it from needing reinitialization on future events
+    shouldDeclarePageVariable: event.action === "goto",
     declare: true,
   });
 
-  const eventCode = buildEventCode(options.event, variable);
+  const eventCode = buildEventCode(event, variable);
   return insertBeforeHandle(options.code, `${initializeCode}${eventCode}\n`);
 };

--- a/runner/src/code/patchCheckOrUncheck.ts
+++ b/runner/src/code/patchCheckOrUncheck.ts
@@ -3,14 +3,17 @@ import {
   buildEventCode,
   insertEvent,
   PatchEventOptions,
-  prepareSourceVariables,
 } from "./insertEvent";
 import { ActionExpression } from "./parseCode";
+import { prepareSourceVariables } from "./prepareSourceVariables";
 
 export const patchCheckOrUncheck = (
   options: PatchEventOptions
 ): TextOperation[] => {
-  const { initializeCode, variable } = prepareSourceVariables(options);
+  const { initializeCode, variable } = prepareSourceVariables({
+    ...options,
+    shouldBringPageToFront: true
+  });
   if (initializeCode) return insertEvent(options);
 
   const { code, expressions, event } = options;

--- a/runner/src/code/patchFillOrSelectOption.ts
+++ b/runner/src/code/patchFillOrSelectOption.ts
@@ -1,16 +1,19 @@
 import { ElementEvent, TextOperation } from "../types";
+import { formatArgument } from "./formatArgument";
 import {
-  formatArgument,
   insertEvent,
   PatchEventOptions,
-  prepareSourceVariables,
 } from "./insertEvent";
 import { ActionExpression } from "./parseCode";
+import { prepareSourceVariables } from "./prepareSourceVariables";
 
 export const findExpressionToUpdate = (
   options: PatchEventOptions
 ): ActionExpression | null => {
-  const { initializeCode, variable } = prepareSourceVariables(options);
+  const { initializeCode, variable } = prepareSourceVariables({
+    ...options,
+    shouldBringPageToFront: true
+  });
   if (initializeCode) return null;
 
   const { expressions, event } = options;

--- a/runner/src/code/patchPopup.ts
+++ b/runner/src/code/patchPopup.ts
@@ -1,7 +1,8 @@
 import { TextOperation, WindowEvent } from "../types";
-import { PatchEventOptions, prepareSourceVariables } from "./insertEvent";
+import { PatchEventOptions } from "./insertEvent";
 import { selectAwaitChildExpression } from "./parseCode";
 import { insertBeforeHandle } from "./patchUtils";
+import { prepareSourceVariables } from "./prepareSourceVariables";
 
 export const patchPopup = (options: PatchEventOptions): TextOperation[] => {
   const { pageVariable } = prepareSourceVariables(options);

--- a/runner/src/code/patchReload.ts
+++ b/runner/src/code/patchReload.ts
@@ -2,12 +2,15 @@ import { TextOperation } from "../types";
 import {
   insertEvent,
   PatchEventOptions,
-  prepareSourceVariables,
 } from "./insertEvent";
+import { prepareSourceVariables } from "./prepareSourceVariables";
 
 export const patchReload = (options: PatchEventOptions): TextOperation[] => {
   const { expressions } = options;
-  const { variable } = prepareSourceVariables(options);
+  const { variable } = prepareSourceVariables({
+    ...options,
+    shouldBringPageToFront: true
+  });
 
   const lastExpression = expressions[expressions.length - 1];
 

--- a/runner/src/code/prepareSourceVariables.ts
+++ b/runner/src/code/prepareSourceVariables.ts
@@ -1,0 +1,130 @@
+import { Frame, Page } from "playwright";
+
+import { PlaywrightEvent,Variables } from "../types";
+import { formatArgument } from "./formatArgument";
+import { ActionExpression } from "./parseCode";
+
+export type SourceVariables = {
+  pageVariable: string;
+  frameVariable?: string;
+  initializeCode: string;
+  variable: string;
+};
+
+export type PrepareSourceVariables = {
+  declare?: boolean;
+  expressions: (ActionExpression | null)[];
+  event: PlaywrightEvent;
+  shouldBringPageToFront?: boolean;
+  shouldDeclarePageVariable?: boolean;
+  variables: Variables;
+};
+
+export type PrepareSourceVariable = {
+  declare?: boolean;
+  pageOrFrame: Frame | Page;
+  variables: Variables;
+};
+
+export const findLastPageVariable = (
+  expressions: (ActionExpression | null)[],
+  variables: Variables
+): string | null => {
+  for (let i = expressions.length - 1; i >= 0; i--) {
+    // find the last page
+    const variable = expressions[i]?.variable;
+    if (!variable) continue;
+
+    const maybePage = variables[variable] as Page | undefined;
+    // it is a page if it has bringToFront
+    if (maybePage?.bringToFront) return variable;
+  }
+
+  return null;
+};
+
+export const prepareSourceVariable = ({
+  declare,
+  pageOrFrame,
+  variables,
+}: PrepareSourceVariable): string => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prefix = (pageOrFrame as any).bringToFront ? "page" : "frame";
+
+  let index = 1;
+  let key: string;
+
+  do {
+    key = `${prefix}${index === 1 ? "" : index}`;
+    index += 1;
+  } while (Object.keys(variables).includes(key));
+
+  if (declare) {
+    // store it to prevent re-declaring it for future actions during code gen
+    variables[key] = pageOrFrame;
+  }
+
+  return key;
+};
+
+export const prepareSourceVariables = ({
+  declare = false,
+  event,
+  expressions,
+  shouldBringPageToFront = false,
+  shouldDeclarePageVariable = false,
+  variables,
+}: PrepareSourceVariables): SourceVariables => {
+  let pageVariable = Object.keys(variables).find(
+    (name) => variables[name] === event.page
+  );
+
+  let initializeCode = "";
+
+  if (!pageVariable && shouldDeclarePageVariable) {
+    pageVariable = prepareSourceVariable({
+      declare,
+      pageOrFrame: event.page,
+      variables,
+    });
+    initializeCode = `const ${pageVariable} = await context.newPage();\n`;
+  } else if (!pageVariable) {
+    throw new Error("No matching page found");
+  }
+
+  let frameVariable: string | undefined = undefined;
+
+  if (event.frameSelector) {
+    if (!event.frame) throw new Error("No frame provided");
+
+    frameVariable = Object.keys(variables).find(
+      (name) => variables[name] === event.frame
+    );
+
+    if (!frameVariable) {
+      frameVariable = prepareSourceVariable({
+        declare,
+        pageOrFrame: event.frame,
+        variables,
+      });
+
+      const selector = formatArgument(event.frameSelector);
+      initializeCode = `const ${frameVariable} = await (await ${pageVariable}.waitForSelector(${selector})).contentFrame();\n`;
+    }
+  }
+
+  // if the page changed, bring the page to front
+  if (shouldBringPageToFront) {
+    const lastPageVariable = findLastPageVariable(expressions, variables);
+    if (lastPageVariable && lastPageVariable !== pageVariable) {
+      initializeCode = `await ${pageVariable}.bringToFront();\n` + initializeCode;
+    }
+  }
+
+  return {
+    frameVariable,
+    pageVariable,
+    initializeCode,
+    variable: frameVariable || pageVariable,
+  };
+};

--- a/runner/src/environment/ElementChooser.ts
+++ b/runner/src/environment/ElementChooser.ts
@@ -34,6 +34,12 @@ export class ElementChooser extends EventEmitter {
     this._variables = variables;
   }
 
+  // Primarily for tests
+  _reset(): void {
+    this._codeModel.setValue('')
+    this._setActive(false)
+  }
+
   _setActive(value: boolean): void {
     this._isActive = value;
 

--- a/runner/src/environment/ElementChooser.ts
+++ b/runner/src/environment/ElementChooser.ts
@@ -6,7 +6,7 @@ import { CodeModel } from "../code/CodeModel";
 import { parseActionExpressions } from "../code/parseCode";
 import { prepareSourceVariables } from "../code/prepareSourceVariables";
 import { buildFrameSelector } from '../playwright'
-import { ElementChooserValue, ElementChosen, ElementEvent, TextOperation, Variables, WindowEvent } from "../types";
+import { ElementChooserValue, ElementChosen, Variables } from "../types";
 
 const debug = Debug("qawolf:ElementChooser");
 

--- a/runner/src/environment/ElementChooser.ts
+++ b/runner/src/environment/ElementChooser.ts
@@ -1,16 +1,62 @@
 import Debug from "debug";
 import { EventEmitter } from "events";
-import { BrowserContext } from "playwright";
+import { BrowserContext, Frame, Page } from "playwright";
 
-import { ElementChooserValue, ElementChosen } from "../types";
+import { buildFrameSelector } from '../playwright'
+import { ElementChooserValue, ElementChosen, ElementEvent, TextOperation, Variables, WindowEvent } from "../types";
 
 const debug = Debug("qawolf:ElementChooser");
+
+type BindingOptions = {
+  frame: Frame;
+  page: Page;
+};
+
+export type GetFrameOrPageVariableInput = {
+  event: ElementChosen;
+  variables: Variables;
+};
+
+export const getFrameOrPageVariable = ({
+  event,
+  variables,
+}: GetFrameOrPageVariableInput): string => {
+  const pageVariable = Object.keys(variables).find(
+    (name) => variables[name] === event.page
+  );
+
+  if (!pageVariable) throw new Error("No matching page found");
+
+  let frameVariable: string | undefined = undefined;
+
+  if (event.frameSelector) {
+    if (!event.frame) throw new Error("No frame provided");
+
+    frameVariable = Object.keys(variables).find(
+      (name) => variables[name] === event.frame
+    );
+
+    if (!frameVariable) throw new Error("No matching frame found");
+  }
+
+  return frameVariable || pageVariable
+};
+
+interface ElementChooserOptions {
+  variables: Variables;
+}
 
 export class ElementChooser extends EventEmitter {
   _context?: BrowserContext;
   _contextEmitter?: EventEmitter;
   _isActive = false;
   _lastElementChosen: ElementChosen | null = null;
+  _variables: Variables;
+
+  constructor({ variables }: ElementChooserOptions) {
+    super();
+    this._variables = variables;
+  }
 
   _setActive(value: boolean): void {
     this._isActive = value;
@@ -44,9 +90,17 @@ export class ElementChooser extends EventEmitter {
       }
     });
 
-    await context.exposeBinding("qawElementChosen", async (_, event) =>
+    await context.exposeBinding("qawElementChosen", async ({ frame, page }: BindingOptions, recorderEvent: Omit<ElementChosen, 'page'>) => {
+      const event: ElementChosen = { ...recorderEvent, page };
+
+      const frameSelector = await buildFrameSelector(frame);
+      if (frameSelector) {
+        event.frame = frame;
+        event.frameSelector = frameSelector;
+      }
+      
       contextEmitter.emit("qawElementChosen", event)
-    );
+    });
   }
 
   async start(): Promise<void> {
@@ -84,9 +138,18 @@ export class ElementChooser extends EventEmitter {
   }
 
   get value(): ElementChooserValue {
+    let variable = "page";
+    if (this._lastElementChosen) {
+      variable = getFrameOrPageVariable({
+        event: this._lastElementChosen,
+        variables: this._variables,
+      })
+    }
+
     return {
       ...(this._lastElementChosen || {}),
       isActive: this._isActive,
+      variable
     };
   }
 }

--- a/runner/src/environment/Environment.ts
+++ b/runner/src/environment/Environment.ts
@@ -35,7 +35,7 @@ export class Environment extends EventEmitter {
 
     this._updater = new CodeUpdater({ codeModel, variables: this._variables });
 
-    this._elementChooser = new ElementChooser({ variables: this._variables });
+    this._elementChooser = new ElementChooser({ codeModel, variables: this._variables });
     this._elementChooser.on("elementchooser", (event) =>
       this.emit("elementchooser", event)
     );

--- a/runner/src/environment/Environment.ts
+++ b/runner/src/environment/Environment.ts
@@ -23,7 +23,7 @@ export class Environment extends EventEmitter {
   readonly _vm: VM;
 
   _browser?: Browser;
-  _elementChooser = new ElementChooser();
+  _elementChooser: ElementChooser;
   _inProgress: Run[] = [];
   _variables: Variables = {};
   _updater: CodeUpdater;
@@ -35,6 +35,7 @@ export class Environment extends EventEmitter {
 
     this._updater = new CodeUpdater({ codeModel, variables: this._variables });
 
+    this._elementChooser = new ElementChooser({ variables: this._variables });
     this._elementChooser.on("elementchooser", (event) =>
       this.emit("elementchooser", event)
     );

--- a/runner/src/playwright.ts
+++ b/runner/src/playwright.ts
@@ -1,0 +1,32 @@
+import { Frame } from 'playwright'
+
+export async function buildFrameSelector(frame: Frame): Promise<string | null> {
+  // only build the frame selector if it is one frame down from the parent
+  // skip building the frame for the main frame and nested frames
+  const parentFrame = frame.parentFrame();
+  if (!parentFrame || parentFrame.parentFrame()) return null;
+
+  const name = frame.name();
+
+  const fallbackSelector = name
+    ? `[name="${name}"]`
+    : `[url="${frame.url()}"`;
+
+  try {
+    const frameElement = await frame.frameElement();
+    const selector = await parentFrame.evaluate(
+      ({ frameElement }) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const qawolf: any = (window as any).qawolf;
+        return qawolf.getSelector(frameElement);
+      },
+      { frameElement }
+    );
+    return selector || fallbackSelector;
+  } catch (error) {
+    // Due to timing, there's a possibility that `frameElement()`
+    // throws due to the frame's parent having been closed/disposed.
+  }
+
+  return fallbackSelector;
+}

--- a/runner/src/types.ts
+++ b/runner/src/types.ts
@@ -35,25 +35,26 @@ export type ElementAction =
   | "selectOption"
   | "uncheck";
 
-export interface ElementChosen {
-  frame?: Frame;
-  frameSelector?: string;
+export interface ElementChosen extends PlaywrightEvent {
   isFillable: boolean;
-  page: Page;
   selectors: string[];
   text: string;
 }
 
 export type ElementChooserValue = Partial<ElementChosen> & {
+  initializeCode?: string;
   isActive: boolean;
   variable?: string;
 };
 
-export interface ElementEvent {
-  action: ElementAction;
+export interface PlaywrightEvent {
   page: Page;
   frame?: Frame;
   frameSelector?: string;
+}
+
+export interface ElementEvent extends PlaywrightEvent {
+  action: ElementAction;
   relatedClickSelector?: string;
   selector: string;
   time: number;
@@ -138,9 +139,8 @@ export type Variables = { [key: string]: any };
 
 export type WindowAction = "goBack" | "goto" | "popup" | "reload";
 
-export interface WindowEvent {
+export interface WindowEvent extends PlaywrightEvent {
   action: WindowAction;
-  page: Page;
   popup?: Page;
   time: number;
   value?: string | null;

--- a/runner/src/types.ts
+++ b/runner/src/types.ts
@@ -36,13 +36,17 @@ export type ElementAction =
   | "uncheck";
 
 export interface ElementChosen {
+  frame?: Frame;
+  frameSelector?: string;
   isFillable: boolean;
+  page: Page;
   selectors: string[];
   text: string;
 }
 
 export type ElementChooserValue = Partial<ElementChosen> & {
   isActive: boolean;
+  variable?: string;
 };
 
 export interface ElementEvent {

--- a/runner/test/code/formatArgument.test.ts
+++ b/runner/test/code/formatArgument.test.ts
@@ -1,0 +1,31 @@
+import { formatArgument } from "../../src/code/formatArgument";
+
+describe("formatArgument", () => {
+  it("returns an empty string for null", () => {
+    expect(formatArgument(null)).toEqual('""');
+  });
+
+  it("serializes newlines", () => {
+    expect(
+      formatArgument(`line 1
+line 2`)
+    ).toEqual('"line 1\\nline 2"');
+  });
+
+  it("uses double quotes by default", () => {
+    expect(formatArgument("a")).toBe(`"a"`);
+  });
+
+  it("uses single quotes when there are double quotes in the selector", () => {
+    expect(formatArgument('"a"')).toBe(`'"a"'`);
+  });
+
+  it("uses backtick when there are double and single quotes", () => {
+    expect(formatArgument(`text="a" and 'b'`)).toBe("`text=\"a\" and 'b'`");
+
+    // escapes backtick
+    expect(formatArgument("text=\"a\" and 'b' and `c`")).toBe(
+      "`text=\"a\" and 'b' and \\`c\\``"
+    );
+  });
+});

--- a/runner/test/code/patchCheckOrUncheck.test.ts
+++ b/runner/test/code/patchCheckOrUncheck.test.ts
@@ -3,6 +3,8 @@ import { parseActionExpressions } from "../../src/code/parseCode";
 import { patchCheckOrUncheck } from "../../src/code/patchCheckOrUncheck"
 import { PATCH_HANDLE } from "../../src/code/patchUtils";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 const options: PatchEventOptions = {
   code: "",
   expressions: [],

--- a/runner/test/code/prepareSourceVariables.test.ts
+++ b/runner/test/code/prepareSourceVariables.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../../src/code/prepareSourceVariables";
 import { ElementEvent } from "../../src/types";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 const time = Date.now();
 
 const clickEvent: ElementEvent = {

--- a/runner/test/code/prepareSourceVariables.test.ts
+++ b/runner/test/code/prepareSourceVariables.test.ts
@@ -1,0 +1,165 @@
+import { parseActionExpressions } from "../../src/code/parseCode";
+import { PATCH_HANDLE } from "../../src/code/patchUtils";
+import {
+  findLastPageVariable,
+  prepareSourceVariable,
+  prepareSourceVariables,
+} from "../../src/code/prepareSourceVariables";
+import { ElementEvent } from "../../src/types";
+
+const time = Date.now();
+
+const clickEvent: ElementEvent = {
+  action: "click",
+  selector: ".input",
+  page: "p1" as any,
+  time,
+};
+
+describe("prepareSourceVariable", () => {
+  const frame = {} as any;
+  const page = { bringToFront: 1 } as any;
+
+  it("declares a page", () => {
+    const variables: any = {};
+    expect(
+      prepareSourceVariable({ declare: true, pageOrFrame: page, variables })
+    ).toEqual("page");
+    expect(variables.page).toEqual(page);
+  });
+
+  it("declares a frame", () => {
+    const variables: any = {};
+    expect(
+      prepareSourceVariable({ declare: true, pageOrFrame: frame, variables })
+    ).toEqual("frame");
+    expect(variables.frame).toEqual(frame);
+  });
+
+  it("increments to find an unused variable", () => {
+    const variables: any = { page: "" };
+    expect(
+      prepareSourceVariable({ declare: true, pageOrFrame: page, variables })
+    ).toEqual("page2");
+    expect(variables.page2).toEqual(page);
+  });
+});
+
+describe("findLastPageVariable", () => {
+  it("finds the variable of the last expression that is a page", () => {
+    const expressions = parseActionExpressions(
+      `await page2.click('.hello');${PATCH_HANDLE}`
+    );
+
+    expect(
+      findLastPageVariable(expressions, {
+        page2: {
+          // emulate a page
+          bringToFront: 1,
+        },
+      })
+    ).toEqual("page2");
+  });
+});
+
+describe("prepareSourceVariables", () => {
+  it("initializes the frame if it does not exist", () => {
+    expect(
+      prepareSourceVariables({
+        event: {
+          ...clickEvent,
+          frame: "f1" as any,
+          frameSelector: "#frame",
+        },
+        expressions: [],
+        variables: { page: "p1" },
+      })
+    ).toEqual({
+      initializeCode: `const frame = await (await page.waitForSelector("#frame")).contentFrame();\n`,
+      pageVariable: "page",
+      frameVariable: "frame",
+      variable: "frame",
+    });
+  });
+
+  it("reuses the frame that exists", () => {
+    expect(
+      prepareSourceVariables({
+        event: {
+          ...clickEvent,
+          frame: "f2" as any,
+          frameSelector: "#frame",
+        },
+        expressions: [],
+        variables: { frame2: "f2", page: "p1" },
+      })
+    ).toEqual({
+      initializeCode: "",
+      pageVariable: "page",
+      frameVariable: "frame2",
+      variable: "frame2",
+    });
+  });
+
+  it("initializes a new page for a goto", () => {
+    expect(
+      prepareSourceVariables({
+        declare: true,
+        event: {
+          page: { bringToFront: 1, name: "p3" } as any,
+        },
+        expressions: [],
+        shouldDeclarePageVariable: true,
+        variables: { page: "p1", page2: "p2" },
+      })
+    ).toEqual({
+      initializeCode: `const page3 = await context.newPage();\n`,
+      pageVariable: "page3",
+      variable: "page3",
+    });
+  });
+
+  it("reuses the page that exists", () => {
+    expect(
+      prepareSourceVariables({
+        declare: true,
+        event: {
+          page: "p1" as any,
+        },
+        expressions: [],
+        shouldDeclarePageVariable: true,
+        variables: { page: "p1" },
+      })
+    ).toEqual({
+      initializeCode: "",
+      pageVariable: "page",
+      variable: "page",
+    });
+  });
+
+  it("brings the page to the front when it changes", () => {
+    const expressions = parseActionExpressions(
+      `await page2.click('.hello');${PATCH_HANDLE}`
+    );
+
+    expect(
+      prepareSourceVariables({
+        event: clickEvent,
+        expressions,
+        shouldBringPageToFront: true,
+        variables: {
+          page: "p1",
+          page2: {
+            // emulate a page
+            bringToFront: 1,
+          },
+        },
+      })
+    ).toEqual({
+      frameVariable: undefined,
+      initializeCode: `await page.bringToFront();\n`,
+      pageVariable: "page",
+      variable: "page",
+    });
+  });
+});

--- a/runner/test/environment/ElementChooser.test.ts
+++ b/runner/test/environment/ElementChooser.test.ts
@@ -1,5 +1,5 @@
 import waitUntil from "async-wait-until";
-import { Page } from "playwright";
+import { Frame, Page } from "playwright";
 
 import { CodeModel } from "../../src/code/CodeModel";
 import { ElementChooser } from "../../src/environment/ElementChooser";
@@ -8,7 +8,7 @@ import { launch, LaunchResult, setBody } from "../utils";
 
 let launched: LaunchResult;
 let page: Page;
-let variables: Record<string, any> = {}
+const variables: Record<string, Page | Frame> = {}
 
 const chooser = new ElementChooser({ codeModel: new CodeModel(), variables });
 let events: ElementChooserValue[] = [];

--- a/runner/test/environment/ElementChooser.test.ts
+++ b/runner/test/environment/ElementChooser.test.ts
@@ -1,11 +1,12 @@
 import waitUntil from "async-wait-until";
 import { Page } from "playwright";
 
+import { CodeModel } from "../../src/code/CodeModel";
 import { ElementChooser } from "../../src/environment/ElementChooser";
 import { ElementChooserValue } from "../../src/types";
 import { launch, LaunchResult, setBody } from "../utils";
 
-const chooser = new ElementChooser();
+const chooser = new ElementChooser({ codeModel: new CodeModel(), variables: {} });
 let events: ElementChooserValue[] = [];
 
 chooser.on("elementchooser", (e) => events.push(e));

--- a/runner/test/server/SocketServer.test.ts
+++ b/runner/test/server/SocketServer.test.ts
@@ -138,7 +138,7 @@ describe("SocketServer", () => {
       socket.on("elementchooser", spy);
       socket.emit("subscribe", { type: "elementchooser" });
       await waitUntil(() => spy.mock.calls.length > 0);
-      expect(spy.mock.calls[0][0]).toEqual({ isActive: true });
+      expect(spy.mock.calls[0][0]).toEqual({ isActive: true, variable: "page" });
     });
 
     it("sends initial logs", async () => {


### PR DESCRIPTION
Resolves #1347 

- Choosing an element on any tab will generate code that uses the correct page variable to target that tab
- Choosing an element in any iframe will generate code that uses the correct frame variable to target that frame

Technical details:
- give ElementChooser instance a reference to `this._variables`
- when emitting element chooser events, search `this._variables` to find the correct variable name string based on incoming `frame` and `page` instances from Playwright
- in the app component, use `event.variable` instead of hard coding `page` (fall back to old behavior)
- also pass any `initializeCode` to client so that it can insert it with the snippet