### PR TITLE
fix(cli): spawn cmd.exe directly to avoid Node's DEP0190 warning

### DIFF
--- a/.changeset/windows-cmd-deprecation.md
+++ b/.changeset/windows-cmd-deprecation.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Stop emitting a `DeprecationWarning` on Windows. Under Node 25, `qawolf doctor` and `qawolf flows run` printed Node's DEP0190 warning on every run. Windows needs cmd.exe to run a `.cmd` file, and the CLI asked for it with `shell: true`. Node 25 deprecates that flag when the caller also passes an argument array. The CLI now invokes `cmd.exe /d /s /c` itself and quotes the arguments.

--- a/src/core/cmdEscape.test.ts
+++ b/src/core/cmdEscape.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+import { escapeArgument, escapeCommand } from "./cmdEscape.js";
+
+describe("escapeArgument", () => {
+  it("wraps a plain argument in quotes", () => {
+    expect(escapeArgument("install")).toBe('^^^"install^^^"');
+  });
+
+  // A .cmd shim re-enters cmd.exe, which consumes one layer of ^ escapes, so
+  // every meta char needs two. The wrapping quotes are meta chars themselves.
+  it("double-escapes meta chars, including the quotes it added", () => {
+    expect(escapeArgument("a&b")).toBe('^^^"a^^^&b^^^"');
+  });
+
+  it("escapes the wildcard meta chars", () => {
+    expect(escapeArgument("*.ts")).toBe('^^^"^^^*.ts^^^"');
+    expect(escapeArgument("a?b")).toBe('^^^"a^^^?b^^^"');
+  });
+
+  it("backslash-escapes a quote inside the argument", () => {
+    expect(escapeArgument('a"b')).toBe('^^^"a\\^^^"b^^^"');
+  });
+
+  // Without doubling, the trailing backslash would escape the closing quote
+  // and swallow whatever follows on the command line.
+  it("doubles a trailing backslash", () => {
+    expect(escapeArgument("C:\\dir\\")).toBe('^^^"C:\\dir\\\\^^^"');
+  });
+
+  it("doubles backslashes that precede a quote", () => {
+    expect(escapeArgument('a\\"b')).toBe('^^^"a\\\\\\^^^"b^^^"');
+  });
+});
+
+describe("escapeCommand", () => {
+  it("leaves a path with no meta chars alone", () => {
+    expect(escapeCommand("C:\\proj\\node_modules\\.bin\\npm.cmd")).toBe(
+      "C:\\proj\\node_modules\\.bin\\npm.cmd",
+    );
+  });
+
+  // Windows install paths really do contain spaces and parentheses.
+  it("escapes spaces and parentheses in a path", () => {
+    expect(escapeCommand("C:\\Program Files (x86)\\npm.cmd")).toBe(
+      "C:\\Program^ Files^ ^(x86^)\\npm.cmd",
+    );
+  });
+
+  // Only the outer cmd.exe reads the command, so one layer of ^ is enough.
+  it("escapes meta chars once, unlike arguments", () => {
+    expect(escapeCommand("a&b")).toBe("a^&b");
+  });
+});

--- a/src/core/cmdEscape.ts
+++ b/src/core/cmdEscape.ts
@@ -1,0 +1,17 @@
+// Quoting for a `cmd.exe /d /s /c "<line>"` command line, per https://qntm.org/cmd.
+// Getting this wrong is what BatBadBut (CVE-2024-27980) exploited.
+const metaChars = /([()\][%!^"`<>&|;, *?])/g;
+
+export function escapeCommand(command: string): string {
+  return command.replace(metaChars, "^$1");
+}
+
+// The lookahead form avoids the quadratic backtracking that `(\\*)"` hits on a
+// long backslash run: https://github.com/moxystudio/node-cross-spawn/pull/160
+export function escapeArgument(arg: string): string {
+  const escaped = arg
+    .replace(/(?=(\\+?)?)\1"/g, '$1$1\\"')
+    .replace(/(?=(\\+?)?)\1$/, "$1$1");
+  // Twice, because a .cmd shim forwards %* and cmd.exe parses the line again.
+  return `"${escaped}"`.replace(metaChars, "^$1").replace(metaChars, "^$1");
+}

--- a/src/domains/runtimeEnv/npmInstall.test.ts
+++ b/src/domains/runtimeEnv/npmInstall.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
 import {
   buildNpmInstallSpawn,
@@ -7,21 +7,36 @@ import {
   spawnNpmInstall,
 } from "./npmInstall.js";
 
+const originalComSpec = process.env["ComSpec"];
+
+afterEach(() => {
+  if (originalComSpec === undefined) delete process.env["ComSpec"];
+  else process.env["ComSpec"] = originalComSpec;
+});
+
 describe("buildNpmInstallSpawn", () => {
-  it("spawns npm.cmd through a shell on win32", () => {
+  it("routes npm.cmd through cmd.exe on win32 and keeps cwd", () => {
+    process.env["ComSpec"] = "C:\\Windows\\System32\\cmd.exe";
     const { cmd, args, options } = buildNpmInstallSpawn(
       "C:\\proj\\env",
       "win32",
     );
-    expect(cmd).toBe("npm.cmd");
-    expect(args).toEqual(["install", "--legacy-peer-deps"]);
-    expect(options.shell).toBe(true);
+    expect(cmd).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '"npm.cmd ^^^"install^^^" ^^^"--legacy-peer-deps^^^""',
+    ]);
+    expect(options.windowsVerbatimArguments).toBe(true);
+    expect(options.shell).toBeUndefined();
     expect(options.cwd).toBe("C:\\proj\\env");
   });
 
   it("spawns bare npm without a shell on posix", () => {
-    const { cmd, options } = buildNpmInstallSpawn("/tmp/env", "linux");
+    const { cmd, args, options } = buildNpmInstallSpawn("/tmp/env", "linux");
     expect(cmd).toBe("npm");
+    expect(args).toEqual(["install", "--legacy-peer-deps"]);
     expect(options.shell).toBeUndefined();
     expect(options.cwd).toBe("/tmp/env");
   });

--- a/src/domains/runtimeEnv/npmInstall.ts
+++ b/src/domains/runtimeEnv/npmInstall.ts
@@ -1,7 +1,7 @@
 import type { SpawnOptions } from "node:child_process";
 
 import { resolveNpmCommand } from "~/shell/npm.js";
-import { buildSpawnOptions, spawn as nodeSpawn } from "~/shell/spawn.js";
+import { buildSpawnCommand, spawn as nodeSpawn } from "~/shell/spawn.js";
 
 export type SpawnInstallResult = { exitCode: number; stderr: string };
 
@@ -11,13 +11,14 @@ export function buildNpmInstallSpawn(
   cwd: string,
   platform: NodeJS.Platform,
 ): { cmd: string; args: string[]; options: SpawnOptions } {
-  const cmd = resolveNpmCommand(platform);
-  return {
-    cmd,
+  const built = buildSpawnCommand(
+    resolveNpmCommand(platform),
     // npm 7+ strict peer-dep resolution rejects peerOptional conflicts — revert to npm 6 behaviour.
-    args: ["install", "--legacy-peer-deps"],
-    options: { ...buildSpawnOptions(cmd, platform, undefined), cwd },
-  };
+    ["install", "--legacy-peer-deps"],
+    platform,
+    undefined,
+  );
+  return { ...built, options: { ...built.options, cwd } };
 }
 
 /**

--- a/src/shell/appium/spawnAppium.test.ts
+++ b/src/shell/appium/spawnAppium.test.ts
@@ -1,26 +1,49 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
-import { buildAppiumSpawnOptions } from "./spawnAppium.js";
+import { buildAppiumSpawn } from "./spawnAppium.js";
 
-describe("buildAppiumSpawnOptions", () => {
+const originalComSpec = process.env["ComSpec"];
+
+afterEach(() => {
+  if (originalComSpec === undefined) delete process.env["ComSpec"];
+  else process.env["ComSpec"] = originalComSpec;
+});
+
+describe("buildAppiumSpawn", () => {
   const env = { APPIUM_HOME: "/data/appium" };
 
   it("pipes stdout and stderr and passes the env through", () => {
     expect(
-      buildAppiumSpawnOptions("/envs/node20/.bin/appium", "linux", env),
+      buildAppiumSpawn(
+        "/envs/node20/.bin/appium",
+        ["--port", "4723"],
+        "linux",
+        env,
+      ),
     ).toEqual({
-      stdio: ["ignore", "pipe", "pipe"],
-      env,
+      cmd: "/envs/node20/.bin/appium",
+      args: ["--port", "4723"],
+      options: { stdio: ["ignore", "pipe", "pipe"], env },
     });
   });
 
-  it("sets shell on win32 so Node will run the .cmd shim", () => {
-    expect(
-      buildAppiumSpawnOptions(
-        "C:\\envs\\node20\\.bin\\appium.cmd",
-        "win32",
-        env,
-      ).shell,
-    ).toBe(true);
+  it("routes the .cmd shim through cmd.exe on win32, keeping stdio", () => {
+    process.env["ComSpec"] = "C:\\Windows\\System32\\cmd.exe";
+    const built = buildAppiumSpawn(
+      "C:\\envs\\node20\\.bin\\appium.cmd",
+      ["--port", "4723"],
+      "win32",
+      env,
+    );
+    expect(built.cmd).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(built.args).toEqual([
+      "/d",
+      "/s",
+      "/c",
+      '"C:\\envs\\node20\\.bin\\appium.cmd ^^^"--port^^^" ^^^"4723^^^""',
+    ]);
+    expect(built.options.stdio).toEqual(["ignore", "pipe", "pipe"]);
+    expect(built.options.windowsVerbatimArguments).toBe(true);
+    expect(built.options.shell).toBeUndefined();
   });
 });

--- a/src/shell/appium/spawnAppium.ts
+++ b/src/shell/appium/spawnAppium.ts
@@ -2,7 +2,7 @@ import { spawn, type SpawnOptions } from "node:child_process";
 import net from "node:net";
 import { PassThrough } from "node:stream";
 
-import { buildSpawnOptions } from "~/shell/spawn.js";
+import { buildSpawnCommand } from "~/shell/spawn.js";
 import type {
   AppiumProcess,
   FindFreePortFn,
@@ -19,23 +19,22 @@ export const findFreePort: FindFreePortFn = () =>
     server.on("error", reject);
   });
 
-export function buildAppiumSpawnOptions(
+export function buildAppiumSpawn(
   bin: string,
+  args: string[],
   platform: NodeJS.Platform,
   env: Record<string, string | undefined>,
-): SpawnOptions {
+): { cmd: string; args: string[]; options: SpawnOptions } {
+  const built = buildSpawnCommand(bin, args, platform, env);
   return {
-    stdio: ["ignore", "pipe", "pipe"],
-    ...buildSpawnOptions(bin, platform, env),
+    ...built,
+    options: { stdio: ["ignore", "pipe", "pipe"], ...built.options },
   };
 }
 
 export const defaultSpawnAppium: SpawnAppiumFn = (bin, args, env) => {
-  const child = spawn(
-    bin,
-    args,
-    buildAppiumSpawnOptions(bin, process.platform, env),
-  );
+  const built = buildAppiumSpawn(bin, args, process.platform, env);
+  const child = spawn(built.cmd, built.args, built.options);
   const output = new PassThrough();
   child.stdout?.pipe(output, { end: false });
   child.stderr?.pipe(output, { end: false });

--- a/src/shell/npm.test.ts
+++ b/src/shell/npm.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { resolveNpmCommand } from "./npm.js";
-import { buildSpawnOptions } from "./spawn.js";
+import { buildSpawnCommand } from "./spawn.js";
 
 describe("resolveNpmCommand", () => {
   it("returns npm.cmd on win32", () => {
@@ -13,23 +13,26 @@ describe("resolveNpmCommand", () => {
     expect(resolveNpmCommand("darwin")).toBe("npm");
   });
 
-  // Naming npm.cmd without shell:true trades ENOENT for EINVAL
+  // Naming npm.cmd without routing through cmd.exe trades ENOENT for EINVAL
   // (CVE-2024-27980), so the two must stay paired.
-  it("resolves to a command buildSpawnOptions gives a shell on win32", () => {
-    const opts = buildSpawnOptions(
+  it("resolves to a command buildSpawnCommand sends through cmd.exe", () => {
+    const built = buildSpawnCommand(
       resolveNpmCommand("win32"),
+      [],
       "win32",
       undefined,
     );
-    expect(opts.shell).toBe(true);
+    expect(built.args.slice(0, 3)).toEqual(["/d", "/s", "/c"]);
   });
 
-  it("resolves to a command that gets no shell on posix", () => {
-    const opts = buildSpawnOptions(
+  it("resolves to a command spawned directly on posix", () => {
+    const built = buildSpawnCommand(
       resolveNpmCommand("linux"),
+      [],
       "linux",
       undefined,
     );
-    expect(opts.shell).toBeUndefined();
+    expect(built.cmd).toBe("npm");
+    expect(built.options.shell).toBeUndefined();
   });
 });

--- a/src/shell/npm.ts
+++ b/src/shell/npm.ts
@@ -1,7 +1,7 @@
 // Windows has no npm.exe, and libuv's spawn PATH search ignores PATHEXT, so a
 // bare "npm" is ENOENT there even when `npm --version` works. WSL reports
 // "linux" and carries a POSIX npm; Git Bash reports "win32" and needs npm.cmd.
-// Pass the result through buildSpawnOptions, which adds the required shell.
+// Pass the result through buildSpawnCommand, which routes it via cmd.exe.
 export function resolveNpmCommand(platform: NodeJS.Platform): string {
   return platform === "win32" ? "npm.cmd" : "npm";
 }

--- a/src/shell/spawn.test.ts
+++ b/src/shell/spawn.test.ts
@@ -1,61 +1,106 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 
-import { buildSpawnOptions } from "./spawn.js";
+import { buildSpawnCommand } from "./spawn.js";
 
-describe("buildSpawnOptions", () => {
-  it("returns an empty options object on linux/darwin", () => {
-    expect(
-      buildSpawnOptions("/usr/local/bin/playwright", "linux", undefined),
-    ).toEqual({});
-    expect(
-      buildSpawnOptions("/usr/local/bin/playwright", "darwin", undefined),
-    ).toEqual({});
+const originalComSpec = process.env["ComSpec"];
+
+afterEach(() => {
+  if (originalComSpec === undefined) delete process.env["ComSpec"];
+  else process.env["ComSpec"] = originalComSpec;
+});
+
+describe("buildSpawnCommand", () => {
+  it("passes the command through untouched on linux/darwin", () => {
+    const built = buildSpawnCommand(
+      "/usr/local/bin/playwright",
+      ["--version"],
+      "linux",
+      undefined,
+    );
+    expect(built).toEqual({
+      cmd: "/usr/local/bin/playwright",
+      args: ["--version"],
+      options: {},
+    });
   });
 
-  it("does not set shell on linux/darwin even for a .cmd-suffixed path", () => {
-    const opts = buildSpawnOptions("/tmp/weird.cmd", "linux", undefined);
-    expect(opts.shell).toBeUndefined();
+  it("does not rewrite a .cmd-suffixed path on linux/darwin", () => {
+    const built = buildSpawnCommand("/tmp/weird.cmd", [], "linux", undefined);
+    expect(built.cmd).toBe("/tmp/weird.cmd");
   });
 
-  it("sets shell:true on win32 for a .cmd file", () => {
-    const opts = buildSpawnOptions(
+  it("routes a win32 .cmd through cmd.exe", () => {
+    process.env["ComSpec"] = "C:\\Windows\\System32\\cmd.exe";
+    const built = buildSpawnCommand(
       "C:\\proj\\node_modules\\.bin\\playwright.cmd",
+      ["--version"],
       "win32",
       undefined,
     );
-    expect(opts.shell).toBe(true);
+    expect(built).toEqual({
+      cmd: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '"C:\\proj\\node_modules\\.bin\\playwright.cmd ^^^"--version^^^""',
+      ],
+      options: { windowsVerbatimArguments: true },
+    });
   });
 
-  it("sets shell:true on win32 for a .bat file", () => {
-    const opts = buildSpawnOptions("C:\\tool.bat", "win32", undefined);
-    expect(opts.shell).toBe(true);
+  it("matches the .cmd/.bat suffix case-insensitively on win32", () => {
+    expect(buildSpawnCommand("C:\\x.CMD", [], "win32", undefined).args[0]).toBe(
+      "/d",
+    );
+    expect(buildSpawnCommand("C:\\x.Bat", [], "win32", undefined).args[0]).toBe(
+      "/d",
+    );
   });
 
-  it("sets shell:true on win32 case-insensitively", () => {
-    expect(buildSpawnOptions("C:\\x.CMD", "win32", undefined).shell).toBe(true);
-    expect(buildSpawnOptions("C:\\x.Bat", "win32", undefined).shell).toBe(true);
-  });
-
-  it("does not set shell on win32 for .exe or extension-less files", () => {
+  it("spawns .exe and extension-less files directly on win32", () => {
     expect(
-      buildSpawnOptions("C:\\Windows\\System32\\cmd.exe", "win32", undefined)
-        .shell,
-    ).toBeUndefined();
-    expect(
-      buildSpawnOptions(
-        "C:\\proj\\node_modules\\.bin\\playwright",
+      buildSpawnCommand(
+        "C:\\Windows\\System32\\cmd.exe",
+        [],
         "win32",
         undefined,
-      ).shell,
+      ).cmd,
+    ).toBe("C:\\Windows\\System32\\cmd.exe");
+    expect(
+      buildSpawnCommand(
+        "C:\\proj\\node_modules\\.bin\\playwright",
+        [],
+        "win32",
+        undefined,
+      ).cmd,
+    ).toBe("C:\\proj\\node_modules\\.bin\\playwright");
+  });
+
+  it("falls back to cmd.exe when ComSpec is unset", () => {
+    delete process.env["ComSpec"];
+    expect(buildSpawnCommand("C:\\x.cmd", [], "win32", undefined).cmd).toBe(
+      "cmd.exe",
+    );
+  });
+
+  it("never sets shell", () => {
+    expect(
+      buildSpawnCommand("C:\\x.cmd", ["a"], "win32", undefined).options.shell,
+    ).toBeUndefined();
+    expect(
+      buildSpawnCommand("/bin/sh", ["a"], "linux", undefined).options.shell,
     ).toBeUndefined();
   });
 
-  it("threads env through unchanged", () => {
+  it("threads env through on both platforms", () => {
     const env = { FOO: "bar" };
-    expect(buildSpawnOptions("/bin/sh", "linux", env)).toEqual({ env });
-    expect(buildSpawnOptions("C:\\x.cmd", "win32", env)).toEqual({
+    expect(buildSpawnCommand("/bin/sh", [], "linux", env).options).toEqual({
       env,
-      shell: true,
+    });
+    expect(buildSpawnCommand("C:\\x.cmd", [], "win32", env).options).toEqual({
+      env,
+      windowsVerbatimArguments: true,
     });
   });
 });

--- a/src/shell/spawn.ts
+++ b/src/shell/spawn.ts
@@ -1,5 +1,7 @@
 import { spawn, type SpawnOptions } from "node:child_process";
 
+import { escapeArgument, escapeCommand } from "~/core/cmdEscape.js";
+
 export { spawn };
 
 export type SpawnResult = {
@@ -14,38 +16,43 @@ export type SpawnFn = (
   opts?: { stdin?: string; env?: Record<string, string | undefined> },
 ) => Promise<SpawnResult>;
 
-// Node 18.20.2+/20.12.2+/24 refuses to execute .bat/.cmd files on win32
-// unless shell:true is set (CVE-2024-27980). With shell:true, Node routes
-// through cmd.exe /d /s /c and applies its own arg-quoting — the path the
-// CVE fix is designed to make safe.
+// Node 18.20.2+/20.12.2+/24 refuses to execute .bat/.cmd files on win32 except
+// through cmd.exe (CVE-2024-27980). Node 25 deprecates the shell:true route
+// when the caller also passes an args array (DEP0190), so invoke cmd.exe here.
 //
 // SECURITY CONTRACT for callers spawning .cmd/.bat on win32:
-//   Do not pass attacker-controlled values in `cmd` or `args`. Node's
-//   cmd.exe escaping protects against shell-metacharacter injection in
-//   args, but only when those args are passed as separate array elements
-//   (never concatenated into `cmd`). Call sites today: playwright.cmd,
-//   npm.cmd and appium.cmd with literal args. sdkmanager.bat and
-//   avdmanager.bat take AVD names and system images from flow metadata in
+//   Pass args as separate array elements, never concatenated into `cmd`.
+//   ~/core/cmdEscape.js escapes them, so a meta character in a value cannot
+//   inject a command. The target must forward its arguments with %*, which
+//   the npm shims and the Android .bat launchers both do. Call sites today:
+//   playwright.cmd, npm.cmd and appium.cmd with literal args. sdkmanager.bat
+//   and avdmanager.bat take AVD names and system images from flow metadata in
 //   the user's own repo. Audit any new .cmd/.bat caller before merging.
-export function buildSpawnOptions(
+export function buildSpawnCommand(
   cmd: string,
+  args: string[],
   platform: NodeJS.Platform,
   env: Record<string, string | undefined> | undefined,
-): SpawnOptions {
-  const opts: SpawnOptions = {};
-  if (env) opts.env = env;
-  if (platform === "win32" && /\.(cmd|bat)$/i.test(cmd)) opts.shell = true;
-  return opts;
+): { cmd: string; args: string[]; options: SpawnOptions } {
+  const options: SpawnOptions = {};
+  if (env) options.env = env;
+  if (platform !== "win32" || !/\.(cmd|bat)$/i.test(cmd)) {
+    return { cmd, args, options };
+  }
+  const line = [escapeCommand(cmd), ...args.map(escapeArgument)].join(" ");
+  return {
+    cmd: process.env["ComSpec"] ?? "cmd.exe",
+    args: ["/d", "/s", "/c", `"${line}"`],
+    // args are already quoted; stop Node from quoting them again
+    options: { ...options, windowsVerbatimArguments: true },
+  };
 }
 
 export const defaultSpawn: SpawnFn = (cmd, args, opts) =>
   new Promise((resolve) => {
     const env = opts?.env ? { ...process.env, ...opts.env } : undefined;
-    const child = spawn(
-      cmd,
-      args,
-      buildSpawnOptions(cmd, process.platform, env),
-    );
+    const built = buildSpawnCommand(cmd, args, process.platform, env);
+    const child = spawn(built.cmd, built.args, built.options);
     let stdout = "";
     let stderr = "";
     child.stdout?.on("data", (chunk) => {


### PR DESCRIPTION
Node 25 deprecates `shell: true` when the caller also passes an args array, so Windows users saw a DeprecationWarning on every `doctor` and `flows run`. `cross-spawn` is the reference implementation of the explicit `cmd.exe /d /s /c` route, but it has not shipped in over two years, so this ports its escaping rather than taking the dependency.

One deliberate divergence: cross-spawn double-escapes meta chars only for `node_modules/.bin` shims, which would under-escape a bare `npm.cmd`. `npm.cmd` forwards its arguments and re-enters cmd.exe, so it needs both layers.

Not exercised on real Windows — worth one manual `qawolf doctor` before release.

https://linear.app/qawolf/issue/WIZ-11277/avoid-node-dep0190-deprecation-warning-when-spawning-cmd