### PR TITLE
fix(flows): round-trip non-POSIX env var keys instead of skipping

### DIFF
--- a/.changeset/pull-roundtrip-dotenv-keys.md
+++ b/.changeset/pull-roundtrip-dotenv-keys.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Round-trip environment variables whose keys are not POSIX shell identifiers (e.g. OTP URIs keyed by email) when running flows locally, instead of failing or dropping them.

--- a/.changeset/pull-skip-invalid-dotenv-keys.md
+++ b/.changeset/pull-skip-invalid-dotenv-keys.md
@@ -1,5 +1,0 @@
----
-"@qawolf/cli": patch
----
-
-Skip platform environment variables with keys that cannot be represented in local .env files during flows pull.

--- a/src/core/dotenv.test.ts
+++ b/src/core/dotenv.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import {
-  parseDotenv,
-  serializeDotenv,
-  serializeDotenvSkippingInvalid,
-} from "./dotenv.js";
+import { parseDotenv, serializeDotenv } from "./dotenv.js";
 
 describe("serializeDotenv", () => {
   it('emits KEY="value" lines sorted by key with trailing newline', () => {
@@ -37,34 +33,19 @@ describe("serializeDotenv", () => {
     expect(serializeDotenv({ URL: "a=b c#d" })).toBe('URL="a=b c#d"\n');
   });
 
-  it("throws when a key violates POSIX env-var shape", () => {
-    expect(() => serializeDotenv({ "BAD KEY": "x" })).toThrow(/invalid key/i);
-    expect(() => serializeDotenv({ "1LEADING_DIGIT": "x" })).toThrow(
-      /invalid key/i,
-    );
-  });
-});
-
-describe("serializeDotenvSkippingInvalid", () => {
-  it("skips keys that violate POSIX env-var shape and reports them", () => {
+  it("quotes a key that contains special characters (email-style OTP key)", () => {
     expect(
-      serializeDotenvSkippingInvalid({
-        VALID: "ok",
-        "BAD KEY": "x",
-        "1LEADING_DIGIT": "y",
-        "DOTTED.KEY": "z",
+      serializeDotenv({
+        "app+user@example.com_OTP_URI": "otpauth://totp/x",
       }),
-    ).toEqual({
-      content: 'VALID="ok"\n',
-      skippedKeys: ["1LEADING_DIGIT", "BAD KEY", "DOTTED.KEY"],
-    });
+    ).toBe('"app+user@example.com_OTP_URI"="otpauth://totp/x"\n');
   });
 
-  it("returns empty content when every key is invalid", () => {
-    expect(serializeDotenvSkippingInvalid({ "BAD KEY": "x" })).toEqual({
-      content: "",
-      skippedKeys: ["BAD KEY"],
-    });
+  it("quotes a key with a space or a leading digit", () => {
+    expect(serializeDotenv({ "BAD KEY": "x" })).toBe('"BAD KEY"="x"\n');
+    expect(serializeDotenv({ "1LEADING_DIGIT": "x" })).toBe(
+      '"1LEADING_DIGIT"="x"\n',
+    );
   });
 });
 
@@ -106,10 +87,20 @@ describe("parseDotenv", () => {
     expect(() => parseDotenv("not-a-valid-line\n")).toThrow(/Cannot parse/i);
     expect(() => parseDotenv('UNTERMINATED="oops\n')).toThrow(/Cannot parse/i);
   });
+
+  it("parses a quoted-key line", () => {
+    expect(
+      parseDotenv('"weird+key@host.com_OTP_URI"="otpauth://totp/x"\n'),
+    ).toEqual({ "weird+key@host.com_OTP_URI": "otpauth://totp/x" });
+  });
+
+  it("parses a quoted key containing an escaped double-quote", () => {
+    expect(parseDotenv('"a\\"b"="v"\n')).toEqual({ 'a"b': "v" });
+  });
 });
 
 describe("serializeDotenv ↔ parseDotenv round trip", () => {
-  it("preserves arbitrary values exactly", () => {
+  it("preserves arbitrary values and non-POSIX keys exactly", () => {
     const sample = {
       ALPHA: "simple",
       BETA: 'with "quotes"',
@@ -117,6 +108,7 @@ describe("serializeDotenv ↔ parseDotenv round trip", () => {
       DELTA: "back\\slash",
       EPSILON: "spaces and = and # and / inside",
       ZETA: "",
+      "weird+key@host.com_OTP_URI": 'value with = and " and \n',
     };
 
     const round = parseDotenv(serializeDotenv(sample));

--- a/src/core/dotenv.ts
+++ b/src/core/dotenv.ts
@@ -1,46 +1,26 @@
 // Shared serializer / parser for the dotenv format `qawolf flows pull` writes
-// and `qawolf flows run` reads. Always double-quotes values; escapes `\\`,
-// `\"`, `\n`, `\r`, `\t`. Round-trips exactly (escape/unescape are inverses).
+// and `qawolf flows run` reads. Always double-quotes values; keys that are not
+// bare POSIX identifiers are also double-quoted. `quote`/`unquote` apply to
+// both keys and values. Escapes `\\`, `\"`, `\n`, `\r`, `\t`. Round-trips
+// exactly (escape/unescape are inverses).
 
 import { flowsMessages } from "~/core/messages/index.js";
 
-const envKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const lineRe = /^([A-Za-z_][A-Za-z0-9_]*)="((?:[^"\\]|\\.)*)"$/;
-
-export type SerializeDotenvSkippingInvalidResult = {
-  readonly content: string;
-  // Keys that are not valid POSIX shell identifiers (e.g. they contain a `.`
-  // or a space). A `.env` file cannot represent them, so pull callers can
-  // choose to skip them while surfacing the names to the user.
-  readonly skippedKeys: readonly string[];
-};
-
-function isDotenvKey(key: string): boolean {
-  return envKeyPattern.test(key);
-}
+const bareKeyPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const lineRe =
+  /^(?:([A-Za-z_][A-Za-z0-9_]*)|"((?:[^"\\]|\\.)*)")="((?:[^"\\]|\\.)*)"$/;
 
 export function serializeDotenv(vars: Record<string, string>): string {
   const keys = Object.keys(vars).sort();
-  for (const key of keys) {
-    if (!isDotenvKey(key)) {
-      throw new Error(flowsMessages.dotenv.invalidKey(key));
-    }
-  }
   if (keys.length === 0) return "";
-  return `${keys.map((key) => `${key}=${quote(vars[key] ?? "")}`).join("\n")}\n`;
-}
-
-export function serializeDotenvSkippingInvalid(
-  vars: Record<string, string>,
-): SerializeDotenvSkippingInvalidResult {
-  const keys = Object.keys(vars).sort();
-  const validVars: Record<string, string> = {};
-  const skippedKeys: string[] = [];
-  for (const key of keys) {
-    if (isDotenvKey(key)) validVars[key] = vars[key] ?? "";
-    else skippedKeys.push(key);
-  }
-  return { content: serializeDotenv(validVars), skippedKeys };
+  return `${keys
+    .map(
+      (key) =>
+        `${bareKeyPattern.test(key) ? key : quote(key)}=${quote(
+          vars[key] ?? "",
+        )}`,
+    )
+    .join("\n")}\n`;
 }
 
 function quote(value: string): string {
@@ -62,7 +42,7 @@ export function parseDotenv(content: string): Record<string, string> {
     if (!match) {
       throw new Error(flowsMessages.dotenv.unparseableLine(line));
     }
-    out[match[1]!] = unquote(match[2]!);
+    out[match[1] ?? unquote(match[2]!)] = unquote(match[3]!);
   }
   return out;
 }

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -80,15 +80,6 @@ export const flowsMessages = {
       `${pm} install failed in ${envDir}:\n${stderr}`,
   },
   dotenv: {
-    invalidKey: (key: string) =>
-      `Cannot serialize env var with invalid key: ${JSON.stringify(key)}`,
-    skippedKeys: (keys: readonly string[]) =>
-      `Skipped ${pluralize(
-        keys.length,
-        "environment variable",
-      )} with key(s) that are not valid POSIX shell identifiers (cannot be written to .env): ${keys
-        .map((key) => JSON.stringify(key))
-        .join(", ")}`,
     unparseableLine: (line: string) =>
       `Cannot parse .env line: ${JSON.stringify(line)}`,
   },

--- a/src/domains/flows/pull/envVars.test.ts
+++ b/src/domains/flows/pull/envVars.test.ts
@@ -32,26 +32,6 @@ describe("writeEnvFile", () => {
 
     expect(await pathExists(join(workDir, ".env"))).toBe(false);
   });
-
-  it("writes valid vars, drops invalid keys, and reports them", async () => {
-    const { skippedKeys } = await writeEnvFile(workDir, {
-      TOKEN: "abc",
-      "BRIAN_2.0_AUTH_TOKEN": "secret",
-    });
-
-    expect(skippedKeys).toEqual(["BRIAN_2.0_AUTH_TOKEN"]);
-    const body = await readFile(join(workDir, ".env"), "utf8");
-    expect(body).toBe('TOKEN="abc"\n');
-  });
-
-  it("does not write an empty .env when every key is invalid", async () => {
-    const { skippedKeys } = await writeEnvFile(workDir, {
-      "BRIAN_2.0_AUTH_TOKEN": "secret",
-    });
-
-    expect(skippedKeys).toEqual(["BRIAN_2.0_AUTH_TOKEN"]);
-    expect(await pathExists(join(workDir, ".env"))).toBe(false);
-  });
 });
 
 describe("writeEnvFile (memory fs)", () => {

--- a/src/domains/flows/pull/envVars.ts
+++ b/src/domains/flows/pull/envVars.ts
@@ -3,19 +3,15 @@ import { join } from "node:path";
 import { makeDefaultFs } from "~/shell/fs.js";
 import type { Fs } from "~/shell/fs.js";
 
-import { serializeDotenvSkippingInvalid } from "~/core/dotenv.js";
+import { serializeDotenv } from "~/core/dotenv.js";
 
 export async function writeEnvFile(
   envDir: string,
   vars: Record<string, string>,
   fs: Fs = makeDefaultFs(),
-): Promise<{ skippedKeys: readonly string[] }> {
-  if (Object.keys(vars).length === 0) return { skippedKeys: [] };
-  const { content, skippedKeys } = serializeDotenvSkippingInvalid(vars);
-  // Only write when there is at least one valid var. An all-invalid set
-  // serializes to "" and we leave no empty .env behind.
-  if (content !== "") {
-    await fs.writeFile(join(envDir, ".env"), content, { mode: 0o600 });
-  }
-  return { skippedKeys };
+): Promise<void> {
+  if (Object.keys(vars).length === 0) return;
+  await fs.writeFile(join(envDir, ".env"), serializeDotenv(vars), {
+    mode: 0o600,
+  });
 }

--- a/src/domains/flows/pull/handler.test.ts
+++ b/src/domains/flows/pull/handler.test.ts
@@ -114,7 +114,6 @@ describe("handleFlowsPull json mode output", () => {
       "flowCount",
       "flowsWithTeamStorageRefs",
       "manifestPath",
-      "skippedEnvVarKeys",
     ]);
     expect(payload).toEqual({
       assetsDir: expect.stringContaining("/assets"),
@@ -128,7 +127,6 @@ describe("handleFlowsPull json mode output", () => {
       ),
       flowCount: 2,
       envVarCount: 2,
-      skippedEnvVarKeys: [],
       flowsWithTeamStorageRefs: [],
       manifestPath: join(destDir, manifestFilename),
     });

--- a/src/domains/flows/pull/handler.ts
+++ b/src/domains/flows/pull/handler.ts
@@ -111,10 +111,6 @@ export async function handleFlowsPull(
         ),
     );
 
-    if (result.skippedEnvVarKeys.length > 0) {
-      ctx.ui.warn(flowsMessages.dotenv.skippedKeys(result.skippedEnvVarKeys));
-    }
-
     if (ctx.ui.mode === "json") {
       ctx.ui.output(
         {
@@ -124,7 +120,6 @@ export async function handleFlowsPull(
           fetchedAt: fetched.bundleFetchedAt.toISOString(),
           flowCount: result.flowCount,
           envVarCount: result.envVarCount,
-          skippedEnvVarKeys: result.skippedEnvVarKeys,
           flowsWithTeamStorageRefs: result.flowsWithTeamStorageRefs,
           assetDownloadedCount: assetResult.downloadedCount,
           assetReusedCount: assetResult.reusedCount,

--- a/src/domains/flows/pull/stage.test.ts
+++ b/src/domains/flows/pull/stage.test.ts
@@ -47,7 +47,6 @@ describe("stageBundle", () => {
       flowCount: 2,
       envVarCount: 1,
       flowsWithTeamStorageRefs: [],
-      skippedEnvVarKeys: [],
     });
     expect(await readFile(join(destDir, "checkout.flow.ts"), "utf8")).toBe(
       "// checkout\n",

--- a/src/domains/flows/pull/stage.ts
+++ b/src/domains/flows/pull/stage.ts
@@ -30,7 +30,6 @@ type StageBundleResult = {
   flowCount: number;
   envVarCount: number;
   flowsWithTeamStorageRefs: string[];
-  skippedEnvVarKeys: readonly string[];
 };
 
 export async function stageBundle(
@@ -62,11 +61,7 @@ export async function stageBundle(
       ...args.envVars,
       TEAM_STORAGE_DIR: args.assetsAbs,
     };
-    const { skippedKeys: skippedEnvVarKeys } = await writeEnvFile(
-      tmpDir,
-      effectiveEnvVars,
-      fs,
-    );
+    await writeEnvFile(tmpDir, effectiveEnvVars, fs);
     const manifest = await buildManifest(
       {
         envId: args.envId,
@@ -98,11 +93,8 @@ export async function stageBundle(
     return {
       envDir: args.destAbs,
       flowCount: manifest.flows.length,
-      // Skipped keys never made it into the .env, so don't count them.
-      envVarCount:
-        Object.keys(effectiveEnvVars).length - skippedEnvVarKeys.length,
+      envVarCount: Object.keys(effectiveEnvVars).length,
       flowsWithTeamStorageRefs,
-      skippedEnvVarKeys,
     };
   } catch (err) {
     await removeTempDir(tmpDir, registry, fs).catch(() => {});


### PR DESCRIPTION
## What

Stacks on **#1372** (`wiz-dotenv-core`). Converts the `.env` serializer from *rejecting / skipping* non-POSIX env var keys to **round-tripping any key by quoting it**, fixing WIZ-10843.

```
qawolf flows run --headed --env <env-id> "path/to/flow"
# before: Cannot serialize env var with invalid key: "<email-style _OTP_URI key>"
```

## Why this instead of skipping

The skip-with-warning approach merged in #1373 unblocks `pull`, but it **drops** the offending key — and the key in the reported case is an `_OTP_URI` the MFA flow reads via `process.env["…"]`. Dropping it just moves the failure later and quieter (MFA can't authenticate).

The POSIX restriction is self-imposed and unnecessary here:
- The `.env` is written **and** read only by our own `serializeDotenv`/`parseDotenv` — no shell sources it, and there's no `dotenv` npm dependency.
- Node's `process.env` accepts arbitrary string keys; the flow reads the key by exact string.

So the right fix is to make the format represent any key. The error becomes impossible rather than handled — which makes the `skippedKeys` machinery from #1373 dead code, so this PR removes it.

## How

`src/core/dotenv.ts`:
- Keys that aren't bare POSIX identifiers are double-quoted using the same escaping already applied to values; the parser accepts a bare **or** quoted key.
- Bare keys stay bare, so normal `.env` output is unchanged.
- `serializeDotenv` no longer throws.

```
"app+user@example.com_OTP_URI"="otpauth://totp/x"
NORMAL="plain"
```

Removed (now dead under round-trip): `serializeDotenvSkippingInvalid`, `SerializeDotenvSkippingInvalidResult`, `isDotenvKey`, the `invalidKey`/`skippedKeys` messages, and the `skippedEnvVarKeys` plumbing through `envVars` → `stage` → `handler` (+ JSON output field).

Net: **−128 / +49** across 11 files.

## Test plan

- `bun test src/core/dotenv.test.ts src/domains/flows/pull` → **102 pass, 0 fail** (new cases: quoted email-style OTP key, space / leading-digit keys, quoted-key parse incl. escaped `"`, round-trip with a non-POSIX key)
- `bun run typecheck`, `bun run knip`, `bun run lint` → clean

## Merge note

Base is `wiz-dotenv-core`. If #1372 lands first, retarget this to `main` — it rebases cleanly (the skip-fix it reverts came in via #1373, already in #1372).

Closes WIZ-10843

🤖 Generated with [Claude Code](https://claude.com/claude-code)

