### PR TITLE
ci(release): open Version Packages PR via qa-wolf-ops App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,16 @@ jobs:
 
       - run: bun run build
 
+      # Mint a short-lived token for the qa-wolf-ops App so the changesets action can
+      # open the "Version Packages" PR. The default GITHUB_TOKEN cannot create PRs (org
+      # policy), and PRs it opens would not trigger CI; the App token does both.
+      - name: Generate qa-wolf-ops token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.QA_WOLF_OPS_CLIENT_ID }}
+          private-key: ${{ secrets.QA_WOLF_OPS_PRIVATE_KEY }}
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
@@ -40,7 +50,7 @@ jobs:
           version: bun run version-packages
           publish: bunx changeset publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,8 @@ jobs:
 
       - run: bun run build
 
-      # Mint a short-lived token for the qa-wolf-ops App so the changesets action can
-      # open the "Version Packages" PR. The default GITHUB_TOKEN cannot create PRs (org
-      # policy), and PRs it opens would not trigger CI; the App token does both.
+      # GITHUB_TOKEN can't create PRs under org policy, and PRs it opens don't
+      # trigger CI; the App token does both.
       - name: Generate qa-wolf-ops token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0


### PR DESCRIPTION
## What

Swap the token the changesets action uses from the default `GITHUB_TOKEN` to a short-lived **qa-wolf-ops** GitHub App token, minted at runtime with `actions/create-github-app-token` (pinned to v3.2.0). Mirrors the App-token pattern already used in `wolf-ops` CI (`.github/workflows/claude-reviewer-assignment.yml`).

## Why

The release workflow has been failing at **Create Release PR or Publish**:

> HttpError: GitHub Actions is not permitted to create or approve pull requests.

The default `GITHUB_TOKEN` cannot open PRs under the org policy. The initial `1.0.0` release only shipped because the "Version Packages" PR (#1369) was opened **manually** after the action pushed the branch — the action's PR creation has never succeeded here. New changesets are now queued (→ `1.0.1`) with no open version PR, so the action tries to create one again and fails.

A second benefit: PRs opened with `GITHUB_TOKEN` do **not** trigger downstream workflows, so the Version Packages PR would skip CI. An App-token-authored PR runs CI normally.

## Prerequisites

1. ✅ Secrets **`QA_WOLF_OPS_CLIENT_ID`** / **`QA_WOLF_OPS_PRIVATE_KEY`** — confirmed organization-managed (same secrets `wolf-ops` uses).
2. ⬜ **qa-wolf-ops App installed on `qawolf/cli`** with **Contents: write** + **Pull requests: write**. The `create-github-app-token` step fails fast if the App is not installed on this repo, so the next release run is the decisive check.

## Test plan

- Merge, then confirm the next push to `main` with a pending changeset opens a `changeset-release/main` PR authored by `qa-wolf-ops[bot]` and that CI runs on it.