### PR TITLE
fix(config): build binaries reliably after changesets publish

### DIFF
--- a/.changeset/normalize-bin-path.md
+++ b/.changeset/normalize-bin-path.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Normalize the `bin` entry to `dist/cli.js` so npm no longer rewrites it (with a publish warning) when publishing.

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,6 +3,16 @@ name: Release Binaries
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -48,6 +58,8 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
+      - run: bun run generate
+
       - name: Build binary
         run: bun scripts/buildBinary.ts --target "${{ matrix.target }}" --outfile "${{ matrix.outfile }}"
 
@@ -55,6 +67,6 @@ jobs:
         run: ./${{ matrix.outfile }} --version
 
       - name: Upload to release
-        run: gh release upload "${{ github.event.release.tag_name }}" "${{ matrix.outfile }}" --clobber
+        run: gh release upload "${{ inputs.tag || github.event.release.tag_name }}" "${{ matrix.outfile }}" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,6 +14,12 @@ on:
         required: true
         type: string
 
+# Serialize runs per tag: release/workflow_call/workflow_dispatch can otherwise
+# race on uploading assets for the same release.
+concurrency:
+  group: release-binaries-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -65,6 +71,13 @@ jobs:
         run: ./${{ matrix.outfile }} --version
 
       - name: Upload to release
-        run: gh release upload "${{ inputs.tag || github.event.release.tag_name }}" "${{ matrix.outfile }}" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # env indirection keeps the dispatch-provided tag out of shell template expansion
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$ ]] || {
+            echo "Invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          }
+          gh release upload "$RELEASE_TAG" "${{ matrix.outfile }}" --clobber

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -58,10 +58,8 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - run: bun run generate
-
       - name: Build binary
-        run: bun scripts/buildBinary.ts --target "${{ matrix.target }}" --outfile "${{ matrix.outfile }}"
+        run: bun run build:binary --target="${{ matrix.target }}" --outfile="${{ matrix.outfile }}"
 
       - name: Smoke test binary
         run: ./${{ matrix.outfile }} --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -31,6 +34,7 @@ jobs:
       - run: bun run build
 
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: bun run version-packages
@@ -39,3 +43,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      # Only set when a publish actually happened; safe on version-mode runs.
+      - name: Resolve release tag
+        id: tag
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          VERSION=$(echo "$PUBLISHED_PACKAGES" | bun -e "const d = await Bun.stdin.text(); console.log(JSON.parse(d)[0].version)")
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+  binaries:
+    name: Binaries
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-binaries.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "build": "bun run generate && bun scripts/build.ts",
-    "build:binary": "bun scripts/buildBinary.ts",
+    "build:binary": "bun run generate && bun scripts/buildBinary.ts",
     "dev": "bun run src/main.ts",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
@@ -47,7 +47,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "postbuild": "./scripts/postbuild.sh",
-    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
+    "prepare": "git config core.hooksPath .githooks || true",
     "test": "bun run generate && bun test",
     "test:watch": "bun test --watch",
     "typecheck": "bun run generate && tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/qawolf/cli.git"
   },
   "bin": {
-    "qawolf": "./dist/cli.js"
+    "qawolf": "dist/cli.js"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
<!-- Fixes the empty v1.0.0 release assets; relates to the launch runbook (WIZ-10793). -->

# Overview of Changes

All five v1.0.0 binary builds failed because the workflow never ran `bun run generate`, so the gitignored `src/generated/dependencyVersions.ts` did not exist at compile time. Separately, `release-binaries.yml` never auto-triggers at all: the GitHub Release is created with the workflow's `GITHUB_TOKEN`, whose events GitHub suppresses to prevent recursion — the v1.0.0 attempt only ran after a manual draft-republish toggle. release.yml now chains the binary build directly via `workflow_call` when the changesets step reports `published == true` (passing the `v<version>` tag), the generate step runs before compiling, a `workflow_dispatch(tag)` fallback enables manual backfill, and `bin.qawolf` is normalized to `dist/cli.js` (patch changeset) to silence npm's publish-time auto-correction warning.

# Testing

```bash
bun run generate && bun scripts/buildBinary.ts --target bun-darwin-arm64 --outfile /tmp/qawolf-bin
/tmp/qawolf-bin --version   # → 1.0.0 (verified locally)
```

After merge: Actions → Release Binaries → Run workflow with tag `v1.0.0` to backfill the missing release assets, then confirm `https://github.com/qawolf/cli/releases/latest/download/qawolf-darwin-arm64` resolves. Version-mode release runs (no publish) skip the tag step and the binaries job entirely.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)