### PR TITLE
fix(runner): set default web locale to en-US

### DIFF
--- a/.changeset/web-locale-en-us.md
+++ b/.changeset/web-locale-en-us.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Set the default browser locale for local web flows to en-US.

--- a/src/domains/runner/web/contextSetup.test.ts
+++ b/src/domains/runner/web/contextSetup.test.ts
@@ -122,7 +122,7 @@ describe("initHar", () => {
 });
 
 describe("buildContextSetup", () => {
-  it("should return viewport and screen without recordVideo when video is off and no harPath", () => {
+  it("should return viewport, screen, and locale without recordVideo when video is off and no harPath", () => {
     const result = buildContextSetup(
       { width: 1280, height: 720 },
       { video: "off", outputDir: "/out" },
@@ -131,6 +131,7 @@ describe("buildContextSetup", () => {
     expect(result).toEqual({
       viewport: { width: 1280, height: 720 },
       screen: { width: 1280, height: 720 },
+      locale: "en-US",
     });
   });
 
@@ -143,6 +144,7 @@ describe("buildContextSetup", () => {
     expect(result).toEqual({
       viewport: { width: 1280, height: 720 },
       screen: { width: 1280, height: 720 },
+      locale: "en-US",
       recordVideo: {
         dir: "/out/videos",
         size: { width: 1280, height: 720 },
@@ -159,6 +161,7 @@ describe("buildContextSetup", () => {
     expect(result).toEqual({
       viewport: { width: 1280, height: 720 },
       screen: { width: 1280, height: 720 },
+      locale: "en-US",
       recordHar: {
         path: "/out/har/flow.har",
         mode: "minimal",
@@ -176,6 +179,7 @@ describe("buildContextSetup", () => {
     expect(result).toEqual({
       viewport: { width: 1280, height: 720 },
       screen: { width: 1280, height: 720 },
+      locale: "en-US",
       recordVideo: {
         dir: "/out/videos",
         size: { width: 1280, height: 720 },

--- a/src/domains/runner/web/contextSetup.ts
+++ b/src/domains/runner/web/contextSetup.ts
@@ -63,14 +63,18 @@ export function buildContextSetup(
     harPath !== undefined
       ? buildHarContextOpts(harPath, options.harContent ?? "omit")
       : {};
+  // Send a concrete Accept-Language so the app resolves a real locale instead
+  // of falling back to the first configured one (which can be non-English,
+  // e.g. Afrikaans, and would break English text assertions / OTP parsing).
+  const base = {
+    viewport: videoSize,
+    screen: videoSize,
+    locale: "en-US",
+    ...harOpts,
+  };
   return options.video !== "off"
-    ? {
-        viewport: videoSize,
-        screen: videoSize,
-        recordVideo: { dir: videosDir, size: videoSize },
-        ...harOpts,
-      }
-    : { viewport: videoSize, screen: videoSize, ...harOpts };
+    ? { ...base, recordVideo: { dir: videosDir, size: videoSize } }
+    : base;
 }
 
 /**

--- a/src/domains/runner/web/types.ts
+++ b/src/domains/runner/web/types.ts
@@ -15,6 +15,7 @@ export type BrowserLaunchOptions = {
 export type ContextSetupOptions = {
   viewport?: { width: number; height: number };
   screen?: { width: number; height: number };
+  locale?: string;
   recordVideo?: { dir: string; size: { width: number; height: number } };
   recordHar?: {
     path: string;


### PR DESCRIPTION
## Summary

Independent PR.

- Set Playwright context locale to `en-US` for local web flows
- Extend the local context setup type to include `locale`
- Update context setup tests

## Why

Some apps fall back to a non-English locale when `Accept-Language` / locale is unspecified. Setting a stable default avoids locale-dependent failures in English text assertions and email/OTP parsing.

## Tests

- `bun run lint`
- `bun run typecheck`
- `bun run test src/domains/runner/web/contextSetup.test.ts src/domains/runner/web/createWebLaunchContext.test.ts`
