### PR TITLE
fix(flows): skip invalid dotenv keys on pull

### DIFF
--- a/.changeset/pull-skip-invalid-dotenv-keys.md
+++ b/.changeset/pull-skip-invalid-dotenv-keys.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Skip platform environment variables with keys that cannot be represented in local .env files during flows pull.

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -82,6 +82,13 @@ export const flowsMessages = {
   dotenv: {
     invalidKey: (key: string) =>
       `Cannot serialize env var with invalid key: ${JSON.stringify(key)}`,
+    skippedKeys: (keys: readonly string[]) =>
+      `Skipped ${pluralize(
+        keys.length,
+        "environment variable",
+      )} with key(s) that are not valid POSIX shell identifiers (cannot be written to .env): ${keys
+        .map((key) => JSON.stringify(key))
+        .join(", ")}`,
     unparseableLine: (line: string) =>
       `Cannot parse .env line: ${JSON.stringify(line)}`,
   },

--- a/src/domains/flows/pull/envVars.test.ts
+++ b/src/domains/flows/pull/envVars.test.ts
@@ -32,6 +32,26 @@ describe("writeEnvFile", () => {
 
     expect(await pathExists(join(workDir, ".env"))).toBe(false);
   });
+
+  it("writes valid vars, drops invalid keys, and reports them", async () => {
+    const { skippedKeys } = await writeEnvFile(workDir, {
+      TOKEN: "abc",
+      "BRIAN_2.0_AUTH_TOKEN": "secret",
+    });
+
+    expect(skippedKeys).toEqual(["BRIAN_2.0_AUTH_TOKEN"]);
+    const body = await readFile(join(workDir, ".env"), "utf8");
+    expect(body).toBe('TOKEN="abc"\n');
+  });
+
+  it("does not write an empty .env when every key is invalid", async () => {
+    const { skippedKeys } = await writeEnvFile(workDir, {
+      "BRIAN_2.0_AUTH_TOKEN": "secret",
+    });
+
+    expect(skippedKeys).toEqual(["BRIAN_2.0_AUTH_TOKEN"]);
+    expect(await pathExists(join(workDir, ".env"))).toBe(false);
+  });
 });
 
 describe("writeEnvFile (memory fs)", () => {

--- a/src/domains/flows/pull/envVars.ts
+++ b/src/domains/flows/pull/envVars.ts
@@ -3,15 +3,19 @@ import { join } from "node:path";
 import { makeDefaultFs } from "~/shell/fs.js";
 import type { Fs } from "~/shell/fs.js";
 
-import { serializeDotenv } from "~/core/dotenv.js";
+import { serializeDotenvSkippingInvalid } from "~/core/dotenv.js";
 
 export async function writeEnvFile(
   envDir: string,
   vars: Record<string, string>,
   fs: Fs = makeDefaultFs(),
-): Promise<void> {
-  if (Object.keys(vars).length === 0) return;
-  await fs.writeFile(join(envDir, ".env"), serializeDotenv(vars), {
-    mode: 0o600,
-  });
+): Promise<{ skippedKeys: readonly string[] }> {
+  if (Object.keys(vars).length === 0) return { skippedKeys: [] };
+  const { content, skippedKeys } = serializeDotenvSkippingInvalid(vars);
+  // Only write when there is at least one valid var. An all-invalid set
+  // serializes to "" and we leave no empty .env behind.
+  if (content !== "") {
+    await fs.writeFile(join(envDir, ".env"), content, { mode: 0o600 });
+  }
+  return { skippedKeys };
 }

--- a/src/domains/flows/pull/handler.test.ts
+++ b/src/domains/flows/pull/handler.test.ts
@@ -114,6 +114,7 @@ describe("handleFlowsPull json mode output", () => {
       "flowCount",
       "flowsWithTeamStorageRefs",
       "manifestPath",
+      "skippedEnvVarKeys",
     ]);
     expect(payload).toEqual({
       assetsDir: expect.stringContaining("/assets"),
@@ -127,6 +128,7 @@ describe("handleFlowsPull json mode output", () => {
       ),
       flowCount: 2,
       envVarCount: 2,
+      skippedEnvVarKeys: [],
       flowsWithTeamStorageRefs: [],
       manifestPath: join(destDir, manifestFilename),
     });

--- a/src/domains/flows/pull/handler.ts
+++ b/src/domains/flows/pull/handler.ts
@@ -111,6 +111,10 @@ export async function handleFlowsPull(
         ),
     );
 
+    if (result.skippedEnvVarKeys.length > 0) {
+      ctx.ui.warn(flowsMessages.dotenv.skippedKeys(result.skippedEnvVarKeys));
+    }
+
     if (ctx.ui.mode === "json") {
       ctx.ui.output(
         {
@@ -120,6 +124,7 @@ export async function handleFlowsPull(
           fetchedAt: fetched.bundleFetchedAt.toISOString(),
           flowCount: result.flowCount,
           envVarCount: result.envVarCount,
+          skippedEnvVarKeys: result.skippedEnvVarKeys,
           flowsWithTeamStorageRefs: result.flowsWithTeamStorageRefs,
           assetDownloadedCount: assetResult.downloadedCount,
           assetReusedCount: assetResult.reusedCount,

--- a/src/domains/flows/pull/stage.test.ts
+++ b/src/domains/flows/pull/stage.test.ts
@@ -47,6 +47,7 @@ describe("stageBundle", () => {
       flowCount: 2,
       envVarCount: 1,
       flowsWithTeamStorageRefs: [],
+      skippedEnvVarKeys: [],
     });
     expect(await readFile(join(destDir, "checkout.flow.ts"), "utf8")).toBe(
       "// checkout\n",

--- a/src/domains/flows/pull/stage.ts
+++ b/src/domains/flows/pull/stage.ts
@@ -30,6 +30,7 @@ type StageBundleResult = {
   flowCount: number;
   envVarCount: number;
   flowsWithTeamStorageRefs: string[];
+  skippedEnvVarKeys: readonly string[];
 };
 
 export async function stageBundle(
@@ -61,7 +62,11 @@ export async function stageBundle(
       ...args.envVars,
       TEAM_STORAGE_DIR: args.assetsAbs,
     };
-    await writeEnvFile(tmpDir, effectiveEnvVars, fs);
+    const { skippedKeys: skippedEnvVarKeys } = await writeEnvFile(
+      tmpDir,
+      effectiveEnvVars,
+      fs,
+    );
     const manifest = await buildManifest(
       {
         envId: args.envId,
@@ -93,8 +98,11 @@ export async function stageBundle(
     return {
       envDir: args.destAbs,
       flowCount: manifest.flows.length,
-      envVarCount: Object.keys(effectiveEnvVars).length,
+      // Skipped keys never made it into the .env, so don't count them.
+      envVarCount:
+        Object.keys(effectiveEnvVars).length - skippedEnvVarKeys.length,
       flowsWithTeamStorageRefs,
+      skippedEnvVarKeys,
     };
   } catch (err) {
     await removeTempDir(tmpDir, registry, fs).catch(() => {});


### PR DESCRIPTION
## Summary

Stacked on #1372.

- Skip platform env vars whose keys cannot be represented in local `.env` files
- Warn users with the skipped key names
- Include `skippedEnvVarKeys` in JSON output
- Exclude skipped keys from `envVarCount`
- Avoid writing an empty `.env` when every key is invalid

## Why

Some platform env-var keys are valid in QA Wolf but invalid as shell-style `.env` keys, for example keys containing `.`. Previously one such key could fail the entire `qawolf flows pull`. This keeps the pull useful while making the skipped vars explicit.

## Stack

- Depends on #1372

## Tests

- `bun run lint`
- `bun run typecheck`
- `bun run test src/domains/flows/pull/envVars.test.ts src/domains/flows/pull/handler.test.ts src/domains/flows/pull/stage.test.ts`
