### PR TITLE
feat(cli): notify when a newer published version is available

### DIFF
--- a/.changeset/update-check-notice.md
+++ b/.changeset/update-check-notice.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": minor
+---
+
+The CLI now checks the npm registry for a newer published version while a command runs. After the command completes, the CLI shows an update notice one time for each new version. Human mode shows a styled note. Agent mode writes plain text to stderr. JSON mode writes a note diagnostic to stderr and does not change stdout. Set QAWOLF_NO_UPDATE_CHECK=1 to disable the check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,8 @@ src/
 │   ├── patternArgs.ts   # CLI pattern argument parsing
 │   ├── pluralize.ts     # pluralize
 │   ├── sleep.ts         # sleep
-│   └── types.ts         # BrowserName, VideoMode, TraceMode, HarMode, TestCounts
+│   ├── types.ts         # BrowserName, VideoMode, TraceMode, HarMode, TestCounts
+│   └── version.ts       # isNewerVersion
 ├── shell/               # I/O executors — process spawning, UI, API clients
 │   ├── appium/          # Android emulator + Appium server lifecycle
 │   ├── commandContext.ts # CommandContext, CommandResult types
@@ -52,6 +53,7 @@ src/
 │   ├── logger.ts        # pino-based structured logger
 │   ├── manifest/        # bundle manifest read/lookup
 │   ├── npm.ts           # resolveNpmCommand
+│   ├── npmRegistry.ts   # fetchLatestVersion (update-check registry lookup)
 │   ├── platform/        # tRPC client, getIdentity, signed-URL/bundle download, team storage
 │   ├── reporter/        # Reporter interface, console + JUnit + composite reporters
 │   ├── resolveExport.ts # ESM export resolution
@@ -68,7 +70,8 @@ src/
 │   ├── flows/           # expandPatterns, peekFlowMeta, flowsList, pull/
 │   ├── init/            # init handler + templates
 │   ├── install/         # installBrowsers, installBrowserList
-│   └── runner/          # flowsRun, runWebFlow, runAndroidFlow, worker dispatch + pool
+│   ├── runner/          # flowsRun, runWebFlow, runAndroidFlow, worker dispatch + pool
+│   └── updateCheck/     # startUpdateCheck: new-version notice after commands
 └── commands/            # Thin CLI glue — Commander registration + composite root
     ├── context.ts       # withContext() Commander action wrapper
     ├── program.ts       # createProgram() factory

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -27,6 +27,12 @@ import type {
   CommandContext,
   CommandResult,
 } from "~/shell/commandContext.js";
+import { fetchLatestVersion } from "~/shell/npmRegistry.js";
+import {
+  startUpdateCheck,
+  type UpdateNotifier,
+} from "~/domains/updateCheck/updateCheck.js";
+import packageJson from "../../package.json" with { type: "json" };
 
 type ContextAction = (ctx: CommandContext) => Promise<CommandResult>;
 type AuthContextAction = (ctx: AuthCommandContext) => Promise<CommandResult>;
@@ -39,6 +45,7 @@ export function buildBaseContext(
   ctx: CommandContext;
   apiBaseUrl: string;
   loggingSystem: LoggingSystem;
+  updateNotifier: UpdateNotifier;
 } {
   const env = process.env;
   const flags = command.optsWithGlobals<GlobalFlags>();
@@ -61,12 +68,22 @@ export function buildBaseContext(
     ...(verboseWrite ? { verboseWrite } : {}),
   });
   const apiBaseUrl = resolveHostUrl(env);
+  const fs = makeDefaultFs();
+  const ui = createUI(outputMode, {
+    clack,
+    ...(verboseTarget ? { verboseTarget } : {}),
+  });
+  const updateNotifier = startUpdateCheck({
+    env,
+    currentVersion: packageJson.version,
+    configDir: getConfigDir(),
+    fs,
+    fetchLatestVersion: () => fetchLatestVersion(packageJson.name),
+    renderNotice: (body, title) => ui.note(body, title),
+  });
   return {
     ctx: {
-      ui: createUI(outputMode, {
-        clack,
-        ...(verboseTarget ? { verboseTarget } : {}),
-      }),
+      ui,
       configDir: getConfigDir(),
       outputMode,
       isInteractive: isInteractive({
@@ -76,10 +93,11 @@ export function buildBaseContext(
       apiBaseUrl,
       signals,
       log: (scope) => loggingSystem.createLogger(scope),
-      fs: makeDefaultFs(),
+      fs,
     },
     apiBaseUrl,
     loggingSystem,
+    updateNotifier,
   };
 }
 
@@ -88,7 +106,10 @@ export function withContext(
   fn: ContextAction,
 ): (opts: unknown, command: Command) => Promise<void> {
   return async (_opts: unknown, command: Command): Promise<void> => {
-    const { ctx, loggingSystem } = buildBaseContext(command, signals);
+    const { ctx, loggingSystem, updateNotifier } = buildBaseContext(
+      command,
+      signals,
+    );
     try {
       const result = await fn(ctx);
       if (result !== undefined) {
@@ -100,6 +121,7 @@ export function withContext(
       process.exitCode = 1;
     } finally {
       loggingSystem.flush();
+      await updateNotifier.notifyIfOutdated();
     }
   };
 }
@@ -113,7 +135,7 @@ export function withAuthContext(
   } = {},
 ): (opts: unknown, command: Command) => Promise<void> {
   return async (_opts: unknown, command: Command): Promise<void> => {
-    const { ctx, apiBaseUrl, loggingSystem } = buildBaseContext(
+    const { ctx, apiBaseUrl, loggingSystem, updateNotifier } = buildBaseContext(
       command,
       signals,
     );
@@ -127,6 +149,7 @@ export function withAuthContext(
     });
     if (resolved === undefined) {
       loggingSystem.flush();
+      await updateNotifier.notifyIfOutdated();
       return;
     }
 
@@ -150,6 +173,7 @@ export function withAuthContext(
       process.exitCode = 1;
     } finally {
       loggingSystem.flush();
+      await updateNotifier.notifyIfOutdated();
     }
   };
 }

--- a/src/core/messages/index.ts
+++ b/src/core/messages/index.ts
@@ -5,3 +5,4 @@ export { initMessages } from "./init.js";
 export { installMessages } from "./install.js";
 export { runnerMessages } from "./runner.js";
 export { packageLoadFailed } from "./toolNotFound.js";
+export { updateCheckMessages } from "./updateCheck.js";

--- a/src/core/messages/updateCheck.ts
+++ b/src/core/messages/updateCheck.ts
@@ -1,0 +1,5 @@
+export const updateCheckMessages = {
+  title: "Update available",
+  body: (current: string, latest: string): string =>
+    `@qawolf/cli ${current} → ${latest}\nRun \`npm install -g @qawolf/cli\` to update.`,
+};

--- a/src/core/version.test.ts
+++ b/src/core/version.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+
+import { isNewerVersion } from "./version.js";
+
+describe("isNewerVersion", () => {
+  it("detects newer patch, minor, and major releases", () => {
+    expect(isNewerVersion("1.3.2", "1.3.3")).toBe(true);
+    expect(isNewerVersion("1.3.2", "1.4.0")).toBe(true);
+    expect(isNewerVersion("1.3.2", "2.0.0")).toBe(true);
+  });
+
+  it("compares numerically, not lexicographically", () => {
+    expect(isNewerVersion("1.9.0", "1.10.0")).toBe(true);
+    expect(isNewerVersion("1.10.0", "1.9.0")).toBe(false);
+  });
+
+  it("returns false for equal or older versions", () => {
+    expect(isNewerVersion("1.3.2", "1.3.2")).toBe(false);
+    expect(isNewerVersion("1.3.2", "1.3.1")).toBe(false);
+    expect(isNewerVersion("2.0.0", "1.9.9")).toBe(false);
+  });
+
+  it("returns false when either version is not a plain release", () => {
+    expect(isNewerVersion("1.3.2", "1.4.0-beta.1")).toBe(false);
+    expect(isNewerVersion("1.3.2-beta.1", "1.4.0")).toBe(false);
+    expect(isNewerVersion("1.3.2", "not-a-version")).toBe(false);
+    expect(isNewerVersion("", "1.4.0")).toBe(false);
+  });
+});

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -11,9 +11,9 @@ function parseRelease(version: string): Release | undefined {
 }
 
 /**
- * True when `latest` is a strictly newer release than `current`. Only plain
- * `major.minor.patch` versions compare; anything else (prereleases, garbage)
- * returns false so callers stay silent rather than mis-notify.
+ * Only plain `major.minor.patch` versions compare. Prereleases and
+ * unparseable input return false, so callers stay silent rather than
+ * mis-notify.
  */
 export function isNewerVersion(current: string, latest: string): boolean {
   const cur = parseRelease(current);

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,25 @@
+type Release = { major: number; minor: number; patch: number };
+
+function parseRelease(version: string): Release | undefined {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return undefined;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+/**
+ * True when `latest` is a strictly newer release than `current`. Only plain
+ * `major.minor.patch` versions compare; anything else (prereleases, garbage)
+ * returns false so callers stay silent rather than mis-notify.
+ */
+export function isNewerVersion(current: string, latest: string): boolean {
+  const cur = parseRelease(current);
+  const next = parseRelease(latest);
+  if (cur === undefined || next === undefined) return false;
+  if (next.major !== cur.major) return next.major > cur.major;
+  if (next.minor !== cur.minor) return next.minor > cur.minor;
+  return next.patch > cur.patch;
+}

--- a/src/domains/updateCheck/updateCheck.test.ts
+++ b/src/domains/updateCheck/updateCheck.test.ts
@@ -12,6 +12,7 @@ function makeNotifier(overrides: {
   currentVersion?: string;
   fs?: Fs;
   fetchLatestVersion?: () => Promise<string | undefined>;
+  renderNotice?: () => void;
 }) {
   const written: { body: string; title: string }[] = [];
   let fetchCalls = 0;
@@ -26,7 +27,10 @@ function makeNotifier(overrides: {
         overrides.fetchLatestVersion ?? (() => Promise.resolve("2.0.0"))
       )();
     },
-    renderNotice: (body, title) => written.push({ body, title }),
+    renderNotice: (body, title) => {
+      written.push({ body, title });
+      overrides.renderNotice?.();
+    },
   });
   return { notifier, written, fetchCalls: () => fetchCalls };
 }
@@ -109,5 +113,23 @@ describe("startUpdateCheck", () => {
     await settle();
     await notifier.notifyIfOutdated();
     expect(written).toHaveLength(1);
+  });
+
+  it("does not throw when rendering fails, and retries next run", async () => {
+    const fs = makeMemoryFs();
+    const first = makeNotifier({
+      fs,
+      renderNotice: () => {
+        throw new Error("EPIPE");
+      },
+    });
+    await settle();
+    await first.notifier.notifyIfOutdated();
+
+    // A failed render must not record the version as announced.
+    const second = makeNotifier({ fs });
+    await settle();
+    await second.notifier.notifyIfOutdated();
+    expect(second.written).toHaveLength(1);
   });
 });

--- a/src/domains/updateCheck/updateCheck.test.ts
+++ b/src/domains/updateCheck/updateCheck.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Fs } from "~/shell/fs.js";
+import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+import { startUpdateCheck } from "./updateCheck.js";
+
+// Let the fetch's .then chain run before reading the settled value.
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makeNotifier(overrides: {
+  env?: Record<string, string | undefined>;
+  currentVersion?: string;
+  fs?: Fs;
+  fetchLatestVersion?: () => Promise<string | undefined>;
+}) {
+  const written: { body: string; title: string }[] = [];
+  let fetchCalls = 0;
+  const notifier = startUpdateCheck({
+    env: overrides.env ?? {},
+    currentVersion: overrides.currentVersion ?? "1.0.0",
+    configDir: "/config",
+    fs: overrides.fs ?? makeMemoryFs(),
+    fetchLatestVersion: () => {
+      fetchCalls += 1;
+      return (
+        overrides.fetchLatestVersion ?? (() => Promise.resolve("2.0.0"))
+      )();
+    },
+    renderNotice: (body, title) => written.push({ body, title }),
+  });
+  return { notifier, written, fetchCalls: () => fetchCalls };
+}
+
+describe("startUpdateCheck", () => {
+  it("announces a newer version after the fetch settles", async () => {
+    const { notifier, written } = makeNotifier({});
+    await settle();
+    await notifier.notifyIfOutdated();
+    expect(written).toHaveLength(1);
+    expect(written[0]?.body).toContain("1.0.0 → 2.0.0");
+    expect(written[0]?.title).toBe("Update available");
+  });
+
+  it("stays silent while the fetch is still pending", async () => {
+    const { notifier, written } = makeNotifier({
+      fetchLatestVersion: () => new Promise(() => {}),
+    });
+    await notifier.notifyIfOutdated();
+    expect(written).toHaveLength(0);
+  });
+
+  it("stays silent when the published version is not newer", async () => {
+    const { notifier, written } = makeNotifier({
+      currentVersion: "2.0.0",
+      fetchLatestVersion: () => Promise.resolve("2.0.0"),
+    });
+    await settle();
+    await notifier.notifyIfOutdated();
+    expect(written).toHaveLength(0);
+  });
+
+  it("announces each version at most once across runs", async () => {
+    const fs = makeMemoryFs();
+    const first = makeNotifier({ fs });
+    await settle();
+    await first.notifier.notifyIfOutdated();
+    expect(first.written).toHaveLength(1);
+
+    const second = makeNotifier({ fs });
+    await settle();
+    await second.notifier.notifyIfOutdated();
+    expect(second.written).toHaveLength(0);
+  });
+
+  it("announces again when an even newer version ships", async () => {
+    const fs = makeMemoryFs();
+    const first = makeNotifier({ fs });
+    await settle();
+    await first.notifier.notifyIfOutdated();
+
+    const second = makeNotifier({
+      fs,
+      fetchLatestVersion: () => Promise.resolve("3.0.0"),
+    });
+    await settle();
+    await second.notifier.notifyIfOutdated();
+    expect(second.written).toHaveLength(1);
+    expect(second.written[0]?.body).toContain("1.0.0 → 3.0.0");
+  });
+
+  it("does not fetch when QAWOLF_NO_UPDATE_CHECK is set", async () => {
+    const { notifier, written, fetchCalls } = makeNotifier({
+      env: { QAWOLF_NO_UPDATE_CHECK: "1" },
+    });
+    await settle();
+    await notifier.notifyIfOutdated();
+    expect(fetchCalls()).toBe(0);
+    expect(written).toHaveLength(0);
+  });
+
+  it("still announces (and never throws) when the state file is unwritable", async () => {
+    const fs: Fs = {
+      ...makeMemoryFs(),
+      readFile: () => Promise.reject(new Error("boom")),
+      mkdir: () => Promise.reject(new Error("boom")),
+      writeFile: () => Promise.reject(new Error("boom")),
+    };
+    const { notifier, written } = makeNotifier({ fs });
+    await settle();
+    await notifier.notifyIfOutdated();
+    expect(written).toHaveLength(1);
+  });
+});

--- a/src/domains/updateCheck/updateCheck.ts
+++ b/src/domains/updateCheck/updateCheck.ts
@@ -56,10 +56,17 @@ export function startUpdateCheck(deps: {
         // No notice recorded yet. Fall through and announce.
       }
 
-      deps.renderNotice(
-        updateCheckMessages.body(deps.currentVersion, latest),
-        updateCheckMessages.title,
-      );
+      try {
+        deps.renderNotice(
+          updateCheckMessages.body(deps.currentVersion, latest),
+          updateCheckMessages.title,
+        );
+      } catch {
+        // The command already finished, and a write can still fail (EPIPE on a
+        // closed pipe). Leave the marker unwritten so the next run retries.
+        return;
+      }
+
       try {
         await deps.fs.mkdir(deps.configDir, { recursive: true });
         await deps.fs.writeFile(noticePath, `${latest}\n`);

--- a/src/domains/updateCheck/updateCheck.ts
+++ b/src/domains/updateCheck/updateCheck.ts
@@ -8,9 +8,8 @@ const noticeFile = "last-update-notice";
 
 export type UpdateNotifier = {
   /**
-   * Print the update notice if the background check has already found a
-   * newer, not-yet-announced version. Never waits on the network and never
-   * throws.
+   * Announces only if the check already settled on a newer, not-yet-announced
+   * version. Never waits on the network; never throws.
    */
   notifyIfOutdated(): Promise<void>;
 };
@@ -20,14 +19,9 @@ const noopNotifier: UpdateNotifier = {
 };
 
 /**
- * Kick off a background check against the npm registry for a newer published
- * CLI version. Call `notifyIfOutdated` after the command finishes: it takes
- * the fetch result only if it already settled, and announces each new version
- * at most once (tracked in a config-dir state file).
- *
- * The notice renders per output mode (clack box, plain stderr lines, or a
- * JSONL diagnostic); `renderNotice` should wire to `ui.note`. No-op when
- * `QAWOLF_NO_UPDATE_CHECK` is set.
+ * Starts a background check for a newer published CLI version. Call
+ * `notifyIfOutdated` after the command finishes. Wire `renderNotice` to
+ * `ui.note` so each output mode formats the notice itself.
  */
 export function startUpdateCheck(deps: {
   env: Record<string, string | undefined>;

--- a/src/domains/updateCheck/updateCheck.ts
+++ b/src/domains/updateCheck/updateCheck.ts
@@ -1,0 +1,77 @@
+import { join } from "node:path";
+
+import { updateCheckMessages } from "~/core/messages/index.js";
+import { isNewerVersion } from "~/core/version.js";
+import type { Fs } from "~/shell/fs.js";
+
+const noticeFile = "last-update-notice";
+
+export type UpdateNotifier = {
+  /**
+   * Print the update notice if the background check has already found a
+   * newer, not-yet-announced version. Never waits on the network and never
+   * throws.
+   */
+  notifyIfOutdated(): Promise<void>;
+};
+
+const noopNotifier: UpdateNotifier = {
+  notifyIfOutdated: () => Promise.resolve(),
+};
+
+/**
+ * Kick off a background check against the npm registry for a newer published
+ * CLI version. Call `notifyIfOutdated` after the command finishes: it takes
+ * the fetch result only if it already settled, and announces each new version
+ * at most once (tracked in a config-dir state file).
+ *
+ * The notice renders per output mode (clack box, plain stderr lines, or a
+ * JSONL diagnostic); `renderNotice` should wire to `ui.note`. No-op when
+ * `QAWOLF_NO_UPDATE_CHECK` is set.
+ */
+export function startUpdateCheck(deps: {
+  env: Record<string, string | undefined>;
+  currentVersion: string;
+  configDir: string;
+  fs: Fs;
+  fetchLatestVersion: () => Promise<string | undefined>;
+  renderNotice: (body: string, title: string) => void;
+}): UpdateNotifier {
+  if (deps.env["QAWOLF_NO_UPDATE_CHECK"]) {
+    return noopNotifier;
+  }
+
+  let latest: string | undefined;
+  void deps.fetchLatestVersion().then(
+    (version) => {
+      latest = version;
+    },
+    () => undefined,
+  );
+
+  return {
+    async notifyIfOutdated() {
+      if (latest === undefined) return;
+      if (!isNewerVersion(deps.currentVersion, latest)) return;
+
+      const noticePath = join(deps.configDir, noticeFile);
+      try {
+        const notified = (await deps.fs.readFile(noticePath)).trim();
+        if (notified === latest) return;
+      } catch {
+        // No notice recorded yet. Fall through and announce.
+      }
+
+      deps.renderNotice(
+        updateCheckMessages.body(deps.currentVersion, latest),
+        updateCheckMessages.title,
+      );
+      try {
+        await deps.fs.mkdir(deps.configDir, { recursive: true });
+        await deps.fs.writeFile(noticePath, `${latest}\n`);
+      } catch {
+        // Best-effort: worst case the notice repeats next run.
+      }
+    },
+  };
+}

--- a/src/shell/npmRegistry.test.ts
+++ b/src/shell/npmRegistry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+
+import { fetchLatestVersion } from "./npmRegistry.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchLatestVersion", () => {
+  it("returns the version from the registry's latest dist-tag", async () => {
+    let requestedUrl = "";
+    const version = await fetchLatestVersion("@qawolf/cli", {
+      fetchFn: (url) => {
+        requestedUrl = url;
+        return Promise.resolve(jsonResponse({ version: "9.9.9" }));
+      },
+    });
+    expect(version).toBe("9.9.9");
+    expect(requestedUrl).toBe("https://registry.npmjs.org/@qawolf/cli/latest");
+  });
+
+  it("returns undefined on non-2xx responses", async () => {
+    const version = await fetchLatestVersion("@qawolf/cli", {
+      fetchFn: () => Promise.resolve(jsonResponse({ error: "not found" }, 404)),
+    });
+    expect(version).toBeUndefined();
+  });
+
+  it("returns undefined when the fetch rejects", async () => {
+    const version = await fetchLatestVersion("@qawolf/cli", {
+      fetchFn: () => Promise.reject(new Error("offline")),
+    });
+    expect(version).toBeUndefined();
+  });
+
+  it("returns undefined on unexpected payloads", async () => {
+    // oxlint-disable-next-line unicorn/no-null -- a JSON `null` body is a real registry response shape
+    for (const body of [null, "1.2.3", {}, { version: 123 }]) {
+      const version = await fetchLatestVersion("@qawolf/cli", {
+        fetchFn: () => Promise.resolve(jsonResponse(body)),
+      });
+      expect(version).toBeUndefined();
+    }
+  });
+
+  it("returns undefined when the body is not JSON", async () => {
+    const version = await fetchLatestVersion("@qawolf/cli", {
+      fetchFn: () => Promise.resolve(new Response("<html></html>")),
+    });
+    expect(version).toBeUndefined();
+  });
+});

--- a/src/shell/npmRegistry.test.ts
+++ b/src/shell/npmRegistry.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from "bun:test";
 
 import { fetchLatestVersion } from "./npmRegistry.js";
 
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
+// Bodies are raw response text, matching what the registry puts on the wire.
+function registryResponse(body: string, status = 200): Response {
+  return new Response(body, {
     status,
     headers: { "content-type": "application/json" },
   });
@@ -15,7 +16,7 @@ describe("fetchLatestVersion", () => {
     const version = await fetchLatestVersion("@qawolf/cli", {
       fetchFn: (url) => {
         requestedUrl = url;
-        return Promise.resolve(jsonResponse({ version: "9.9.9" }));
+        return Promise.resolve(registryResponse('{"version":"9.9.9"}'));
       },
     });
     expect(version).toBe("9.9.9");
@@ -24,7 +25,8 @@ describe("fetchLatestVersion", () => {
 
   it("returns undefined on non-2xx responses", async () => {
     const version = await fetchLatestVersion("@qawolf/cli", {
-      fetchFn: () => Promise.resolve(jsonResponse({ error: "not found" }, 404)),
+      fetchFn: () =>
+        Promise.resolve(registryResponse('{"error":"not found"}', 404)),
     });
     expect(version).toBeUndefined();
   });
@@ -37,10 +39,9 @@ describe("fetchLatestVersion", () => {
   });
 
   it("returns undefined on unexpected payloads", async () => {
-    // oxlint-disable-next-line unicorn/no-null -- a JSON `null` body is a real registry response shape
-    for (const body of [null, "1.2.3", {}, { version: 123 }]) {
+    for (const body of ["null", '"1.2.3"', "{}", '{"version":123}']) {
       const version = await fetchLatestVersion("@qawolf/cli", {
-        fetchFn: () => Promise.resolve(jsonResponse(body)),
+        fetchFn: () => Promise.resolve(registryResponse(body)),
       });
       expect(version).toBeUndefined();
     }
@@ -48,7 +49,7 @@ describe("fetchLatestVersion", () => {
 
   it("returns undefined when the body is not JSON", async () => {
     const version = await fetchLatestVersion("@qawolf/cli", {
-      fetchFn: () => Promise.resolve(new Response("<html></html>")),
+      fetchFn: () => Promise.resolve(registryResponse("<html></html>")),
     });
     expect(version).toBeUndefined();
   });

--- a/src/shell/npmRegistry.ts
+++ b/src/shell/npmRegistry.ts
@@ -7,9 +7,9 @@ type FetchLike = (
 ) => Promise<Response>;
 
 /**
- * Latest published version of `packageName` per the npm registry's `latest`
- * dist-tag, or undefined on any failure (offline, timeout, bad payload).
- * The update check must never break a command.
+ * Reads the registry's `latest` dist-tag. Returns undefined on any failure
+ * (offline, timeout, bad payload), because the update check must never break
+ * a command.
  */
 export async function fetchLatestVersion(
   packageName: string,

--- a/src/shell/npmRegistry.ts
+++ b/src/shell/npmRegistry.ts
@@ -1,0 +1,32 @@
+const registryUrl = "https://registry.npmjs.org";
+const timeoutMs = 3000;
+
+type FetchLike = (
+  url: string,
+  init: { signal: AbortSignal },
+) => Promise<Response>;
+
+/**
+ * Latest published version of `packageName` per the npm registry's `latest`
+ * dist-tag, or undefined on any failure (offline, timeout, bad payload).
+ * The update check must never break a command.
+ */
+export async function fetchLatestVersion(
+  packageName: string,
+  deps: { fetchFn?: FetchLike } = {},
+): Promise<string | undefined> {
+  const fetchFn = deps.fetchFn ?? globalThis.fetch;
+  try {
+    const response = await fetchFn(`${registryUrl}/${packageName}/latest`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return undefined;
+    const body: unknown = await response.json();
+    if (body === null || typeof body !== "object" || !("version" in body)) {
+      return undefined;
+    }
+    return typeof body.version === "string" ? body.version : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

The CLI shows its own version with `--version`. It does not tell the user when a newer release exists. Outdated installations stay in use.

This change adds an update notice. When a command starts, the CLI sends a background request to the npm registry for the `latest` dist-tag. When the command completes, the CLI shows a notice if the response is available. The CLI does not wait for the network. If the request fails, the CLI shows nothing.

- The CLI announces each new version one time only. It records the announced version in the `last-update-notice` file in the config directory.
- The notice renders through `ui.note`, so each output mode shows it in its own format. Human mode shows a clack note box. Agent mode writes a two-line plain notice to stderr. JSON mode writes a `{"type":"note",...}` diagnostic line to stderr, the same shape as the other diagnostics. The stdout stream stays unchanged in all modes.
- Set `QAWOLF_NO_UPDATE_CHECK=1` to disable the check. The CLI then sends no request.
- The version comparison is a pure function in `core/version.ts`. The registry request is in `shell/npmRegistry.ts` and does not use the npm executable, so it operates in the standalone binary. The notice policy is in `domains/updateCheck/` with injected dependencies. The file `commands/context.ts` connects the check to the two command wrappers.

Known limits: `--help` and `--version` do not run command actions, so they do not show the notice. A very fast command can complete before the registry response arrives. The CLI then shows no notice for that run. This is the intended trade for zero added latency.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- New tests cover: version comparison edge cases (prerelease and invalid input give no notice), registry request failure modes, once-per-version behavior across runs, a newer release after a recorded notice, the env opt-out, and an unwritable state file (the notice still shows, no throw).
- Manual checks against the real registry, with a local version below the published version: the box shows in a TTY, the plain notice shows with `--agent`, `--json` writes a note diagnostic to stderr, stdout is unchanged in both, a second run shows nothing, and the notice returns after removal of the state file.

| Mode | stderr | stdout |
|---|---|---|
| Human TTY | `◇ Update available` clack box | unchanged |
| `--agent` | `Update available: @qawolf/cli 1.3.2 → 1.4.0` plus the install line | unchanged |
| `--json` | `{"type":"note","title":"Update available",...}` | unchanged, data only |
| Any mode, second run | nothing (already announced) | unchanged |
| `QAWOLF_NO_UPDATE_CHECK=1` | nothing, and no request sent | unchanged |

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
