### PR TITLE
feat(cli): add --no-browser-deps to skip browser OS dependency install

### DIFF
--- a/.changeset/no-browser-deps-flag.md
+++ b/.changeset/no-browser-deps-flag.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": minor
+---
+
+Add `--no-browser-deps` to `flows run`, `install`, and `install browsers`. On Linux the CLI runs `playwright install --with-deps`, whose OS dependency step shells out to `apt-get` and needs root — on non-root machines without sudo it hangs or fails at a `su` prompt (`playwright install chromium failed: Password:`) even when every system library is already installed. The new flag skips that step and only installs the browsers themselves, so non-root environments with preinstalled system libraries (for example CI images baked with `playwright install-deps`, or a shared `PLAYWRIGHT_BROWSERS_PATH` cache) can run web flows. Default behavior is unchanged; if libraries are missing at launch, Playwright reports the exact packages to install.

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -6,25 +6,27 @@ exports[`--help output qawolf 1`] = `
 Run QA Wolf flows locally
 
 Options:
-  -V, --version       output the version number
-  --verbose           Enable debug logging to stderr
-  --json              Output as JSON
-  --agent             Output for agent consumption
-  -h, --help          display help for command
+  -V, --version                output the version number
+  --verbose                    Enable debug logging to stderr
+  --json                       Output as JSON
+  --agent                      Output for agent consumption
+  -h, --help                   display help for command
 
 Commands:
-  auth                Manage authentication with QA Wolf
-  doctor [options]    Diagnose problems running flows locally
-  flows               Manage and run QA Wolf flows
-  init [options]      Scaffold a QA Wolf project in the current directory
-  install [pattern]   Install every runtime dependency the project's flows need
-  automate [options]  Request an automation that builds the selected draft flows
-                      in an environment.
-  environment         QA Wolf public API environment commands
-  issue               QA Wolf public API issue commands
-  run                 Trigger and manage QA Wolf runs on the platform
-  tag                 QA Wolf public API tag commands
-  help [command]      display help for command
+  auth                         Manage authentication with QA Wolf
+  doctor [options]             Diagnose problems running flows locally
+  flows                        Manage and run QA Wolf flows
+  init [options]               Scaffold a QA Wolf project in the current
+                               directory
+  install [options] [pattern]  Install every runtime dependency the project's
+                               flows need
+  automate [options]           Request an automation that builds the selected
+                               draft flows in an environment.
+  environment                  QA Wolf public API environment commands
+  issue                        QA Wolf public API issue commands
+  run                          Trigger and manage QA Wolf runs on the platform
+  tag                          QA Wolf public API tag commands
+  help [command]               display help for command
 "
 `;
 
@@ -49,18 +51,23 @@ exports[`--help output qawolf install 1`] = `
 Install every runtime dependency the project's flows need
 
 Arguments:
-  pattern             Glob limiting which flows determine required dependencies
+  pattern                       Glob limiting which flows determine required
+                                dependencies
 
 Options:
-  -h, --help          display help for command
+  --no-browser-deps             Skip installing OS-level browser dependencies
+                                (Linux --with-deps, which needs root); requires
+                                the system libraries to already be present
+  -h, --help                    display help for command
 
 Commands:
-  browsers [pattern]  Install Playwright browsers used by the project's web
-                      flows
-  android [pattern]   Install Android system images, AVDs, and the Appium driver
-                      used by the project's Android flows
-  clear [options]     Remove the managed runtime cache (all installed runtime
-                      versions)
+  browsers [options] [pattern]  Install Playwright browsers used by the
+                                project's web flows
+  android [pattern]             Install Android system images, AVDs, and the
+                                Appium driver used by the project's Android
+                                flows
+  clear [options]               Remove the managed runtime cache (all installed
+                                runtime versions)
 
 Examples:
   $ qawolf install
@@ -74,7 +81,10 @@ exports[`--help output qawolf install browsers 1`] = `
 Install Playwright browsers used by the project's web flows
 
 Options:
-  -h, --help  display help for command
+  --no-browser-deps  Skip installing OS-level browser dependencies (Linux
+                     --with-deps, which needs root); requires the system
+                     libraries to already be present
+  -h, --help         display help for command
 
 Examples:
   $ qawolf install browsers
@@ -180,6 +190,9 @@ Options:
   --deps <dir>          Use this prepared dependency directory instead of
                         auto-installing the runtime; or set QAWOLF_RUNTIME_DIR
                         to relocate the managed runtime
+  --no-browser-deps     Skip installing OS-level browser dependencies (Linux
+                        --with-deps, which needs root); requires the system
+                        libraries to already be present
   -h, --help            display help for command
 
 Examples:

--- a/src/commands/flows/buildFlowsRunDeps.ts
+++ b/src/commands/flows/buildFlowsRunDeps.ts
@@ -49,6 +49,7 @@ export function buildFlowsRunDeps(args: BuildFlowsRunDepsArgs): FlowsRunDeps {
       installBrowserList(innerCtx, browsers, {
         spawn: defaultSpawn,
         platform: process.platform,
+        browserDeps: flags.browserDeps,
         playwrightCliPath: resolvePlaywrightCli(resolvedDir, process.platform),
       }),
     runWebFlow: defaultRunWebFlow,

--- a/src/commands/flows/hybridRun.test.ts
+++ b/src/commands/flows/hybridRun.test.ts
@@ -88,6 +88,7 @@ function defaultFlags(): FlowsRunFlags {
     harContent: "omit",
     outputDir: "/tmp",
     headed: false,
+    browserDeps: true,
   };
 }
 

--- a/src/commands/flows/run.register.ts
+++ b/src/commands/flows/run.register.ts
@@ -103,6 +103,10 @@ export function registerFlowsRunCommand(
       "--deps <dir>",
       "Use this prepared dependency directory instead of auto-installing the runtime; or set QAWOLF_RUNTIME_DIR to relocate the managed runtime",
     )
+    .option(
+      "--no-browser-deps",
+      "Skip installing OS-level browser dependencies (Linux --with-deps, which needs root); requires the system libraries to already be present",
+    )
     .addHelpText("after", runExamples)
     .action(
       (

--- a/src/commands/flows/runDefaults.handle.test.ts
+++ b/src/commands/flows/runDefaults.handle.test.ts
@@ -71,6 +71,7 @@ function defaultFlags(): FlowsRunFlags {
     harContent: "omit",
     outputDir: "/tmp",
     headed: false,
+    browserDeps: true,
   };
 }
 

--- a/src/commands/flows/runDefaults.reporterWiring.test.ts
+++ b/src/commands/flows/runDefaults.reporterWiring.test.ts
@@ -32,6 +32,7 @@ function defaultFlags(): FlowsRunFlags {
     harContent: "omit",
     outputDir: "/tmp",
     headed: false,
+    browserDeps: true,
   };
 }
 

--- a/src/commands/flows/runStagedFlows.test.ts
+++ b/src/commands/flows/runStagedFlows.test.ts
@@ -59,6 +59,7 @@ function defaultFlags(): FlowsRunFlags {
     harContent: "omit",
     outputDir: "/tmp",
     headed: false,
+    browserDeps: true,
   };
 }
 

--- a/src/commands/install/all.ts
+++ b/src/commands/install/all.ts
@@ -101,6 +101,7 @@ export async function installAll(
 export async function handleInstall(
   ctx: CommandContext,
   pattern: string | undefined,
+  options: { browserDeps: boolean },
 ): Promise<CommandResult> {
   const { fs } = ctx;
   return installAll(ctx, pattern, {
@@ -109,7 +110,11 @@ export async function handleInstall(
       defaultExpandPatterns(patterns, cwd ?? process.cwd(), undefined, fs),
     peekFlowMeta: makePeekFlowMeta(fs),
     resolveDepsRoot: (files) => resolveDepsRoot({ files, fs }),
-    installBrowsers: handleInstallBrowsers,
+    installBrowsers: (innerCtx, innerPattern, envDir) =>
+      handleInstallBrowsers(innerCtx, innerPattern, {
+        envDir,
+        browserDeps: options.browserDeps,
+      }),
     installAndroid: handleInstallAndroid,
   });
 }

--- a/src/commands/install/browserDepsFlag.test.ts
+++ b/src/commands/install/browserDepsFlag.test.ts
@@ -35,6 +35,19 @@ describe("mergedBrowserDeps", () => {
     expect(seen).toBe(false);
   });
 
+  it("is false when the flag is written before the subcommand", async () => {
+    let seen: boolean | undefined;
+    const program = makeInstallLikeProgram((merged) => {
+      seen = merged;
+    });
+
+    await program.parseAsync(["--no-browser-deps", "browsers"], {
+      from: "user",
+    });
+
+    expect(seen).toBe(false);
+  });
+
   it("is true when the flag is not passed at all", async () => {
     let seen: boolean | undefined;
     const program = makeInstallLikeProgram((merged) => {

--- a/src/commands/install/browserDepsFlag.test.ts
+++ b/src/commands/install/browserDepsFlag.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
+
+import { mergedBrowserDeps } from "./browserDepsFlag.js";
+
+// Mirrors the real `install` / `install browsers` registration: both commands
+// define --no-browser-deps. In Commander's default parsing mode the parent
+// consumes the flag even when it is written after the subcommand name, so the
+// subcommand must merge its own opts with the parent's.
+function makeInstallLikeProgram(onAction: (merged: boolean) => void): Command {
+  const program = new Command()
+    .name("install")
+    .option("--no-browser-deps")
+    .exitOverride();
+  program
+    .command("browsers")
+    .option("--no-browser-deps")
+    .action((opts: { browserDeps: boolean }, command: Command) => {
+      onAction(mergedBrowserDeps(opts.browserDeps, command));
+    });
+  return program;
+}
+
+describe("mergedBrowserDeps", () => {
+  it("is false when the parent consumed --no-browser-deps written after the subcommand", async () => {
+    let seen: boolean | undefined;
+    const program = makeInstallLikeProgram((merged) => {
+      seen = merged;
+    });
+
+    await program.parseAsync(["browsers", "--no-browser-deps"], {
+      from: "user",
+    });
+
+    expect(seen).toBe(false);
+  });
+
+  it("is true when the flag is not passed at all", async () => {
+    let seen: boolean | undefined;
+    const program = makeInstallLikeProgram((merged) => {
+      seen = merged;
+    });
+
+    await program.parseAsync(["browsers"], { from: "user" });
+
+    expect(seen).toBe(true);
+  });
+
+  it("is false without a parent when the subcommand itself parsed the flag", () => {
+    expect(mergedBrowserDeps(false, new Command())).toBe(false);
+  });
+});

--- a/src/commands/install/browserDepsFlag.ts
+++ b/src/commands/install/browserDepsFlag.ts
@@ -1,0 +1,12 @@
+import type { Command } from "commander";
+
+/**
+ * Resolves --no-browser-deps for a subcommand whose parent registers the same
+ * flag. Commander's default parsing lets the parent consume the flag even when
+ * it is written after the subcommand name, leaving the subcommand's own opts at
+ * the default. The flag is negation-only, so ANDing both scopes is exact.
+ */
+export function mergedBrowserDeps(local: boolean, command: Command): boolean {
+  const parent = command.parent?.opts<{ browserDeps?: boolean }>().browserDeps;
+  return local && parent !== false;
+}

--- a/src/commands/install/browsers.fixtures.ts
+++ b/src/commands/install/browsers.fixtures.ts
@@ -27,6 +27,7 @@ export type DepsOverrides = {
   metaByFile?: Record<string, FakeMeta>;
   spawn?: SpawnFn;
   platform?: NodeJS.Platform;
+  browserDeps?: boolean;
 };
 
 export function makeDeps(overrides: DepsOverrides): InstallBrowsersDeps {
@@ -36,6 +37,7 @@ export function makeDeps(overrides: DepsOverrides): InstallBrowsersDeps {
     cwd: "/proj",
     spawn: overrides.spawn ?? spawnSequence(ok),
     platform: overrides.platform ?? "darwin",
+    browserDeps: overrides.browserDeps ?? true,
     expandPatterns: mock<InstallBrowsersDeps["expandPatterns"]>(() =>
       Promise.resolve([...files]),
     ),

--- a/src/commands/install/browsers.test.ts
+++ b/src/commands/install/browsers.test.ts
@@ -120,6 +120,17 @@ describe("installBrowsers", () => {
     ]);
   });
 
+  it("omits --with-deps on Linux when browserDeps is false", async () => {
+    const { deps, ctx } = setup("Web - Chrome", {
+      platform: "linux",
+      browserDeps: false,
+    });
+
+    await installBrowsers(ctx, undefined, deps);
+
+    expect(deps.spawn).toHaveBeenCalledWith(fakeCli, ["install", "chromium"]);
+  });
+
   it("throws and stops on first non-zero exit", async () => {
     const ctx = makeCtx();
     const deps = makeDeps({

--- a/src/commands/install/browsers.ts
+++ b/src/commands/install/browsers.ts
@@ -11,15 +11,17 @@ import { installBrowsers } from "~/domains/install/browsers.js";
 export async function handleInstallBrowsers(
   ctx: CommandContext,
   pattern: string | undefined,
-  envDir?: string,
+  options: { envDir: string | undefined; browserDeps: boolean },
 ): Promise<CommandResult> {
   const cwd = process.cwd();
   const { fs } = ctx;
+  const { envDir, browserDeps } = options;
 
   return installBrowsers(ctx, pattern, {
     cwd,
     spawn: defaultSpawn,
     platform: process.platform,
+    browserDeps,
     expandPatterns: (patterns, dir) =>
       defaultExpandPatterns(patterns, dir ?? cwd, undefined, fs),
     peekFlowMeta: makePeekFlowMeta(fs),

--- a/src/commands/install/index.ts
+++ b/src/commands/install/index.ts
@@ -9,6 +9,9 @@ import { handleInstall } from "./all.js";
 import { handleInstallBrowsers } from "./browsers.js";
 import { handleInstallClear } from "./clear.js";
 
+const noBrowserDepsDescription =
+  "Skip installing OS-level browser dependencies (Linux --with-deps, which needs root); requires the system libraries to already be present";
+
 export function registerInstallCommand(
   program: Command,
   signals: SignalRegistry,
@@ -19,6 +22,7 @@ export function registerInstallCommand(
       "[pattern]",
       "Glob limiting which flows determine required dependencies",
     )
+    .option("--no-browser-deps", noBrowserDepsDescription)
     .addHelpText(
       "after",
       `
@@ -26,15 +30,21 @@ Examples:
   $ qawolf install
   $ qawolf install "flows/checkout/**"`,
     )
-    .action((pattern: string | undefined, opts: unknown, command: Command) => {
-      return withContext(signals, (ctx) => handleInstall(ctx, pattern))(
-        opts,
-        command,
-      );
-    });
+    .action(
+      (
+        pattern: string | undefined,
+        opts: { browserDeps: boolean },
+        command: Command,
+      ) => {
+        return withContext(signals, (ctx) =>
+          handleInstall(ctx, pattern, { browserDeps: opts.browserDeps }),
+        )(opts, command);
+      },
+    );
 
   declareCommandKind(install.command("browsers [pattern]"), "local")
     .description("Install Playwright browsers used by the project's web flows")
+    .option("--no-browser-deps", noBrowserDepsDescription)
     .addHelpText(
       "after",
       `
@@ -42,12 +52,20 @@ Examples:
   $ qawolf install browsers
   $ qawolf install browsers "flows/web/**"`,
     )
-    .action((pattern: string | undefined, opts: unknown, command: Command) => {
-      return withContext(signals, (ctx) => handleInstallBrowsers(ctx, pattern))(
-        opts,
-        command,
-      );
-    });
+    .action(
+      (
+        pattern: string | undefined,
+        opts: { browserDeps: boolean },
+        command: Command,
+      ) => {
+        return withContext(signals, (ctx) =>
+          handleInstallBrowsers(ctx, pattern, {
+            envDir: undefined,
+            browserDeps: opts.browserDeps,
+          }),
+        )(opts, command);
+      },
+    );
 
   declareCommandKind(install.command("android [pattern]"), "local")
     .description(

--- a/src/commands/install/index.ts
+++ b/src/commands/install/index.ts
@@ -7,6 +7,7 @@ import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { handleInstallAndroid } from "./android.js";
 import { handleInstall } from "./all.js";
 import { handleInstallBrowsers } from "./browsers.js";
+import { mergedBrowserDeps } from "./browserDepsFlag.js";
 import { handleInstallClear } from "./clear.js";
 
 const noBrowserDepsDescription =
@@ -61,7 +62,7 @@ Examples:
         return withContext(signals, (ctx) =>
           handleInstallBrowsers(ctx, pattern, {
             envDir: undefined,
-            browserDeps: opts.browserDeps,
+            browserDeps: mergedBrowserDeps(opts.browserDeps, command),
           }),
         )(opts, command);
       },

--- a/src/commands/program.test.ts
+++ b/src/commands/program.test.ts
@@ -79,6 +79,23 @@ describe("createProgram", () => {
     expect(run).toBeDefined();
   });
 
+  it("registers --no-browser-deps (default true) on flows run, install, and install browsers", () => {
+    const program = createProgram({ signals: noopSignals });
+    const flows = program.commands.find((c) => c.name() === "flows");
+    const run = flows?.commands.find((c) => c.name() === "run");
+    const install = program.commands.find((c) => c.name() === "install");
+    const browsers = install?.commands.find((c) => c.name() === "browsers");
+
+    for (const command of [run, install, browsers]) {
+      expect(command).toBeDefined();
+      const option = command?.options.find(
+        (o) => o.long === "--no-browser-deps",
+      );
+      expect(option).toBeDefined();
+      expect(command?.getOptionValue("browserDeps")).toBe(true);
+    }
+  });
+
   it("throws on unknown option", () => {
     let err: unknown;
     try {

--- a/src/domains/install/browsers.ts
+++ b/src/domains/install/browsers.ts
@@ -10,6 +10,8 @@ export type InstallBrowsersDeps = {
   readonly cwd: string;
   readonly spawn: SpawnFn;
   readonly platform: NodeJS.Platform;
+  /** When false, skip Playwright's OS-level dependency install (Linux `--with-deps`). */
+  readonly browserDeps: boolean;
   readonly expandPatterns: (
     patterns: string[],
     cwd?: string,
@@ -21,6 +23,8 @@ export type InstallBrowsersDeps = {
 export type InstallBrowserListDeps = {
   readonly spawn: SpawnFn;
   readonly platform: NodeJS.Platform;
+  /** When false, skip Playwright's OS-level dependency install (Linux `--with-deps`). */
+  readonly browserDeps: boolean;
   readonly playwrightCliPath: string;
 };
 
@@ -33,7 +37,7 @@ export async function installBrowserList(
     browsers.map((browser) => ({
       message: installMessages.installingBrowser(browser),
       task: async () => {
-        const args = buildArgs(browser, deps.platform);
+        const args = buildArgs(browser, deps.platform, deps.browserDeps);
         const result = await deps.spawn(deps.playwrightCliPath, args);
         if (result.exitCode !== 0) {
           throw new Error(formatError(browser, result));
@@ -62,6 +66,7 @@ export async function installBrowsers(
   await installBrowserList(ctx, browsers, {
     spawn: deps.spawn,
     platform: deps.platform,
+    browserDeps: deps.browserDeps,
     playwrightCliPath,
   });
 }
@@ -79,8 +84,15 @@ async function collectBrowsers(
   return [...seen].sort();
 }
 
-function buildArgs(browser: BrowserName, platform: NodeJS.Platform): string[] {
-  return platform === "linux"
+function buildArgs(
+  browser: BrowserName,
+  platform: NodeJS.Platform,
+  browserDeps: boolean,
+): string[] {
+  // --with-deps runs apt-get, which needs root even when every package is
+  // already present; --no-browser-deps lets non-root Linux runners with
+  // preinstalled system libraries skip it.
+  return platform === "linux" && browserDeps
     ? ["install", "--with-deps", browser]
     : ["install", browser];
 }

--- a/src/domains/runner/run.fixtures.ts
+++ b/src/domains/runner/run.fixtures.ts
@@ -47,6 +47,7 @@ export function defaultFlags(): FlowsRunFlags {
     harContent: "omit",
     outputDir: "qawolf-output",
     headed: false,
+    browserDeps: true,
   };
 }
 

--- a/src/domains/runner/runInternals.ts
+++ b/src/domains/runner/runInternals.ts
@@ -42,6 +42,8 @@ export type FlowsRunFlags = {
   readonly junit?: string | boolean;
   // --deps <dir>: use this prepared dependency directory instead of auto-resolving.
   readonly deps?: string;
+  // --no-browser-deps: skip Playwright's OS dependency install (Linux --with-deps).
+  readonly browserDeps: boolean;
 };
 
 export type FlowsRunDeps = {
@@ -130,9 +132,8 @@ export async function dispatchFlow({
       error: new FlowRunError(flow.name, 1, err),
     };
   }
-  // Stamping is supplementary diagnostic info — surface I/O failures via
-  // deps.warn so the user/support can see them, but never let a lookup
-  // error erase the flow's pass/fail outcome.
+  // Stamping is supplementary diagnostics — surface I/O failures via
+  // deps.warn, but never let a lookup error erase the pass/fail outcome.
   let stamp;
   try {
     stamp = await deps.findFlowStamp(flow.file);
@@ -143,8 +144,7 @@ export async function dispatchFlow({
   if (stamp) run = { ...run, manifest: stamp };
   const durationMs = deps.now() - flowStart;
   const outcome = run.passed ? "pass" : "fail";
-  const attempts = run.attempts;
-  const attempt = pluralize(attempts, "attempt");
+  const attempt = pluralize(run.attempts, "attempt");
   deps.logger?.info(`${outcome}: ${flow.name} (${durationMs}ms, ${attempt})`);
   return { run, durationMs };
 }


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

On Linux the CLI unconditionally runs `playwright install --with-deps <browser>` before web flows. The `--with-deps` step shells out to `apt-get`, which requires root **even when every system library is already installed** (apt needs its lock). On non-root machines without sudo, Playwright falls back to `su root -c "apt-get …"`, which either aborts (`playwright install chromium failed: Password:`) or hangs indefinitely waiting for a password — there is no timeout. This makes `flows run` unusable on non-root CI runners regardless of how well-provisioned the image is.

- **`--no-browser-deps`** (on `flows run`, `install`, and `install browsers`): drops `--with-deps` from the Playwright invocation, so only the browsers themselves are installed — no apt, no root. Commander's negated-boolean handling keeps the default (`browserDeps: true`) unchanged for everyone else. Intended for environments where system libraries are preinstalled (e.g. images baked with `playwright install-deps`); if they aren't, the failure moves to browser launch, where Playwright names the exact missing packages.
- **Parent/child flag resolution** (`browserDepsFlag.ts`): both `install` and `install browsers` register the flag, and in Commander's default parsing mode the parent consumes it even when written after the subcommand name — leaving the subcommand's opts at the default. `mergedBrowserDeps` ANDs both scopes (exact, since the flag is negation-only). Found via runtime verification; covered by a regression test reproducing the topology.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- New tests: `buildArgs` omits `--with-deps` on Linux when `browserDeps` is false; flag registered with default `true` on all three commands; `mergedBrowserDeps` parent-consumption regression.
- A/B verified against the built CLI in an `ubuntu:24.04` container as a non-root user with no sudo (real `playwright@1.58.2` + `@qawolf/flows@0.1.4`, real browser download):

| Scenario | Pre-fix / no flag | With `--no-browser-deps` |
|---|---|---|
| `flows run`, bare Ubuntu 24.04, non-root, no sudo | ❌ wedges at `su root -c apt-get…`, then `playwright install chromium failed: Password:` | ✅ chromium installed, flow ran, exit 0, no `su` spawned |
| Same box after every system library was installed (as root, image-build style) | ❌ still fails — apt needs root even with nothing to install | ✅ install step no-ops |
| Flow that launches real Chromium, navigates, asserts title/text (libs baked into image) | — | ✅ passes as non-root |
| Arg matrix via arg-logging playwright stub (`install browsers`, `install`, `flows run` × flag) | default keeps `install --with-deps chromium` | flag yields `install chromium` on all three commands |
| Probes | — | typo `--no-browser-dep` → `(Did you mean --no-browser-deps?)`; flag twice → idempotent |

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
