### PR TITLE
fix(cli): spawn npm.cmd on Windows so npm is found on PATH

### DIFF
--- a/.changeset/windows-npm-cmd.md
+++ b/.changeset/windows-npm-cmd.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": patch
 ---
 
-Fix `spawn npm ENOENT` on Windows. `flows run` failed while preparing the environment and `qawolf doctor` reported "npm is not installed or not on PATH", even though `npm --version` worked in the same shell. Windows ships npm as `npm.cmd` and has no `npm.exe`, and libuv's spawn PATH search ignores `PATHEXT` and only appends `.com`/`.exe` — so the bare name `npm` never resolved, while cmd.exe found it because cmd.exe does apply `PATHEXT`. The CLI now spawns `npm.cmd` with `shell: true` on Windows, which is also the pairing Node requires to execute a batch file after CVE-2024-27980. WSL is unaffected: it reports `linux` and carries a POSIX npm.
+Fix `spawn npm ENOENT` on Windows. `flows run` failed while preparing the environment, and `qawolf doctor` reported "npm is not installed or not on PATH". Both failed even though `npm --version` worked in the same shell. Windows ships npm as `npm.cmd` and has no `npm.exe`, which Node's process spawn requires. The CLI now runs `npm.cmd` on Windows. WSL is unaffected, because it reports itself as Linux and carries a POSIX npm.

--- a/.changeset/windows-npm-cmd.md
+++ b/.changeset/windows-npm-cmd.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Fix `spawn npm ENOENT` on Windows. `flows run` failed while preparing the environment and `qawolf doctor` reported "npm is not installed or not on PATH", even though `npm --version` worked in the same shell. Windows ships npm as `npm.cmd` and has no `npm.exe`, and libuv's spawn PATH search ignores `PATHEXT` and only appends `.com`/`.exe` — so the bare name `npm` never resolved, while cmd.exe found it because cmd.exe does apply `PATHEXT`. The CLI now spawns `npm.cmd` with `shell: true` on Windows, which is also the pairing Node requires to execute a batch file after CVE-2024-27980. WSL is unaffected: it reports `linux` and carries a POSIX npm.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ src/
 │   ├── fs.ts            # filesystem helpers
 │   ├── logger.ts        # pino-based structured logger
 │   ├── manifest/        # bundle manifest read/lookup
+│   ├── npm.ts           # resolveNpmCommand
 │   ├── platform/        # tRPC client, getIdentity, signed-URL/bundle download, team storage
 │   ├── playwright.ts    # resolvePlaywrightCli
 │   ├── reporter/        # Reporter interface, console + JUnit + composite reporters

--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -86,6 +86,7 @@ export async function handleDoctor(
     envDir,
     resolveAppiumBin,
     requiredAvds,
+    platform: process.platform,
   });
   const allResults = [cliCheck, ...results];
   renderResults(ctx.ui, allResults);

--- a/src/domains/doctor/checks/index.ts
+++ b/src/domains/doctor/checks/index.ts
@@ -27,6 +27,7 @@ type CheckDeps = {
   readonly envDir: string | undefined;
   readonly resolveAppiumBin: (envDir: string) => string;
   readonly requiredAvds: readonly string[];
+  readonly platform: NodeJS.Platform;
 };
 
 export async function runChecks(deps: CheckDeps): Promise<CheckResult[]> {
@@ -49,7 +50,7 @@ export async function runChecks(deps: CheckDeps): Promise<CheckResult[]> {
     }),
     checkApiKey({ apiKey: deps.apiKey }),
     checkApiUrl({ fetch: deps.fetch, apiBaseUrl: deps.apiBaseUrl }),
-    checkNpmRegistry({ spawn: deps.spawn }),
+    checkNpmRegistry({ spawn: deps.spawn, platform: deps.platform }),
     checkFileAssets({
       files: deps.flowFiles,
       readFile: deps.readFile,

--- a/src/domains/doctor/checks/npmRegistry.test.ts
+++ b/src/domains/doctor/checks/npmRegistry.test.ts
@@ -15,7 +15,7 @@ function spawnReturning(result: SpawnResult): SpawnFn {
 describe("checkNpmRegistry", () => {
   it("passes on exit 0", async () => {
     const spawn = spawnReturning({ exitCode: 0, stdout: "", stderr: "" });
-    const r = await checkNpmRegistry({ spawn });
+    const r = await checkNpmRegistry({ spawn, platform: "linux" });
     expect(r).toEqual({ name: "npm-registry", status: "pass" });
     expect(spawn).toHaveBeenCalledWith("npm", ["ping"]);
   });
@@ -26,14 +26,20 @@ describe("checkNpmRegistry", () => {
       stdout: "",
       stderr: "registry unreachable\n",
     });
-    const r = await checkNpmRegistry({ spawn });
+    const r = await checkNpmRegistry({ spawn, platform: "linux" });
     expect(r.status).toBe("warn");
     expect(r.detail).toBe("registry unreachable");
   });
 
+  it("pings via npm.cmd on win32", async () => {
+    const spawn = spawnReturning({ exitCode: 0, stdout: "", stderr: "" });
+    await checkNpmRegistry({ spawn, platform: "win32" });
+    expect(spawn).toHaveBeenCalledWith("npm.cmd", ["ping"]);
+  });
+
   it("warns when npm is missing", async () => {
     const spawn = spawnReturning({ exitCode: -1, stdout: "", stderr: "" });
-    const r = await checkNpmRegistry({ spawn });
+    const r = await checkNpmRegistry({ spawn, platform: "linux" });
     expect(r.status).toBe("warn");
     expect(r.detail).toContain("not installed");
   });

--- a/src/domains/doctor/checks/npmRegistry.test.ts
+++ b/src/domains/doctor/checks/npmRegistry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
+import { doctorMessages } from "~/core/messages/index.js";
 import type { SpawnFn, SpawnResult } from "~/shell/spawn.js";
 
 import { checkNpmRegistry } from "./npmRegistry.js";
@@ -35,6 +36,20 @@ describe("checkNpmRegistry", () => {
     const spawn = spawnReturning({ exitCode: 0, stdout: "", stderr: "" });
     await checkNpmRegistry({ spawn, platform: "win32" });
     expect(spawn).toHaveBeenCalledWith("npm.cmd", ["ping"]);
+  });
+
+  // With shell:true, cmd.exe launches successfully and reports a missing
+  // npm.cmd as exit 9009, so the spawn `error` path never fires on win32.
+  it("reports a missing npm on win32, where cmd.exe exits 9009", async () => {
+    const spawn = spawnReturning({
+      exitCode: 9009,
+      stdout: "",
+      stderr:
+        "'npm.cmd' is not recognized as an internal or external command,\n",
+    });
+    const r = await checkNpmRegistry({ spawn, platform: "win32" });
+    expect(r.status).toBe("warn");
+    expect(r.detail).toBe(doctorMessages.npmRegistry.notInstalled);
   });
 
   it("warns when npm is missing", async () => {

--- a/src/domains/doctor/checks/npmRegistry.ts
+++ b/src/domains/doctor/checks/npmRegistry.ts
@@ -1,16 +1,18 @@
 import { doctorMessages } from "~/core/messages/index.js";
+import { resolveNpmCommand } from "~/shell/npm.js";
 import type { SpawnFn } from "~/shell/spawn.js";
 
 import type { CheckResult } from "~/domains/doctor/types.js";
 
 type NpmRegistryDeps = {
   readonly spawn: SpawnFn;
+  readonly platform: NodeJS.Platform;
 };
 
 export async function checkNpmRegistry(
   deps: NpmRegistryDeps,
 ): Promise<CheckResult> {
-  const result = await deps.spawn("npm", ["ping"]);
+  const result = await deps.spawn(resolveNpmCommand(deps.platform), ["ping"]);
 
   if (result.exitCode < 0) {
     return {

--- a/src/domains/doctor/checks/npmRegistry.ts
+++ b/src/domains/doctor/checks/npmRegistry.ts
@@ -14,7 +14,12 @@ export async function checkNpmRegistry(
 ): Promise<CheckResult> {
   const result = await deps.spawn(resolveNpmCommand(deps.platform), ["ping"]);
 
-  if (result.exitCode < 0) {
+  // cmd.exe's "command not found" code. win32 runs npm.cmd through a shell,
+  // so the spawn itself succeeds and a missing npm surfaces here instead of
+  // on the exitCode < 0 path.
+  const cmdNotFound = deps.platform === "win32" && result.exitCode === 9009;
+
+  if (result.exitCode < 0 || cmdNotFound) {
     return {
       name: "npm-registry",
       status: "warn",

--- a/src/domains/doctor/checks/runChecks.test.ts
+++ b/src/domains/doctor/checks/runChecks.test.ts
@@ -15,6 +15,7 @@ const androidDeps = {
   envDir: undefined,
   resolveAppiumBin: (dir: string) => `${dir}/node_modules/.bin/appium`,
   requiredAvds: [] as readonly string[],
+  platform: "linux" as NodeJS.Platform,
 };
 
 describe("runChecks", () => {

--- a/src/domains/runtimeEnv/npmInstall.test.ts
+++ b/src/domains/runtimeEnv/npmInstall.test.ts
@@ -1,6 +1,11 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it } from "bun:test";
 
-import { buildNpmInstallSpawn } from "./npmInstall.js";
+import {
+  buildNpmInstallSpawn,
+  type NpmSpawnFn,
+  spawnNpmInstall,
+} from "./npmInstall.js";
 
 describe("buildNpmInstallSpawn", () => {
   it("spawns npm.cmd through a shell on win32", () => {
@@ -19,5 +24,37 @@ describe("buildNpmInstallSpawn", () => {
     expect(cmd).toBe("npm");
     expect(options.shell).toBeUndefined();
     expect(options.cwd).toBe("/tmp/env");
+  });
+});
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: { resume: () => void };
+    stderr: EventEmitter;
+  };
+  child.stdout = { resume: () => {} };
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+describe("spawnNpmInstall", () => {
+  // Guards the wiring, not just the plan: dropping the options argument would
+  // restore the Windows failure while buildNpmInstallSpawn's tests still pass.
+  it("forwards the built command, args, and options to spawn", async () => {
+    const calls: { cmd: string; args: string[]; options: object }[] = [];
+    const child = fakeChild();
+    const spawn = ((cmd: string, args: string[], options: object) => {
+      calls.push({ cmd, args, options });
+      return child;
+    }) as unknown as NpmSpawnFn;
+
+    const promise = spawnNpmInstall("/tmp/env", spawn);
+    child.emit("close", 0);
+    const result = await promise;
+
+    expect(result.exitCode).toBe(0);
+    expect(calls[0]?.cmd).toBe("npm");
+    expect(calls[0]?.args).toEqual(["install", "--legacy-peer-deps"]);
+    expect(calls[0]?.options).toMatchObject({ cwd: "/tmp/env" });
   });
 });

--- a/src/domains/runtimeEnv/npmInstall.test.ts
+++ b/src/domains/runtimeEnv/npmInstall.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildNpmInstallSpawn } from "./npmInstall.js";
+
+describe("buildNpmInstallSpawn", () => {
+  it("spawns npm.cmd through a shell on win32", () => {
+    const { cmd, args, options } = buildNpmInstallSpawn(
+      "C:\\proj\\env",
+      "win32",
+    );
+    expect(cmd).toBe("npm.cmd");
+    expect(args).toEqual(["install", "--legacy-peer-deps"]);
+    expect(options.shell).toBe(true);
+    expect(options.cwd).toBe("C:\\proj\\env");
+  });
+
+  it("spawns bare npm without a shell on posix", () => {
+    const { cmd, options } = buildNpmInstallSpawn("/tmp/env", "linux");
+    expect(cmd).toBe("npm");
+    expect(options.shell).toBeUndefined();
+    expect(options.cwd).toBe("/tmp/env");
+  });
+});

--- a/src/domains/runtimeEnv/npmInstall.ts
+++ b/src/domains/runtimeEnv/npmInstall.ts
@@ -5,6 +5,8 @@ import { buildSpawnOptions, spawn as nodeSpawn } from "~/shell/spawn.js";
 
 export type SpawnInstallResult = { exitCode: number; stderr: string };
 
+export type NpmSpawnFn = typeof nodeSpawn;
+
 export function buildNpmInstallSpawn(
   cwd: string,
   platform: NodeJS.Platform,
@@ -23,10 +25,13 @@ export function buildNpmInstallSpawn(
  * exit code and stderr. Uses the richer `stderr || err.message` fallback on
  * spawn error so callers always have diagnostic context.
  */
-export function spawnNpmInstall(cwd: string): Promise<SpawnInstallResult> {
+export function spawnNpmInstall(
+  cwd: string,
+  spawn: NpmSpawnFn = nodeSpawn,
+): Promise<SpawnInstallResult> {
   return new Promise((resolve) => {
     const { cmd, args, options } = buildNpmInstallSpawn(cwd, process.platform);
-    const child = nodeSpawn(cmd, args, options);
+    const child = spawn(cmd, args, options);
     let stderr = "";
     // Drain stdout so a large install (playwright + appium) can't fill the pipe
     // buffer and stall npm; we only need the exit code and stderr.

--- a/src/domains/runtimeEnv/npmInstall.ts
+++ b/src/domains/runtimeEnv/npmInstall.ts
@@ -1,6 +1,22 @@
-import { spawn as nodeSpawn } from "~/shell/spawn.js";
+import type { SpawnOptions } from "node:child_process";
+
+import { resolveNpmCommand } from "~/shell/npm.js";
+import { buildSpawnOptions, spawn as nodeSpawn } from "~/shell/spawn.js";
 
 export type SpawnInstallResult = { exitCode: number; stderr: string };
+
+export function buildNpmInstallSpawn(
+  cwd: string,
+  platform: NodeJS.Platform,
+): { cmd: string; args: string[]; options: SpawnOptions } {
+  const cmd = resolveNpmCommand(platform);
+  return {
+    cmd,
+    // npm 7+ strict peer-dep resolution rejects peerOptional conflicts — revert to npm 6 behaviour.
+    args: ["install", "--legacy-peer-deps"],
+    options: { ...buildSpawnOptions(cmd, platform, undefined), cwd },
+  };
+}
 
 /**
  * Runs `npm install --legacy-peer-deps` in the given directory and returns the
@@ -9,8 +25,8 @@ export type SpawnInstallResult = { exitCode: number; stderr: string };
  */
 export function spawnNpmInstall(cwd: string): Promise<SpawnInstallResult> {
   return new Promise((resolve) => {
-    // npm 7+ strict peer-dep resolution rejects peerOptional conflicts — revert to npm 6 behaviour.
-    const child = nodeSpawn("npm", ["install", "--legacy-peer-deps"], { cwd });
+    const { cmd, args, options } = buildNpmInstallSpawn(cwd, process.platform);
+    const child = nodeSpawn(cmd, args, options);
     let stderr = "";
     // Drain stdout so a large install (playwright + appium) can't fill the pipe
     // buffer and stall npm; we only need the exit code and stderr.

--- a/src/shell/npm.test.ts
+++ b/src/shell/npm.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveNpmCommand } from "./npm.js";
+import { buildSpawnOptions } from "./spawn.js";
+
+describe("resolveNpmCommand", () => {
+  it("returns npm.cmd on win32", () => {
+    expect(resolveNpmCommand("win32")).toBe("npm.cmd");
+  });
+
+  it("returns npm on linux and darwin", () => {
+    expect(resolveNpmCommand("linux")).toBe("npm");
+    expect(resolveNpmCommand("darwin")).toBe("npm");
+  });
+
+  // Naming npm.cmd without shell:true trades ENOENT for EINVAL
+  // (CVE-2024-27980), so the two must stay paired.
+  it("resolves to a command buildSpawnOptions gives a shell on win32", () => {
+    const opts = buildSpawnOptions(
+      resolveNpmCommand("win32"),
+      "win32",
+      undefined,
+    );
+    expect(opts.shell).toBe(true);
+  });
+
+  it("resolves to a command that gets no shell on posix", () => {
+    const opts = buildSpawnOptions(
+      resolveNpmCommand("linux"),
+      "linux",
+      undefined,
+    );
+    expect(opts.shell).toBeUndefined();
+  });
+});

--- a/src/shell/npm.ts
+++ b/src/shell/npm.ts
@@ -1,11 +1,7 @@
-// Windows ships npm as npm.cmd (plus npm.ps1 and a POSIX script) — there is no
-// npm.exe. libuv's spawn PATH search ignores PATHEXT and only appends .com/.exe,
-// so a bare "npm" fails with ENOENT even when `npm --version` works in the same
-// shell, because cmd.exe does apply PATHEXT. Pair the result with
-// buildSpawnOptions, which supplies the shell:true that Node requires to run a
-// .cmd (CVE-2024-27980). WSL reports "linux" and carries a POSIX npm, so it
-// takes the bare-name branch; Git Bash runs a Windows Node build, reports
-// "win32", and needs npm.cmd.
+// Windows has no npm.exe, and libuv's spawn PATH search ignores PATHEXT, so a
+// bare "npm" is ENOENT there even when `npm --version` works. WSL reports
+// "linux" and carries a POSIX npm; Git Bash reports "win32" and needs npm.cmd.
+// Pass the result through buildSpawnOptions, which adds the required shell.
 export function resolveNpmCommand(platform: NodeJS.Platform): string {
   return platform === "win32" ? "npm.cmd" : "npm";
 }

--- a/src/shell/npm.ts
+++ b/src/shell/npm.ts
@@ -1,0 +1,11 @@
+// Windows ships npm as npm.cmd (plus npm.ps1 and a POSIX script) — there is no
+// npm.exe. libuv's spawn PATH search ignores PATHEXT and only appends .com/.exe,
+// so a bare "npm" fails with ENOENT even when `npm --version` works in the same
+// shell, because cmd.exe does apply PATHEXT. Pair the result with
+// buildSpawnOptions, which supplies the shell:true that Node requires to run a
+// .cmd (CVE-2024-27980). WSL reports "linux" and carries a POSIX npm, so it
+// takes the bare-name branch; Git Bash runs a Windows Node build, reports
+// "win32", and needs npm.cmd.
+export function resolveNpmCommand(platform: NodeJS.Platform): string {
+  return platform === "win32" ? "npm.cmd" : "npm";
+}

--- a/src/shell/spawn.ts
+++ b/src/shell/spawn.ts
@@ -23,9 +23,9 @@ export type SpawnFn = (
 //   Do not pass attacker-controlled values in `cmd` or `args`. Node's
 //   cmd.exe escaping protects against shell-metacharacter injection in
 //   args, but only when those args are passed as separate array elements
-//   (never concatenated into `cmd`). Today the only such call site is
-//   playwright.cmd with literal args (browser names, --version); audit any
-//   new .cmd/.bat caller before merging.
+//   (never concatenated into `cmd`). Today the call sites are playwright.cmd
+//   (browser names, --version) and npm.cmd (install, ping), all literal args;
+//   audit any new .cmd/.bat caller before merging.
 export function buildSpawnOptions(
   cmd: string,
   platform: NodeJS.Platform,


### PR DESCRIPTION
Windows has no `npm.exe`, and libuv's spawn PATH search ignores `PATHEXT` and only appends `.com`/`.exe` — so bare `spawn("npm")` was `ENOENT` while `npm --version` worked, because cmd.exe does apply `PATHEXT`. Naming `npm.cmd` alone is not enough: after CVE-2024-27980 Node rejects a batch file unless `shell: true` is set, so the two are resolved together. The second commit covers a review finding — with a shell, cmd.exe launches successfully and reports a missing npm as exit 9009, which had left the doctor's own "not installed" message unreachable on the only platform it describes.

I could not execute the win32 branch (macOS host), so that half rests on the platform-parameterized tests, not on observation. WIZ-11275 adds the Windows CI job that would have caught this.

Fixes WIZ-11274