### PR TITLE
build(config): unblock changesets version commit in CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# CI validates via ci.yml; the changesets release commit must not re-run these checks
+if [ "$CI" = "true" ]; then
+  exit 0
+fi
+
 set -e
 bash scripts/check-naming.sh
 bun run lint --max-warnings 0

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typecheck": "bun run generate && tsc --noEmit",
     "uninstall:binary": "rm ~/.local/bin/qawolf",
     "uninstall:local": "npm unlink -g @qawolf/cli",
-    "version-packages": "changeset version"
+    "version-packages": "changeset version && bun run format"
   },
   "dependencies": {
     "@clack/prompts": "1.5.1",


### PR DESCRIPTION
<!-- Relates to the failed Release run on main after the history swap -->

# Overview of Changes

The first release run on this repo failed while creating the "Version Packages" commit: the `prepare` script points `core.hooksPath` at `.githooks`, so `bun install` in release.yml armed the pre-commit hook inside CI, and `format:check` rejected the freshly generated, unformatted `CHANGELOG.md`. The hook now exits early when `CI=true` (ci.yml already runs every one of its checks), and `version-packages` runs `bun run format` after `changeset version` so the committed changelog keeps `oxfmt --check .` passing for every contributor's local pre-commit hook.

# Testing

```bash
CI=true sh .githooks/pre-commit        # exits 0 immediately
sh .githooks/pre-commit                # full suite still runs locally
bun run version-packages && bun run format:check   # passes against the pending changesets
bun run lint
bun run typecheck
bun run knip
```

Merging to main re-triggers release.yml, which should open the Version Packages PR for v1.0.0.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)