### PR TITLE
build(cli): add a Windows CI smoke job for the spawn path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,41 @@ jobs:
             node dist/cli.js --version
             node test/node20/smoke.mjs
           fi
+
+  # Only a Windows runner reaches CreateProcess, so only this job catches a
+  # win32 spawn regression. WIZ-11274 (`spawn npm ENOENT`) shipped through that
+  # gap. `test/spawn/smoke.mjs` explains the mechanism.
+  #
+  # TODO WIZ-11279: add `bun run test` here. Around 30 test files assert POSIX
+  # separators or file modes, so the suite fails on win32 today.
+  #
+  # Every multi-line step sets `shell: bash`. The windows-latest default is
+  # pwsh, which reports only the last command's exit code, so an earlier
+  # failure would pass silently.
+  windows-smoke:
+    name: Windows smoke
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: package.json
+      - run: bun install --frozen-lockfile
+      # build:bundle skips the postbuild hook, which shells out to bash to
+      # prepend a shebang and chmod dist/cli.js. Windows needs neither to run
+      # `node dist/cli.js`.
+      - run: bun run build:bundle
+      - name: Bundle spawn helpers for smoke
+        shell: bash
+        run: |
+          bun build src/shell/npm.ts --target=node --format=esm --outfile test/spawn/npm.generated.mjs
+          bun build src/shell/spawn.ts --target=node --format=esm --outfile test/spawn/spawn.generated.mjs
+      - name: Smoke — bundle boots + npm spawns
+        shell: bash
+        run: |
+          node dist/cli.js --version
+          node test/spawn/smoke.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ dist/
 # Generated source files
 src/generated/
 
-# Generated smoke-test loader bundle (built in the runtime-smoke CI job)
+# Generated smoke-test bundles (built in CI)
 test/node20/loader.generated.mjs
+test/spawn/*.generated.mjs
 
 # Environment
 .env

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -106,7 +106,8 @@
     "dist/",
     "node_modules/",
     "knip.config.ts",
-    "test/node20/"
+    "test/node20/",
+    "test/spawn/"
   ],
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "bun run generate && bun scripts/build.ts",
+    "build": "bun run build:bundle",
+    "build:bundle": "bun run generate && bun scripts/build.ts",
     "build:binary": "bun run build && bun scripts/buildBinary.ts",
     "dev": "bun run src/main.ts",
     "format": "oxfmt .",

--- a/test/spawn/smoke.mjs
+++ b/test/spawn/smoke.mjs
@@ -1,0 +1,37 @@
+// Cross-platform witness that the CLI can spawn npm on the host, through the
+// REAL shipped resolveNpmCommand + defaultSpawn rather than a copy.
+//
+// Unit tests take the platform as a parameter, so they pass on Linux whatever
+// win32 does. Only a Windows runner reaches CreateProcess. That is where
+// WIZ-11274 failed: Windows ships npm.cmd, and libuv's PATH search ignores
+// PATHEXT, so a bare "npm" is ENOENT.
+//
+// bun bundles src/shell/npm.ts and src/shell/spawn.ts into the *.generated.mjs
+// files (see the windows-smoke CI job). The bundle step resolves the `~/` path
+// alias that Node cannot.
+import { resolveNpmCommand } from "./npm.generated.mjs";
+import { defaultSpawn } from "./spawn.generated.mjs";
+
+// One platform value picks the command name and the invocation route, which is
+// the contract SpawnFn requires.
+const platform = process.platform;
+const cmd = resolveNpmCommand(platform);
+const result = await defaultSpawn(cmd, ["--version"], { platform });
+
+if (result.exitCode !== 0) {
+  console.error(
+    `npm-spawn smoke FAILED: "${cmd} --version" exited ${result.exitCode}\n${result.stderr}`,
+  );
+  process.exit(1);
+}
+
+if (!/^\d+\.\d+\.\d+/.test(result.stdout.trim())) {
+  console.error(
+    `npm-spawn smoke FAILED: "${cmd} --version" printed no version: ${JSON.stringify(result.stdout)}`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `npm-spawn smoke OK on ${process.platform}: ${cmd} ${result.stdout.trim()}`,
+);


### PR DESCRIPTION
Unit tests take the platform as a parameter, so they pass on Linux whatever win32 does — which is how WIZ-11274 (`spawn npm ENOENT`) reached a customer. Only a Windows runner reaches CreateProcess, so this job boots the bundle and spawns npm through the real `resolveNpmCommand` and `defaultSpawn`.

The ticket asked for typecheck plus the test suite. Typecheck is platform-independent, and around 30 test files assert POSIX separators or file modes, so the suite fails on win32 for reasons unrelated to the product — WIZ-11279 tracks that. Neither step would have caught WIZ-11274; the spawn smoke does.

Closes WIZ-11275