### PR TITLE
chore(runner): add changeset for #playwright alias fix

### DIFF
--- a/.changeset/resolve-playwright-subpath-import.md
+++ b/.changeset/resolve-playwright-subpath-import.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Resolve the `#playwright` subpath import when running flows in the isolated managed runtime. QA Wolf flow bundles import Playwright through a Node.js `imports` alias (`#playwright`), but the pulled bundle's `package.json` omits the `imports` field, so the staged `exec/package.json` could not resolve it and flows failed with `ERR_PACKAGE_IMPORT_NOT_DEFINED`. The CLI now merges the `#playwright` alias into the staged `exec/package.json`, pointing it at the pinned Playwright resolved through the inner-hop `node_modules` symlink — fixing both the Node import path and the compiled-binary bundle path.


### PR DESCRIPTION
> Description drafted with AI, edited and reviewed by me.

# Overview of Changes

Adds the missing changeset for the `#playwright` runtime-isolate fix that merged in #1386 **without one**, so no release was triggered. This PR carries only the changeset (`patch` bump for `@qawolf/cli`) to cut a release that includes that fix.

The fix itself (already on `main`): flows in the isolated managed runtime crashed with `ERR_PACKAGE_IMPORT_NOT_DEFINED` because the pulled bundle's `package.json` omits the `imports` field. `writeExecSubpathImports` now merges the `#playwright` alias into the staged `exec/package.json`, resolving it through the inner-hop `node_modules` symlink to the pinned Playwright.

# Testing

No code changes — changeset only. Validated with:

```bash
bunx changeset status
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable — changeset only)
- [x] No breaking changes
