### PR TITLE
fix(cli): spawn using the platform the caller passed

### DIFF
--- a/src/commands/install/android.ts
+++ b/src/commands/install/android.ts
@@ -29,6 +29,7 @@ export async function handleInstallAndroid(
     arch: process.arch,
     androidHome,
     checkExists: (path: string) => fs.existsSync(path),
+    platform: process.platform,
     sdkManagerPath: sdkManagerBin(androidHome, process.platform),
     avdManagerPath: avdManagerBin(androidHome, process.platform),
     expandPatterns: (patterns, cwd) =>

--- a/src/commands/install/browsers.test.ts
+++ b/src/commands/install/browsers.test.ts
@@ -23,7 +23,9 @@ describe("installBrowsers", () => {
 
     expect(result).toBeUndefined();
     expect(deps.spawn).toHaveBeenCalledTimes(1);
-    expect(deps.spawn).toHaveBeenCalledWith(fakeCli, ["install", "chromium"]);
+    expect(deps.spawn).toHaveBeenCalledWith(fakeCli, ["install", "chromium"], {
+      platform: "darwin",
+    });
     expect(ui.withProgress).toHaveBeenCalledWith(
       expect.anything(),
       "Installed 1 browser.",
@@ -44,10 +46,11 @@ describe("installBrowsers", () => {
 
     await installBrowsers(ctx, undefined, deps);
 
+    const darwin = { platform: "darwin" };
     expect(callsOf(deps.spawn)).toEqual([
-      [fakeCli, ["install", "chromium"]],
-      [fakeCli, ["install", "firefox"]],
-      [fakeCli, ["install", "webkit"]],
+      [fakeCli, ["install", "chromium"], darwin],
+      [fakeCli, ["install", "firefox"], darwin],
+      [fakeCli, ["install", "webkit"], darwin],
     ]);
     expect(ctx.ui.withProgress).toHaveBeenCalledWith(
       expect.anything(),
@@ -113,11 +116,11 @@ describe("installBrowsers", () => {
 
     await installBrowsers(ctx, undefined, deps);
 
-    expect(deps.spawn).toHaveBeenCalledWith(fakeCli, [
-      "install",
-      "--with-deps",
-      "chromium",
-    ]);
+    expect(deps.spawn).toHaveBeenCalledWith(
+      fakeCli,
+      ["install", "--with-deps", "chromium"],
+      { platform: "linux" },
+    );
   });
 
   it("omits --with-deps on Linux when browserDeps is false", async () => {
@@ -128,7 +131,9 @@ describe("installBrowsers", () => {
 
     await installBrowsers(ctx, undefined, deps);
 
-    expect(deps.spawn).toHaveBeenCalledWith(fakeCli, ["install", "chromium"]);
+    expect(deps.spawn).toHaveBeenCalledWith(fakeCli, ["install", "chromium"], {
+      platform: "linux",
+    });
   });
 
   it("throws and stops on first non-zero exit", async () => {

--- a/src/domains/doctor/checks/android.test.ts
+++ b/src/domains/doctor/checks/android.test.ts
@@ -49,13 +49,17 @@ describe("checkAndroid: adb", () => {
   it("invokes adb at the SDK-relative path when ANDROID_HOME is set", async () => {
     const spawn = spawnRouter({});
     await checkAndroid(baseDeps({ spawn }));
-    expect(spawn).toHaveBeenCalledWith(adbPath, ["--version"]);
+    expect(spawn).toHaveBeenCalledWith(adbPath, ["--version"], {
+      platform: "linux",
+    });
   });
 
   it("invokes bare `adb` when ANDROID_HOME is missing", async () => {
     const spawn = spawnRouter({});
     await checkAndroid(baseDeps({ spawn, androidHome: undefined }));
-    expect(spawn).toHaveBeenCalledWith("adb", ["--version"]);
+    expect(spawn).toHaveBeenCalledWith("adb", ["--version"], {
+      platform: "linux",
+    });
   });
 
   it("fails when adb cannot launch, surfacing the spawn error and attempted path", async () => {

--- a/src/domains/doctor/checks/android.ts
+++ b/src/domains/doctor/checks/android.ts
@@ -33,6 +33,6 @@ export async function checkAndroid(
     deps.resolveAppiumBin,
     deps.checkExists,
   );
-  const uiautomator2 = await checkUiautomator2(deps.spawn, bin);
+  const uiautomator2 = await checkUiautomator2(deps.spawn, bin, deps.platform);
   return [home, adb, emulator, ...avds, appium, uiautomator2];
 }

--- a/src/domains/doctor/checks/androidAppium.ts
+++ b/src/domains/doctor/checks/androidAppium.ts
@@ -49,6 +49,7 @@ export function checkAppium(
 export async function checkUiautomator2(
   spawn: SpawnFn,
   appiumBin: string | undefined,
+  platform: NodeJS.Platform,
 ): Promise<CheckResult> {
   if (!appiumBin) {
     return {
@@ -59,6 +60,7 @@ export async function checkUiautomator2(
   }
   const result = await spawn(appiumBin, ["driver", "list", "--installed"], {
     env: { APPIUM_HOME: appiumHome },
+    platform,
   });
   if (result.exitCode !== 0) {
     return {

--- a/src/domains/doctor/checks/androidSdk.ts
+++ b/src/domains/doctor/checks/androidSdk.ts
@@ -37,7 +37,7 @@ export async function checkAdb(
   platform: NodeJS.Platform,
 ): Promise<CheckResult> {
   const bin = adbBin(androidHome, platform);
-  const result = await spawn(bin, ["--version"]);
+  const result = await spawn(bin, ["--version"], { platform });
   if (result.exitCode < 0) {
     return {
       name: "adb",
@@ -57,7 +57,7 @@ export async function checkEmulatorBin(
   platform: NodeJS.Platform,
 ): Promise<CheckResult> {
   const bin = emulatorBin(androidHome, platform);
-  const result = await spawn(bin, ["-version"]);
+  const result = await spawn(bin, ["-version"], { platform });
   if (result.exitCode < 0) {
     return {
       name: "android-emulator",
@@ -86,7 +86,7 @@ export async function checkAvds(
 ): Promise<CheckResult[]> {
   if (requiredAvds.length === 0) return [];
   const bin = emulatorBin(androidHome, platform);
-  const result = await spawn(bin, ["-list-avds"]);
+  const result = await spawn(bin, ["-list-avds"], { platform });
   if (result.exitCode < 0) {
     return [
       {

--- a/src/domains/doctor/checks/index.ts
+++ b/src/domains/doctor/checks/index.ts
@@ -47,6 +47,7 @@ export async function runChecks(deps: CheckDeps): Promise<CheckResult[]> {
     checkPlaywright({
       spawn: deps.spawn,
       playwrightCliPath: deps.playwrightCliPath,
+      platform: deps.platform,
     }),
     checkApiKey({ apiKey: deps.apiKey }),
     checkApiUrl({ fetch: deps.fetch, apiBaseUrl: deps.apiBaseUrl }),

--- a/src/domains/doctor/checks/npmRegistry.test.ts
+++ b/src/domains/doctor/checks/npmRegistry.test.ts
@@ -18,7 +18,7 @@ describe("checkNpmRegistry", () => {
     const spawn = spawnReturning({ exitCode: 0, stdout: "", stderr: "" });
     const r = await checkNpmRegistry({ spawn, platform: "linux" });
     expect(r).toEqual({ name: "npm-registry", status: "pass" });
-    expect(spawn).toHaveBeenCalledWith("npm", ["ping"]);
+    expect(spawn).toHaveBeenCalledWith("npm", ["ping"], { platform: "linux" });
   });
 
   it("warns on non-zero exit", async () => {
@@ -35,11 +35,13 @@ describe("checkNpmRegistry", () => {
   it("pings via npm.cmd on win32", async () => {
     const spawn = spawnReturning({ exitCode: 0, stdout: "", stderr: "" });
     await checkNpmRegistry({ spawn, platform: "win32" });
-    expect(spawn).toHaveBeenCalledWith("npm.cmd", ["ping"]);
+    expect(spawn).toHaveBeenCalledWith("npm.cmd", ["ping"], {
+      platform: "win32",
+    });
   });
 
-  // With shell:true, cmd.exe launches successfully and reports a missing
-  // npm.cmd as exit 9009, so the spawn `error` path never fires on win32.
+  // cmd.exe launches successfully and reports a missing npm.cmd as exit 9009,
+  // so the spawn `error` path never fires on win32.
   it("reports a missing npm on win32, where cmd.exe exits 9009", async () => {
     const spawn = spawnReturning({
       exitCode: 9009,

--- a/src/domains/doctor/checks/npmRegistry.ts
+++ b/src/domains/doctor/checks/npmRegistry.ts
@@ -12,9 +12,12 @@ type NpmRegistryDeps = {
 export async function checkNpmRegistry(
   deps: NpmRegistryDeps,
 ): Promise<CheckResult> {
-  const result = await deps.spawn(resolveNpmCommand(deps.platform), ["ping"]);
+  const { platform } = deps;
+  const result = await deps.spawn(resolveNpmCommand(platform), ["ping"], {
+    platform,
+  });
 
-  // cmd.exe's "command not found" code. win32 runs npm.cmd through a shell,
+  // cmd.exe's "command not found" code. win32 runs npm.cmd through cmd.exe,
   // so the spawn itself succeeds and a missing npm surfaces here instead of
   // on the exitCode < 0 path.
   const cmdNotFound = deps.platform === "win32" && result.exitCode === 9009;

--- a/src/domains/doctor/checks/playwright.test.ts
+++ b/src/domains/doctor/checks/playwright.test.ts
@@ -17,6 +17,7 @@ const fakeCli = "/fake/node_modules/.bin/playwright";
 const checkDeps = (spawn: SpawnFn) => ({
   spawn,
   playwrightCliPath: fakeCli,
+  platform: "linux" as NodeJS.Platform,
 });
 
 describe("checkPlaywright", () => {
@@ -27,6 +28,7 @@ describe("checkPlaywright", () => {
     const r = await checkPlaywright({
       spawn,
       playwrightCliPath: undefined,
+      platform: "linux",
     });
     expect(r.status).toBe("fail");
     expect(r.detail).toContain("Could not find");
@@ -45,7 +47,9 @@ describe("checkPlaywright", () => {
       status: "pass",
       version: "1.49.1",
     });
-    expect(spawn).toHaveBeenCalledWith(fakeCli, ["--version"]);
+    expect(spawn).toHaveBeenCalledWith(fakeCli, ["--version"], {
+      platform: "linux",
+    });
   });
 
   it("fails when spawn errors (process failed to launch)", async () => {

--- a/src/domains/doctor/checks/playwright.ts
+++ b/src/domains/doctor/checks/playwright.ts
@@ -6,6 +6,7 @@ import type { CheckResult } from "~/domains/doctor/types.js";
 type PlaywrightDeps = {
   readonly spawn: SpawnFn;
   readonly playwrightCliPath: string | undefined;
+  readonly platform: NodeJS.Platform;
 };
 
 export async function checkPlaywright(
@@ -19,7 +20,9 @@ export async function checkPlaywright(
     };
   }
 
-  const result = await deps.spawn(deps.playwrightCliPath, ["--version"]);
+  const result = await deps.spawn(deps.playwrightCliPath, ["--version"], {
+    platform: deps.platform,
+  });
 
   if (result.exitCode < 0) {
     return {

--- a/src/domains/install/android/avd.test.ts
+++ b/src/domains/install/android/avd.test.ts
@@ -21,9 +21,9 @@ const spec = {
 
 function makeSpawn(overrides: Record<string, SpawnResult> = {}): {
   fn: SpawnFn;
-  calls: [string, string[], ({ stdin?: string } | undefined)?][];
+  calls: Parameters<SpawnFn>[];
 } {
-  const calls: [string, string[], ({ stdin?: string } | undefined)?][] = [];
+  const calls: Parameters<SpawnFn>[] = [];
   const fn: SpawnFn = (cmd, args, opts) => {
     calls.push([cmd, args, opts]);
     return Promise.resolve(overrides[args[0] ?? cmd] ?? success);
@@ -59,6 +59,7 @@ function makeDeps(
     avdManagerPath,
     androidHome: sdk,
     checkExists: overrides.checkExists ?? (() => false),
+    platform: "linux" as NodeJS.Platform,
   };
 }
 
@@ -80,7 +81,10 @@ describe("installAvds", () => {
     const { fn: spawn, calls } = makeSpawn();
     await installAvds(makeCtx(), [spec], makeDeps({ spawn }));
     const licensesCall = calls.find(([, args]) => args[0] === "--licenses");
-    expect(licensesCall?.[2]).toEqual({ stdin: "y\n".repeat(20) });
+    expect(licensesCall?.[2]).toEqual({
+      stdin: "y\n".repeat(20),
+      platform: "linux",
+    });
   });
 
   it("should skip system image install when image directory exists", async () => {

--- a/src/domains/install/android/avd.ts
+++ b/src/domains/install/android/avd.ts
@@ -15,6 +15,8 @@ export type InstallAvdsDeps = {
   readonly avdManagerPath: string;
   readonly androidHome: string;
   readonly checkExists: (path: string) => boolean;
+  /** Must match the platform that resolved sdkManagerPath and avdManagerPath. */
+  readonly platform: NodeJS.Platform;
 };
 
 export async function installAvds(
@@ -23,7 +25,9 @@ export async function installAvds(
   deps: InstallAvdsDeps,
 ): Promise<void> {
   // Verify sdkmanager is reachable before doing any work.
-  const versionResult = await deps.spawn(deps.sdkManagerPath, ["--version"]);
+  const versionResult = await deps.spawn(deps.sdkManagerPath, ["--version"], {
+    platform: deps.platform,
+  });
   if (versionResult.exitCode !== 0) {
     throw new Error(
       installMessages.android.sdkmanagerNotFound(deps.sdkManagerPath),
@@ -39,6 +43,7 @@ export async function installAvds(
     ctx.ui.step(installMessages.android.acceptingLicenses);
     await deps.spawn(deps.sdkManagerPath, ["--licenses"], {
       stdin: "y\n".repeat(20),
+      platform: deps.platform,
     });
   }
 
@@ -65,7 +70,9 @@ export async function installAvds(
     ctx.ui.step(
       installMessages.android.installingSystemImage(spec.systemImage),
     );
-    const result = await deps.spawn(deps.sdkManagerPath, [spec.systemImage]);
+    const result = await deps.spawn(deps.sdkManagerPath, [spec.systemImage], {
+      platform: deps.platform,
+    });
     if (result.exitCode !== 0) {
       const detail =
         (result.stderr || result.stdout)
@@ -83,11 +90,11 @@ export async function installAvds(
   }
 
   // List existing AVDs to skip creation when already present.
-  const listResult = await deps.spawn(deps.avdManagerPath, [
-    "list",
-    "avd",
-    "-c",
-  ]);
+  const listResult = await deps.spawn(
+    deps.avdManagerPath,
+    ["list", "avd", "-c"],
+    { platform: deps.platform },
+  );
   const existingAvds = new Set(
     listResult.stdout
       .split("\n")
@@ -102,17 +109,21 @@ export async function installAvds(
       continue;
     }
     ctx.ui.step(installMessages.android.creatingAvd(spec.avdName));
-    const result = await deps.spawn(deps.avdManagerPath, [
-      "create",
-      "avd",
-      "-n",
-      spec.avdName,
-      "-k",
-      spec.systemImage,
-      "-d",
-      spec.deviceId,
-      "--force",
-    ]);
+    const result = await deps.spawn(
+      deps.avdManagerPath,
+      [
+        "create",
+        "avd",
+        "-n",
+        spec.avdName,
+        "-k",
+        spec.systemImage,
+        "-d",
+        spec.deviceId,
+        "--force",
+      ],
+      { platform: deps.platform },
+    );
     if (result.exitCode !== 0) {
       const detail =
         (result.stderr || result.stdout)

--- a/src/domains/install/android/driver.test.ts
+++ b/src/domains/install/android/driver.test.ts
@@ -43,7 +43,7 @@ function makeCtx(): CommandContext {
 }
 
 function makeDeps(spawn: SpawnFn) {
-  return { spawn, appiumBinPath };
+  return { spawn, appiumBinPath, platform: "linux" as NodeJS.Platform };
 }
 
 describe("installUiautomator2Driver", () => {

--- a/src/domains/install/android/driver.ts
+++ b/src/domains/install/android/driver.ts
@@ -8,6 +8,8 @@ import { appiumUiautomator2DriverVersion } from "~/generated/dependencyVersions.
 export type InstallDriverDeps = {
   readonly spawn: SpawnFn;
   readonly appiumBinPath: string;
+  /** Must match the platform that resolved appiumBinPath. */
+  readonly platform: NodeJS.Platform;
 };
 
 // Must match the APPIUM_HOME used by createAppiumServer so that drivers
@@ -24,7 +26,7 @@ export async function installUiautomator2Driver(
   const listResult = await deps.spawn(
     deps.appiumBinPath,
     ["driver", "list", "--installed"],
-    { env: appiumEnv },
+    { env: appiumEnv, platform: deps.platform },
   );
   // Appium writes driver list output to stderr on some versions.
   if ((listResult.stdout + listResult.stderr).includes("uiautomator2")) {
@@ -36,7 +38,7 @@ export async function installUiautomator2Driver(
   const installResult = await deps.spawn(
     deps.appiumBinPath,
     ["driver", "install", `uiautomator2@${appiumUiautomator2DriverVersion}`],
-    { env: appiumEnv },
+    { env: appiumEnv, platform: deps.platform },
   );
   if (installResult.exitCode !== 0) {
     const output = installResult.stderr + installResult.stdout;

--- a/src/domains/install/android/index.ts
+++ b/src/domains/install/android/index.ts
@@ -20,6 +20,8 @@ export type InstallAndroidDeps = {
   readonly checkExists: (path: string) => boolean;
   readonly sdkManagerPath: string;
   readonly avdManagerPath: string;
+  /** Must match the platform that resolved the sdkmanager, avdmanager and appium paths. */
+  readonly platform: NodeJS.Platform;
   readonly expandPatterns: (
     patterns: string[],
     cwd?: string,
@@ -53,12 +55,14 @@ export async function installAndroid(
     avdManagerPath: deps.avdManagerPath,
     androidHome: deps.androidHome,
     checkExists: deps.checkExists,
+    platform: deps.platform,
   });
 
   const depsRoot = await deps.resolveDepsRoot(files);
   await installUiautomator2Driver(ctx, {
     spawn: deps.spawn,
     appiumBinPath: deps.resolveAppiumBin(depsRoot),
+    platform: deps.platform,
   });
 
   ctx.ui.success(

--- a/src/domains/install/android/installAndroid.test.ts
+++ b/src/domains/install/android/installAndroid.test.ts
@@ -16,9 +16,9 @@ const success: SpawnResult = { exitCode: 0, stdout: "", stderr: "" };
 
 function makeSpawn(overrides: Record<string, SpawnResult> = {}): {
   fn: SpawnFn;
-  calls: [string, string[], ({ stdin?: string } | undefined)?][];
+  calls: Parameters<SpawnFn>[];
 } {
-  const calls: [string, string[], ({ stdin?: string } | undefined)?][] = [];
+  const calls: Parameters<SpawnFn>[] = [];
   const fn: SpawnFn = (cmd, args, opts) => {
     calls.push([cmd, args, opts]);
     const key = args[0] ?? cmd;
@@ -60,6 +60,7 @@ function makeDeps(
     arch: overrides.arch ?? "arm64",
     androidHome: sdk,
     checkExists: overrides.checkExists ?? (() => false),
+    platform: "linux" as NodeJS.Platform,
     sdkManagerPath,
     avdManagerPath,
     expandPatterns: overrides.expandPatterns ?? (async () => ["/flow.ts"]),
@@ -92,7 +93,11 @@ describe("installAndroid", () => {
   it("should call sdkmanager --version as the first spawn call", async () => {
     const { fn: spawn, calls } = makeSpawn();
     await installAndroid(makeCtx(), undefined, makeDeps({ spawn }));
-    expect(calls[0]).toEqual([sdkManagerPath, ["--version"], undefined]);
+    expect(calls[0]).toEqual([
+      sdkManagerPath,
+      ["--version"],
+      { platform: "linux" },
+    ]);
   });
 
   it("should throw with path and install URL when sdkmanager --version returns non-zero", async () => {
@@ -118,7 +123,10 @@ describe("installAndroid", () => {
     const { fn: spawn, calls } = makeSpawn();
     await installAndroid(makeCtx(), undefined, makeDeps({ spawn }));
     const licensesCall = calls.find(([, args]) => args[0] === "--licenses");
-    expect(licensesCall?.[2]).toEqual({ stdin: "y\n".repeat(20) });
+    expect(licensesCall?.[2]).toEqual({
+      stdin: "y\n".repeat(20),
+      platform: "linux",
+    });
   });
 
   it("should install each unique system image exactly once when two files share the same preset", async () => {

--- a/src/domains/install/browsers.ts
+++ b/src/domains/install/browsers.ts
@@ -38,7 +38,9 @@ export async function installBrowserList(
       message: installMessages.installingBrowser(browser),
       task: async () => {
         const args = buildArgs(browser, deps.platform, deps.browserDeps);
-        const result = await deps.spawn(deps.playwrightCliPath, args);
+        const result = await deps.spawn(deps.playwrightCliPath, args, {
+          platform: deps.platform,
+        });
         if (result.exitCode !== 0) {
           throw new Error(formatError(browser, result));
         }

--- a/src/domains/runner/dispatchViaSubprocess.test.ts
+++ b/src/domains/runner/dispatchViaSubprocess.test.ts
@@ -44,7 +44,7 @@ function fakeSpawn(result: SpawnResult): {
   const calls: { cmd: string; args: string[]; stdin: string | undefined }[] =
     [];
   const spawn: SpawnFn = (cmd, args, opts) => {
-    calls.push({ cmd, args, stdin: opts?.stdin });
+    calls.push({ cmd, args, stdin: opts.stdin });
     return Promise.resolve(result);
   };
   return { spawn, calls };
@@ -64,6 +64,7 @@ describe("runWorkerOnce", () => {
       prefixArgs: [],
       flow,
       optionsJson: "{}",
+      platform: "linux",
     });
 
     expect(out.run.passed).toBe(true);
@@ -84,6 +85,7 @@ describe("runWorkerOnce", () => {
       prefixArgs: ["/app/cli.js"],
       flow,
       optionsJson: '{"retries":0}',
+      platform: "linux",
     });
 
     expect(calls).toHaveLength(1);
@@ -110,6 +112,7 @@ describe("runWorkerOnce", () => {
       prefixArgs: [],
       flow,
       optionsJson: "{}",
+      platform: "linux",
     });
 
     expect(out.run.passed).toBe(false);
@@ -132,6 +135,7 @@ describe("runWorkerOnce", () => {
       prefixArgs: [],
       flow,
       optionsJson: "{}",
+      platform: "linux",
     });
 
     expect(out.run.passed).toBe(false);
@@ -155,6 +159,7 @@ describe("createSubprocessDispatch", () => {
       command: "/bin/qawolf",
       prefixArgs: [],
       resolvedDir: "/proj",
+      platform: "linux",
       webOptions,
       androidOptions,
     });

--- a/src/domains/runner/dispatchViaSubprocess.ts
+++ b/src/domains/runner/dispatchViaSubprocess.ts
@@ -28,15 +28,17 @@ export async function runWorkerOnce(args: {
   prefixArgs: readonly string[];
   flow: ResolvedFlow;
   optionsJson: string;
+  platform: NodeJS.Platform;
   workerEnv?: Record<string, string | undefined> | undefined;
 }): Promise<DispatchResult> {
-  const { spawn, command, prefixArgs, flow, optionsJson, workerEnv } = args;
+  const { spawn, command, prefixArgs, flow, optionsJson, platform, workerEnv } =
+    args;
   const result = await spawn(
     command,
     [...prefixArgs, "flows", "__run-worker", flow.file],
     workerEnv !== undefined
-      ? { stdin: optionsJson, env: workerEnv }
-      : { stdin: optionsJson },
+      ? { stdin: optionsJson, env: workerEnv, platform }
+      : { stdin: optionsJson, platform },
   );
 
   const line = lastNonEmptyLine(result.stdout);
@@ -74,6 +76,7 @@ export function createSubprocessDispatch(env: {
   prefixArgs: readonly string[];
   workerEnv?: Record<string, string | undefined> | undefined;
   resolvedDir: string;
+  platform: NodeJS.Platform;
   webOptions: RunWebFlowOptions;
   androidOptions: RunAndroidFlowOptions;
 }): PooledDispatch {
@@ -82,6 +85,7 @@ export function createSubprocessDispatch(env: {
       spawn: env.spawn,
       command: env.command,
       prefixArgs: env.prefixArgs,
+      platform: env.platform,
       workerEnv: env.workerEnv,
       flow,
       optionsJson: serializeWorkerInput({

--- a/src/domains/runner/makePooledDispatch.ts
+++ b/src/domains/runner/makePooledDispatch.ts
@@ -18,6 +18,7 @@ export function makePooledDispatch(
       spawn: defaultSpawn,
       command,
       prefixArgs,
+      platform: process.platform,
       workerEnv,
       resolvedDir,
       webOptions,

--- a/src/shell/spawn.test.ts
+++ b/src/shell/spawn.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 
-import { buildSpawnCommand } from "./spawn.js";
+import { buildSpawnCommand, defaultSpawn } from "./spawn.js";
 
 const originalComSpec = process.env["ComSpec"];
 
@@ -102,5 +102,31 @@ describe("buildSpawnCommand", () => {
       env,
       windowsVerbatimArguments: true,
     });
+  });
+});
+
+describe.skipIf(process.platform === "win32")("defaultSpawn", () => {
+  // /bin/echo stands in for cmd.exe so a POSIX host can observe the win32
+  // routing that buildSpawnCommand produces.
+  it("routes a .cmd through the shell named by the caller's platform", async () => {
+    process.env["ComSpec"] = "/bin/echo";
+
+    const result = await defaultSpawn("C:\\tools\\npm.cmd", ["ping"], {
+      platform: "win32",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toStartWith('/d /s /c "C:\\tools\\npm.cmd ');
+  });
+
+  it("spawns the command directly when the caller passes a posix platform", async () => {
+    process.env["ComSpec"] = "/bin/echo";
+
+    const result = await defaultSpawn("/bin/echo", ["hello"], {
+      platform: "linux",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("hello");
   });
 });

--- a/src/shell/spawn.ts
+++ b/src/shell/spawn.ts
@@ -57,7 +57,7 @@ export function buildSpawnCommand(
 export const defaultSpawn: SpawnFn = (cmd, args, opts) =>
   new Promise((resolve) => {
     const env = opts.env ? { ...process.env, ...opts.env } : undefined;
-    const built = buildSpawnCommand(cmd, args, process.platform, env);
+    const built = buildSpawnCommand(cmd, args, opts.platform, env);
     const child = spawn(built.cmd, built.args, built.options);
     let stdout = "";
     let stderr = "";

--- a/src/shell/spawn.ts
+++ b/src/shell/spawn.ts
@@ -10,10 +10,16 @@ export type SpawnResult = {
   readonly stderr: string;
 };
 
+// platform is required so one call site decides both the command name and how
+// the command is invoked. Pass the same platform that resolved cmd.
 export type SpawnFn = (
   cmd: string,
   args: string[],
-  opts?: { stdin?: string; env?: Record<string, string | undefined> },
+  opts: {
+    platform: NodeJS.Platform;
+    stdin?: string;
+    env?: Record<string, string | undefined>;
+  },
 ) => Promise<SpawnResult>;
 
 // Node 18.20.2+/20.12.2+/24 refuses to execute .bat/.cmd files on win32 except
@@ -50,7 +56,7 @@ export function buildSpawnCommand(
 
 export const defaultSpawn: SpawnFn = (cmd, args, opts) =>
   new Promise((resolve) => {
-    const env = opts?.env ? { ...process.env, ...opts.env } : undefined;
+    const env = opts.env ? { ...process.env, ...opts.env } : undefined;
     const built = buildSpawnCommand(cmd, args, process.platform, env);
     const child = spawn(built.cmd, built.args, built.options);
     let stdout = "";


### PR DESCRIPTION
`defaultSpawn` derived the cmd.exe routing from `process.platform` while its caller resolved the command name from an injected platform, so the two could disagree — on win32 that meant `npm.cmd` without cmd.exe, which is EINVAL. `platform` is now required in the `SpawnFn` opts rather than optional, so the compiler rejects a spawn that doesn't name the platform it resolved its command with. First commit threads it through every caller with behaviour unchanged; second switches `defaultSpawn` over.

The test points `ComSpec` at `/bin/echo` so a POSIX host can observe the real win32 command line. WIZ-11280 tracks the same split one layer out, where `commands/` still resolves a path and passes a platform separately.

Closes WIZ-11278