### PR TITLE
build(config): gate release job behind release environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,14 @@ concurrency:
 jobs:
   release:
     name: Release
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
<!-- Relates to Linear WIZ-10818. Must merge BEFORE the Version Packages PR. -->

# Overview of Changes

`NPM_TOKEN` exists only as an environment secret on the `release` environment, so the release job must declare `environment: release` for `changeset publish` to authenticate — without it the publish step receives an empty token and v1.0.0 fails npm auth. Gating the job also pauses every release run for required-reviewer approval, which is the exfiltration barrier for the token. Rides along WIZ-10818's tidy-up: ci.yml and release.yml now use the same `actions/checkout` v6.0.3 pin as release-binaries.yml.

# Testing

```bash
grep -A2 "^  release:" .github/workflows/release.yml   # shows environment: release
grep -c df4cb1c0 .github/workflows/ci.yml .github/workflows/release.yml  # 1 each, no v4 pins remain
```

After merge, the release run on main waits for environment approval; approving it should refresh the Version Packages PR branch and, once that PR merges, publish 1.0.0 with the injected token.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)