### PR TITLE
fix(runner): resolve #playwright alias in runtime isolates

### DIFF
--- a/src/domains/runtimeEnv/execSubpathImports.test.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.test.ts
@@ -105,8 +105,13 @@ describe("writeExecSubpathImports", () => {
       readFile: () => Promise.reject(ioError),
     };
 
-    expect(writeExecSubpathImports({ execDir, fs })).rejects.toThrow(
-      "permission denied",
-    );
+    let caught: unknown;
+    try {
+      await writeExecSubpathImports({ execDir, fs });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("permission denied");
   });
 });

--- a/src/domains/runtimeEnv/execSubpathImports.test.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { realpathSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { makeDefaultFs } from "~/shell/fs.js";
+
+import { writeExecSubpathImports } from "./execSubpathImports.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
+  );
+  tmpDirs.length = 0;
+});
+
+async function makeExecDir(): Promise<string> {
+  const d = realpathSync(
+    await mkdtemp(join(tmpdir(), "qawolf-subpath-imports-test-")),
+  );
+  tmpDirs.push(d);
+  return d;
+}
+
+type PackageJson = {
+  name?: string;
+  type?: string;
+  dependencies?: Record<string, string>;
+  imports?: Record<string, unknown>;
+};
+
+async function readPackageJson(execDir: string): Promise<PackageJson> {
+  const content = await readFile(join(execDir, "package.json"), "utf-8");
+  return JSON.parse(content) as PackageJson;
+}
+
+describe("writeExecSubpathImports", () => {
+  it("adds the #playwright alias while preserving existing fields", async () => {
+    const execDir = await makeExecDir();
+    await writeFile(
+      join(execDir, "package.json"),
+      JSON.stringify({
+        name: "@qawolf/demo",
+        type: "module",
+        dependencies: { dotenv: "^16.4.5" },
+      }),
+    );
+
+    await writeExecSubpathImports({ execDir, fs: makeDefaultFs() });
+
+    const pkg = await readPackageJson(execDir);
+    expect(pkg.imports).toEqual({ "#playwright": "playwright" });
+    expect(pkg.name).toBe("@qawolf/demo");
+    expect(pkg.type).toBe("module");
+    expect(pkg.dependencies).toEqual({ dotenv: "^16.4.5" });
+  });
+
+  it("overrides a conflicting #playwright entry but keeps other imports", async () => {
+    const execDir = await makeExecDir();
+    await writeFile(
+      join(execDir, "package.json"),
+      JSON.stringify({
+        imports: { "#playwright": "patchright", "#utils": "./src/utils.js" },
+      }),
+    );
+
+    await writeExecSubpathImports({ execDir, fs: makeDefaultFs() });
+
+    const pkg = await readPackageJson(execDir);
+    expect(pkg.imports).toEqual({
+      "#utils": "./src/utils.js",
+      "#playwright": "playwright",
+    });
+  });
+
+  it("creates package.json with imports when none exists", async () => {
+    const execDir = await makeExecDir();
+
+    await writeExecSubpathImports({ execDir, fs: makeDefaultFs() });
+
+    const pkg = await readPackageJson(execDir);
+    expect(pkg.imports).toEqual({ "#playwright": "playwright" });
+  });
+
+  it("recovers from an invalid package.json by writing a fresh imports map", async () => {
+    const execDir = await makeExecDir();
+    await writeFile(join(execDir, "package.json"), "{ not valid json");
+
+    await writeExecSubpathImports({ execDir, fs: makeDefaultFs() });
+
+    const pkg = await readPackageJson(execDir);
+    expect(pkg.imports).toEqual({ "#playwright": "playwright" });
+  });
+});

--- a/src/domains/runtimeEnv/execSubpathImports.test.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { makeDefaultFs } from "~/shell/fs.js";
+import { type Fs, makeDefaultFs } from "~/shell/fs.js";
 
 import { writeExecSubpathImports } from "./execSubpathImports.js";
 
@@ -93,5 +93,20 @@ describe("writeExecSubpathImports", () => {
 
     const pkg = await readPackageJson(execDir);
     expect(pkg.imports).toEqual({ "#playwright": "playwright" });
+  });
+
+  it("propagates a non-ENOENT read error instead of clobbering package.json", async () => {
+    const execDir = await makeExecDir();
+    const ioError = Object.assign(Error("EACCES: permission denied"), {
+      code: "EACCES",
+    });
+    const fs: Fs = {
+      ...makeDefaultFs(),
+      readFile: () => Promise.reject(ioError),
+    };
+
+    expect(writeExecSubpathImports({ execDir, fs })).rejects.toThrow(
+      "permission denied",
+    );
   });
 });

--- a/src/domains/runtimeEnv/execSubpathImports.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.ts
@@ -1,51 +1,43 @@
 import { join } from "node:path";
 
+import { z } from "zod";
+
 import { isNoEntError } from "~/core/errors.js";
 import { type Fs } from "~/shell/fs.js";
 
 /**
- * Subpath-import aliases flow bundles use to reach pinned executor packages.
- * The platform drops these from the generated bundle package.json; each target
- * is a bare specifier that resolves through the inner-hop node_modules symlink
- * (see populateInnerHop) against exec/package.json. "#playwright" points at the
- * single browser driver the CLI pins (see pinnedPackages) and is the only alias
- * flows use today.
+ * qawolf's `#playwright` driver alias, which the platform omits from bundle
+ * package.json — pointed at the pinned playwright the inner hop symlinks in.
  */
-const flowSubpathImports: Record<string, string> = {
-  "#playwright": "playwright",
-};
+const flowSubpathImports = { "#playwright": "playwright" } as const;
+
+// looseObject keeps all fields; imports is coerced to a record ({} if missing or malformed).
+const packageJsonSchema = z
+  .looseObject({ imports: z.record(z.string(), z.unknown()).catch({}) })
+  .catch({ imports: {} });
 
 export type WriteExecSubpathImportsArgs = {
   execDir: string;
   fs: Fs;
 };
 
-/**
- * Merges the flow subpath-import aliases into exec/package.json so Node and the
- * flow bundler resolve "#playwright" against the inner-hop symlink. Preserves
- * all existing package.json fields and any pre-existing imports, with the flow
- * aliases winning on conflict. Tolerates a missing (ENOENT) or invalid-JSON
- * package.json; other read errors propagate so a transient failure never
- * silently clobbers the staged bundle package.json.
- */
+/** Adds the flow subpath-import aliases to exec/package.json's imports map. */
 export async function writeExecSubpathImports(
   args: WriteExecSubpathImportsArgs,
 ): Promise<void> {
   const { execDir, fs } = args;
   const pkgPath = join(execDir, "package.json");
+  const pkg = packageJsonSchema.parse(await readPackageJson(pkgPath, fs));
 
-  const base = await readPackageJson(pkgPath, fs);
-  const merged = {
-    ...base,
-    imports: { ...readExistingImports(base), ...flowSubpathImports },
-  };
+  const merged = { ...pkg, imports: { ...pkg.imports, ...flowSubpathImports } };
   await fs.writeFile(pkgPath, JSON.stringify(merged, undefined, 2));
 }
 
-async function readPackageJson(
-  pkgPath: string,
-  fs: Fs,
-): Promise<Record<string, unknown>> {
+/**
+ * Reads and parses pkgPath. A missing file or malformed JSON yields {}; other
+ * read errors propagate so a transient failure never clobbers a staged file.
+ */
+async function readPackageJson(pkgPath: string, fs: Fs): Promise<unknown> {
   let content: string;
   try {
     content = await fs.readFile(pkgPath);
@@ -54,18 +46,8 @@ async function readPackageJson(
     throw err;
   }
   try {
-    const parsed: unknown = JSON.parse(content);
-    if (typeof parsed !== "object" || parsed === null) return {};
-    return parsed as Record<string, unknown>;
+    return JSON.parse(content);
   } catch {
     return {};
   }
-}
-
-function readExistingImports(
-  base: Record<string, unknown>,
-): Record<string, unknown> {
-  const raw = base["imports"];
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
-  return raw as Record<string, unknown>;
 }

--- a/src/domains/runtimeEnv/execSubpathImports.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.ts
@@ -1,0 +1,67 @@
+import { join } from "node:path";
+
+import { type Fs } from "~/shell/fs.js";
+
+/**
+ * Subpath-import aliases flow bundles use to reach pinned executor packages.
+ * The platform drops these from the generated bundle package.json; each target
+ * is a bare specifier that resolves through the inner-hop node_modules symlink
+ * (see populateInnerHop) against exec/package.json. "#playwright" points at the
+ * single browser driver the CLI pins (see pinnedPackages) and is the only alias
+ * flows use today.
+ */
+const flowSubpathImports: Record<string, string> = {
+  "#playwright": "playwright",
+};
+
+export type WriteExecSubpathImportsArgs = {
+  execDir: string;
+  fs: Fs;
+};
+
+/**
+ * Merges the flow subpath-import aliases into exec/package.json so Node and the
+ * flow bundler resolve "#playwright" against the inner-hop symlink. Preserves
+ * all existing package.json fields and any pre-existing imports, with the flow
+ * aliases winning on conflict, and tolerates a missing or invalid package.json.
+ */
+export async function writeExecSubpathImports(
+  args: WriteExecSubpathImportsArgs,
+): Promise<void> {
+  const { execDir, fs } = args;
+  const pkgPath = join(execDir, "package.json");
+
+  const base = await readPackageJson(pkgPath, fs);
+  const merged = {
+    ...base,
+    imports: { ...readExistingImports(base), ...flowSubpathImports },
+  };
+  await fs.writeFile(pkgPath, JSON.stringify(merged, undefined, 2));
+}
+
+async function readPackageJson(
+  pkgPath: string,
+  fs: Fs,
+): Promise<Record<string, unknown>> {
+  let content: string;
+  try {
+    content = await fs.readFile(pkgPath);
+  } catch {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    return parsed as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function readExistingImports(
+  base: Record<string, unknown>,
+): Record<string, unknown> {
+  const raw = base["imports"];
+  if (typeof raw !== "object" || raw === null) return {};
+  return raw as Record<string, unknown>;
+}

--- a/src/domains/runtimeEnv/execSubpathImports.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { isNoEntError } from "~/core/errors.js";
 import { type Fs } from "~/shell/fs.js";
 
 /**
@@ -23,7 +24,9 @@ export type WriteExecSubpathImportsArgs = {
  * Merges the flow subpath-import aliases into exec/package.json so Node and the
  * flow bundler resolve "#playwright" against the inner-hop symlink. Preserves
  * all existing package.json fields and any pre-existing imports, with the flow
- * aliases winning on conflict, and tolerates a missing or invalid package.json.
+ * aliases winning on conflict. Tolerates a missing (ENOENT) or invalid-JSON
+ * package.json; other read errors propagate so a transient failure never
+ * silently clobbers the staged bundle package.json.
  */
 export async function writeExecSubpathImports(
   args: WriteExecSubpathImportsArgs,
@@ -46,8 +49,9 @@ async function readPackageJson(
   let content: string;
   try {
     content = await fs.readFile(pkgPath);
-  } catch {
-    return {};
+  } catch (err) {
+    if (isNoEntError(err)) return {};
+    throw err;
   }
   try {
     const parsed: unknown = JSON.parse(content);
@@ -62,6 +66,6 @@ function readExistingImports(
   base: Record<string, unknown>,
 ): Record<string, unknown> {
   const raw = base["imports"];
-  if (typeof raw !== "object" || raw === null) return {};
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
   return raw as Record<string, unknown>;
 }

--- a/src/domains/runtimeEnv/prepareRunDir.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.ts
@@ -4,6 +4,7 @@ import { basename, dirname, join, resolve, sep } from "node:path";
 import { copyDirExcluding } from "~/shell/copyDir.js";
 import { type Fs, makeDefaultFs } from "~/shell/fs.js";
 
+import { writeExecSubpathImports } from "./execSubpathImports.js";
 import { populateInnerHop } from "./innerHop.js";
 import { populateOuterHop } from "./outerHop.js";
 
@@ -49,6 +50,12 @@ export async function prepareRunDir(
   await populateInnerHop({ depsRoot, execDir, fs });
 
   const stagedFiles = await stageFlowFiles({ files, projectDir, execDir, fs });
+
+  // Only the projectDir path copies a package.json into exec; standalone runs
+  // stage bare files that never use the "#playwright" alias.
+  if (projectDir !== undefined) {
+    await writeExecSubpathImports({ execDir, fs });
+  }
 
   await populateOuterHop({ projectDir, runDir, fs });
 


### PR DESCRIPTION
> Description drafted with AI, edited and reviewed by me.

<!-- Link related issues: "Closes #123" or "Relates to #456" -->

# Overview of Changes

Flows in the isolated managed runtime crashed with `ERR_PACKAGE_IMPORT_NOT_DEFINED` because the platform's pulled flow bundle strips the `imports` field from `package.json`, so the staged `exec/package.json` had no `#playwright` alias to resolve. A new `writeExecSubpathImports` helper merges the alias back in after staging, resolving it through the existing inner-hop `node_modules` symlink to the pinned `playwright` package — fixing resolution for both the Node import path and the compiled-binary `Bun.build` path.

Before this fix, running a flow that imports from `#playwright` failed at module resolution:

```
• Sign Out /Users/michael/Library/Application Support/qawolf-nodejs/runtime-runs/5b2e6a877faea7fa-55999/exec/src/flows/authentication/sign-out.flow.ts
    FlowRunError: Flow "sign-out.flow" failed on attempt 1
    Caused by: TypeError [ERR_PACKAGE_IMPORT_NOT_DEFINED]: Package import specifier "#playwright" is not defined in package /Users/michael/Library/Application Support/qawolf-nodejs/runtime-runs/5b2e6a877faea7fa-55999/exec/package.json imported from /Users/michael/Library/Application Support/qawolf-nodejs/runtime-runs/5b2e6a877faea7fa-55999/exec/src/lib/entry-point-page-object.ts
        at importNotDefined (node:internal/modules/esm/resolve:297:10)
        at packageImportsResolve (node:internal/modules/esm/resolve:747:9)
        at moduleResolve (node:internal/modules/esm/resolve:844:16)
        at defaultResolve (node:internal/modules/esm/resolve:988:11)
        at #cachedDefaultResolve (node:internal/modules/esm/loader:697:20)
        at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:714:38)
        at nextStep (node:internal/modules/customization_hooks:189:26)
        at nextStep (node:internal/modules/customization_hooks:189:26)
        at resolveWithHooks (node:internal/modules/customization_hooks:417:10)

  ✗ passed (0.26s)
```

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

1. Pull a flow bundle that imports from `#playwright` and run it via the CLI's managed runtime (`projectDir` set).
2. Verify `exec/package.json` in the staged run dir contains `"imports": { "#playwright": "playwright" }` alongside the bundle's original fields.
3. Confirm the flow executes without `ERR_PACKAGE_IMPORT_NOT_DEFINED`, in both the Node dev path and a compiled binary build.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)
