### PR TITLE
docs(runs): add run create to 1.0.0 release highlights

### DIFF
--- a/.changeset/blue-ears-agree.md
+++ b/.changeset/blue-ears-agree.md
@@ -9,6 +9,7 @@ Highlights:
 - `qawolf auth login` — authenticate with QA Wolf (or set `QAWOLF_API_KEY` in CI)
 - `qawolf flows run --env <env-id>` — pull and run your team's flows locally
 - `qawolf flows pull` — refresh the local flow cache
+- `qawolf run create --environment-id <env-id>` — trigger a run of your flows on the QA Wolf platform
 - `qawolf install` — install runtime dependencies (browsers, Android tooling)
 - `qawolf init` — scaffold a local-only project
 - `qawolf doctor` — diagnose setup problems


### PR DESCRIPTION
<!-- Relates to the 1.0.0 launch; must merge before #1369 (Version Packages). -->

# Overview of Changes

The 1.0.0 major changeset's Highlights list enumerates the command surface but omitted `qawolf run create --environment-id <env-id>`, the platform-run command from the contract-driven public API layer (it only appeared as its own minor changeset). This adds the missing bullet so the published CHANGELOG and GitHub Release notes present the complete command set. After merge, the release workflow regenerates `changeset-release/main`, refreshing #1369 automatically.

# Testing

```bash
bun run dev -- run create --help   # confirms the documented flag is --environment-id
bun run format:check
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)