### PR TITLE
feat: bump @qawolf/api-contracts to 0.17.0

### DIFF
--- a/.changeset/accept-organization-identity.md
+++ b/.changeset/accept-organization-identity.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": minor
 ---
 
-`qawolf auth whoami` now reports organization and user identities, not just teams. It consumes the shared `identityResponse` from `@qawolf/api-contracts` (bumped to 0.17.0) instead of a hand-rolled schema, so it can't drift from the platform: a team API key reports its team, an organization API key its organization, and a user API key the user (email) plus their organization.
+`qawolf auth whoami` now works with organization and user API keys, not just team keys. With an organization key it shows the organization; with a user key it shows the signed-in user (email) and their organization. Previously any non-team key failed with "Could not verify API key: unexpected response format".

--- a/.changeset/accept-organization-identity.md
+++ b/.changeset/accept-organization-identity.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+`qawolf auth whoami` now works with WorkOS organization API keys. The CLI only accepted a team-shaped `/api/v0/identity` response, so an organization key (which returns `{ organization }`) failed with "Could not verify API key: unexpected response format". The identity response schema now comes from `@qawolf/api-contracts` (bumped to 0.15.0) — shared with the platform, so the two can't drift — and `whoami` reports the organization. The api-contracts bump also brings the CLI's public commands current (`--workspace-id` on org-key-aware commands, plus `environment find`, `environment setVariable`, and `flow addTag`).

--- a/.changeset/accept-organization-identity.md
+++ b/.changeset/accept-organization-identity.md
@@ -1,5 +1,5 @@
 ---
-"@qawolf/cli": patch
+"@qawolf/cli": minor
 ---
 
-`qawolf auth whoami` now works with WorkOS organization API keys. The CLI only accepted a team-shaped `/api/v0/identity` response, so an organization key (which returns `{ organization }`) failed with "Could not verify API key: unexpected response format". The identity response schema now comes from `@qawolf/api-contracts` (bumped to 0.15.0) — shared with the platform, so the two can't drift — and `whoami` reports the organization. The api-contracts bump also brings the CLI's public commands current (`--workspace-id` on org-key-aware commands, plus `environment find`, `environment setVariable`, and `flow addTag`).
+`qawolf auth whoami` now reports organization and user identities, not just teams. It consumes the shared `identityResponse` from `@qawolf/api-contracts` (bumped to 0.17.0) instead of a hand-rolled schema, so it can't drift from the platform: a team API key reports its team, an organization API key its organization, and a user API key the user (email) plus their organization.

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
         "@playwright/test": "1.60.0",
-        "@qawolf/api-contracts": "0.14.0",
+        "@qawolf/api-contracts": "0.15.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.14.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-CEHYzyAtsGRsTdhEKZIXjcRi9Q7bFdWwUjvQxFhmJMrLUcJa12t2qTv6wAFRFxp7dqiCiZZqJbjCoBCZBN5b1w=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.15.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-U4RoiERCMMtqUYs/+gyLFW0xLmll1p7PPlR28U/Fz5VAuMK4eigdFaPaNMfjxwNeq8rY5Lx40bShajsyLhVvLQ=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
         "@playwright/test": "1.60.0",
-        "@qawolf/api-contracts": "0.15.0",
+        "@qawolf/api-contracts": "0.17.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.15.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-U4RoiERCMMtqUYs/+gyLFW0xLmll1p7PPlR28U/Fz5VAuMK4eigdFaPaNMfjxwNeq8rY5Lx40bShajsyLhVvLQ=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.17.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-W8pBVPVTeRLG19C4n+fFcR/KUa7PeBzzgqAgZm4yJtIeVG42kMDnc4lN72svwTbjCIXZpNTpilDHw5uBhyj7Og=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
     "@playwright/test": "1.60.0",
-    "@qawolf/api-contracts": "0.15.0",
+    "@qawolf/api-contracts": "0.17.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
     "@playwright/test": "1.60.0",
-    "@qawolf/api-contracts": "0.14.0",
+    "@qawolf/api-contracts": "0.15.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -48,6 +48,7 @@ write on timeout: it may have reached the server the first time.
 | `qawolf automate`                      | write                      | Request an automation that builds the selected draft flows in an environment.                                              |
 | `qawolf doctor`                        | local                      | Diagnose problems running flows locally                                                                                    |
 | `qawolf environment create`            | write                      | Create an environment on the caller's team and return it in the environment.get shape.                                     |
+| `qawolf environment deleteVariable`    | write                      | Remove one environment variable by name. Succeeds whether or not the variable existed.                                     |
 | `qawolf environment find`              | read                       | List the team's environments, newest first.                                                                                |
 | `qawolf environment get`               | read                       | Read a single environment's name, kind, health status, and termination state.                                              |
 | `qawolf environment listVariableNames` | read                       | List the names of an environment's variables, sorted. Names only — values never leave the server.                          |

--- a/src/commands/auth/whoami.test.ts
+++ b/src/commands/auth/whoami.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import type { ApiKeyResult } from "~/domains/auth/types.js";
 import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
-import type { IdentityResponse } from "~/shell/platform/getIdentity.js";
+import type {
+  IdentityResponse,
+  TeamIdentity,
+} from "~/shell/platform/getIdentity.js";
 import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
 import { makeCtx } from "~/shell/commandContext.testUtils.js";
 import { handleWhoami } from "./whoami.js";
@@ -10,7 +13,7 @@ afterEach(() => {
   mock.restore();
 });
 
-function makeTeam(): IdentityResponse["team"] {
+function makeTeam(): TeamIdentity {
   return {
     id: "t1",
     name: "Acme Corp",
@@ -117,6 +120,43 @@ describe("handleWhoami", () => {
           authenticated: true,
           source: "env",
         }),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe("organization identity", () => {
+    function makeOrgDeps() {
+      return makeDeps({
+        getIdentity: mock(() =>
+          Promise.resolve({
+            ok: true as const,
+            value: { organization: { id: "org_1", name: "Acme Org" } },
+          }),
+        ),
+      });
+    }
+
+    it("outputs the organization in JSON output", async () => {
+      const ctx = makeCtx("json", { apiBaseUrl: "https://app.qawolf.com" });
+      await handleWhoami(ctx, makeOrgDeps());
+
+      expect(ctx.ui.output).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticated: true,
+          organization: { id: "org_1", name: "Acme Org" },
+          source: "env",
+        }),
+        expect.any(String),
+      );
+    });
+
+    it("includes the organization name in the human note", async () => {
+      const ctx = makeCtx("human", { apiBaseUrl: "https://app.qawolf.com" });
+      await handleWhoami(ctx, makeOrgDeps());
+
+      expect(ctx.ui.note).toHaveBeenCalledWith(
+        expect.stringContaining("Acme Org"),
         expect.any(String),
       );
     });

--- a/src/commands/auth/whoami.test.ts
+++ b/src/commands/auth/whoami.test.ts
@@ -1,48 +1,11 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import type { ApiKeyResult } from "~/domains/auth/types.js";
-import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
-import type {
-  IdentityResponse,
-  TeamIdentity,
-} from "~/shell/platform/getIdentity.js";
-import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
 import { makeCtx } from "~/shell/commandContext.testUtils.js";
 import { handleWhoami } from "./whoami.js";
+import { makeDeps } from "./whoami.testUtils.js";
 
 afterEach(() => {
   mock.restore();
 });
-
-function makeTeam(): TeamIdentity {
-  return {
-    id: "t1",
-    name: "Acme Corp",
-    slug: "acme",
-    createdAt: "2024-01-01T00:00:00.000Z",
-  };
-}
-
-function makeDeps(
-  overrides: {
-    requireApiKey?: () => Promise<ApiKeyResult>;
-    getIdentity?: () => Promise<PlatformResult<IdentityResponse>>;
-  } = {},
-) {
-  const getIdentity =
-    overrides.getIdentity ??
-    mock(() =>
-      Promise.resolve({
-        ok: true as const,
-        value: { team: makeTeam() },
-      }),
-    );
-  return {
-    requireApiKey:
-      overrides.requireApiKey ??
-      mock(() => Promise.resolve({ key: "test-key", source: "env" as const })),
-    createPlatform: mock(() => ({ getIdentity }) as unknown as PlatformClient),
-  };
-}
 
 describe("handleWhoami", () => {
   describe("human mode — authenticated", () => {
@@ -157,6 +120,47 @@ describe("handleWhoami", () => {
 
       expect(ctx.ui.note).toHaveBeenCalledWith(
         expect.stringContaining("Acme Org"),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe("user identity", () => {
+    function makeUserDeps() {
+      return makeDeps({
+        getIdentity: mock(() =>
+          Promise.resolve({
+            ok: true as const,
+            value: {
+              organization: { id: "org_1", name: "Acme Org" },
+              user: { email: "user@example.com", id: "user_1" },
+            },
+          }),
+        ),
+      });
+    }
+
+    it("outputs the user and organization in JSON output", async () => {
+      const ctx = makeCtx("json", { apiBaseUrl: "https://app.qawolf.com" });
+      await handleWhoami(ctx, makeUserDeps());
+
+      expect(ctx.ui.output).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticated: true,
+          organization: { id: "org_1", name: "Acme Org" },
+          source: "env",
+          user: { email: "user@example.com", id: "user_1" },
+        }),
+        expect.any(String),
+      );
+    });
+
+    it("includes the user email in the human note", async () => {
+      const ctx = makeCtx("human", { apiBaseUrl: "https://app.qawolf.com" });
+      await handleWhoami(ctx, makeUserDeps());
+
+      expect(ctx.ui.note).toHaveBeenCalledWith(
+        expect.stringContaining("user@example.com"),
         expect.any(String),
       );
     });

--- a/src/commands/auth/whoami.testUtils.ts
+++ b/src/commands/auth/whoami.testUtils.ts
@@ -1,0 +1,39 @@
+import { mock } from "bun:test";
+import type { ApiKeyResult } from "~/domains/auth/types.js";
+import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
+import type {
+  IdentityResponse,
+  TeamIdentity,
+} from "~/shell/platform/getIdentity.js";
+import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
+
+function makeTeam(): TeamIdentity {
+  return {
+    id: "t1",
+    name: "Acme Corp",
+    slug: "acme",
+    createdAt: "2024-01-01T00:00:00.000Z",
+  };
+}
+
+export function makeDeps(
+  overrides: {
+    requireApiKey?: () => Promise<ApiKeyResult>;
+    getIdentity?: () => Promise<PlatformResult<IdentityResponse>>;
+  } = {},
+) {
+  const getIdentity =
+    overrides.getIdentity ??
+    mock(() =>
+      Promise.resolve({
+        ok: true as const,
+        value: { team: makeTeam() },
+      }),
+    );
+  return {
+    requireApiKey:
+      overrides.requireApiKey ??
+      mock(() => Promise.resolve({ key: "test-key", source: "env" as const })),
+    createPlatform: mock(() => ({ getIdentity }) as unknown as PlatformClient),
+  };
+}

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -68,6 +68,32 @@ export async function handleWhoami(
 
   const { value } = identity;
 
+  if ("user" in value) {
+    const { organization, user } = value;
+    if (ctx.ui.mode === "human") {
+      ctx.ui.note(
+        authMessages.whoami.userNote({
+          organization,
+          source: resolved.source,
+          user,
+        }),
+        authMessages.whoamiAuthenticated,
+      );
+      ctx.ui.outro(authMessages.outroReady);
+    } else {
+      ctx.ui.output(
+        {
+          authenticated: true,
+          organization,
+          source: resolved.source,
+          user,
+        },
+        authMessages.whoami.authenticatedAs(user.email, resolved.source),
+      );
+    }
+    return;
+  }
+
   if ("organization" in value) {
     const { organization } = value;
     if (ctx.ui.mode === "human") {

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -66,7 +66,33 @@ export async function handleWhoami(
     return { error: "invalid key" };
   }
 
-  const { team } = identity.value;
+  const { value } = identity;
+
+  if ("organization" in value) {
+    const { organization } = value;
+    if (ctx.ui.mode === "human") {
+      ctx.ui.note(
+        authMessages.whoami.organizationNote({
+          organization,
+          source: resolved.source,
+        }),
+        authMessages.whoamiAuthenticated,
+      );
+      ctx.ui.outro(authMessages.outroReady);
+    } else {
+      ctx.ui.output(
+        {
+          authenticated: true,
+          organization,
+          source: resolved.source,
+        },
+        authMessages.whoami.authenticatedAs(organization.name, resolved.source),
+      );
+    }
+    return;
+  }
+
+  const { team } = value;
   const teamUrl = team.slug
     ? new URL("/" + encodeURIComponent(team.slug), ctx.apiBaseUrl).toString()
     : undefined;

--- a/src/commands/flows/flowRuntimeDeps.ts
+++ b/src/commands/flows/flowRuntimeDeps.ts
@@ -27,7 +27,8 @@ async function maybeGetIdentityTeamId(
   platformClient: PlatformClient,
 ): Promise<string | undefined> {
   const identity = await platformClient.getIdentity();
-  return identity.ok ? identity.value.team.id : undefined;
+  if (!identity.ok || !("team" in identity.value)) return undefined;
+  return identity.value.team.id;
 }
 
 function lazyGetInbox({

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -26,11 +26,15 @@ const groupDescriptions: Record<string, string> = {
   run: "Trigger and manage QA Wolf runs on the platform",
 };
 
-// Contracts excluded from generated commands: either served by a hand-written
-// command (flow.list → `qawolf flows list --remote`) or not expressible as CLI
-// flags (issue.update's input is a discriminator-less union).
+// Contracts already served by hand-written commands; the generator must not
+// mint duplicates (flow.list is served by `qawolf flows list --remote`).
+const handWrittenContractNames: ReadonlySet<string> = new Set(["flow.list"]);
+
+// Kept out of generated commands: the hand-written ones above, plus contracts
+// whose input can't be expressed as CLI flags (issue.update is a
+// discriminator-less union).
 const skippedContractNames: ReadonlySet<string> = new Set([
-  "flow.list",
+  ...handWrittenContractNames,
   "issue.update",
 ]);
 

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -26,9 +26,13 @@ const groupDescriptions: Record<string, string> = {
   run: "Trigger and manage QA Wolf runs on the platform",
 };
 
-// Contracts already served by hand-written commands; the generator must not
-// mint duplicates (flow.list is served by `qawolf flows list --remote`).
-const handWrittenContractNames: ReadonlySet<string> = new Set(["flow.list"]);
+// Contracts excluded from generated commands: either served by a hand-written
+// command (flow.list → `qawolf flows list --remote`) or not expressible as CLI
+// flags (issue.update's input is a discriminator-less union).
+const skippedContractNames: ReadonlySet<string> = new Set([
+  "flow.list",
+  "issue.update",
+]);
 
 function resolveGroup(parent: Command, segment: string): Command {
   const existing = parent.commands.find(
@@ -95,7 +99,7 @@ export function registerPublicApiCommands(
   options: Options = {},
 ): void {
   const specs = buildCommandSpecs(options.contracts ?? publicContractsV1, {
-    skipContractNames: handWrittenContractNames,
+    skipContractNames: skippedContractNames,
   });
   for (const spec of specs) {
     registerSpec(program, signals, spec, options.authDeps);

--- a/src/core/messages/auth.ts
+++ b/src/core/messages/auth.ts
@@ -99,5 +99,16 @@ export const authMessages = {
         `ID:           ${input.organization.id}`,
         `Source:       ${input.source}`,
       ].join("\n"),
+    userNote: (input: {
+      user: { email: string; id: string };
+      organization: { id: string; name: string };
+      source: string;
+    }) =>
+      [
+        `User:         ${input.user.email}`,
+        `ID:           ${input.user.id}`,
+        `Organization: ${input.organization.name}`,
+        `Source:       ${input.source}`,
+      ].join("\n"),
   },
 } as const;

--- a/src/core/messages/auth.ts
+++ b/src/core/messages/auth.ts
@@ -90,5 +90,14 @@ export const authMessages = {
       ]
         .filter((line): line is string => Boolean(line))
         .join("\n"),
+    organizationNote: (input: {
+      organization: { id: string; name: string };
+      source: string;
+    }) =>
+      [
+        `Organization: ${input.organization.name}`,
+        `ID:           ${input.organization.id}`,
+        `Source:       ${input.source}`,
+      ].join("\n"),
   },
 } as const;

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -29,6 +29,8 @@ export const flowsMessages = {
     aborted: "Aborted; no changes.",
     extractingBundle: "Extracting bundle",
     downloadingTeamStorageAssets: "Downloading team-storage assets",
+    teamStorageRequiresTeamKey:
+      "Team storage requires a team API key; organization keys are not supported here.",
     summary: (result: PullSummaryInput, assetsAbs: string) => {
       const flows = pluralize(result.flowCount, "flow");
       const envVars =

--- a/src/domains/auth/types.ts
+++ b/src/domains/auth/types.ts
@@ -1,5 +1,3 @@
-import type { IdentityResponse } from "~/shell/platform/getIdentity.js";
-
 // "keychain" = OS credential store (macOS Keychain, Windows Credential Manager, etc.)
 // "file"     = fallback JSON file in the config directory
 export type StorageSource = "keychain" | "file";
@@ -16,8 +14,6 @@ export type LoadApiKeyResult =
   | { found: true; key: string; source: StorageSource }
   | { found: false; errors?: { keychain?: string; file?: string } };
 
-type TeamIdentity = IdentityResponse["team"];
-
 export type ValidateApiKeyResult =
-  | { valid: true; team: TeamIdentity }
+  | { valid: true }
   | { valid: false; error: string };

--- a/src/domains/auth/validate.test.ts
+++ b/src/domains/auth/validate.test.ts
@@ -21,18 +21,32 @@ function makeDeps(result: PlatformResult<IdentityResponse>) {
 }
 
 describe("validateApiKey", () => {
-  it("returns valid with team identity on successful verification", async () => {
-    const teamData = {
-      createdAt: "2024-01-15T00:00:00.000Z",
-      id: "team_123",
-      name: "Acme Corp",
-      slug: "acme",
-    };
-    const deps = makeDeps({ ok: true, value: { team: teamData } });
+  it("returns valid on successful team verification", async () => {
+    const deps = makeDeps({
+      ok: true,
+      value: {
+        team: {
+          createdAt: "2024-01-15T00:00:00.000Z",
+          id: "team_123",
+          name: "Acme Corp",
+          slug: "acme",
+        },
+      },
+    });
 
     const result = await validateApiKey(deps);
-    expect(result).toEqual({ valid: true, team: teamData });
+    expect(result).toEqual({ valid: true });
     expect(deps.platformClient.getIdentity).toHaveBeenCalled();
+  });
+
+  it("returns valid on successful organization verification", async () => {
+    const deps = makeDeps({
+      ok: true,
+      value: { organization: { id: "org_1", name: "Acme Org" } },
+    });
+
+    const result = await validateApiKey(deps);
+    expect(result).toEqual({ valid: true });
   });
 
   it("returns invalid when API responds with 401 (already formatted by platform client)", async () => {

--- a/src/domains/auth/validate.ts
+++ b/src/domains/auth/validate.ts
@@ -15,8 +15,5 @@ export async function validateApiKey(
     return { valid: false, error: result.error };
   }
 
-  return {
-    valid: true,
-    team: result.value.team,
-  };
+  return { valid: true };
 }

--- a/src/domains/publicApi/commandSpecs.test.ts
+++ b/src/domains/publicApi/commandSpecs.test.ts
@@ -6,7 +6,9 @@ import { buildCommandSpecs } from "./commandSpecs.js";
 
 describe("buildCommandSpecs", () => {
   it("flattens the published contract tree into command specs", () => {
-    const specs = buildCommandSpecs(publicContractsV1);
+    const specs = buildCommandSpecs(publicContractsV1, {
+      skipContractNames: new Set(["issue.update"]),
+    });
 
     const runCreate = specs.find(
       (spec) => spec.trpcPath === "public.run.create",

--- a/src/shell/platform/createPlatformClient.test.ts
+++ b/src/shell/platform/createPlatformClient.test.ts
@@ -60,8 +60,7 @@ describe("getIdentity", () => {
     const req = calledRequest(f);
     expect(req.url).toBe(`${baseUrl}/api/v0/identity`);
     expect(req.auth).toBe(`Bearer ${apiKey}`);
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.value.team).toEqual(team);
+    expect(result).toEqual({ ok: true, value: { team } });
   });
 
   it("returns ok:false with auth error for HTTP 401", async () => {

--- a/src/shell/platform/createPlatformClient.ts
+++ b/src/shell/platform/createPlatformClient.ts
@@ -1,3 +1,4 @@
+import { flowsMessages } from "~/core/messages/index.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
 import type { Logger } from "~/shell/logger.js";
 import {
@@ -113,8 +114,7 @@ export function createPlatformClient(
       if (!("team" in identity.value)) {
         return {
           ok: false,
-          error:
-            "Team storage requires a team API key; organization keys are not supported here.",
+          error: flowsMessages.pull.teamStorageRequiresTeamKey,
         };
       }
       return listTeamStorageFiles(

--- a/src/shell/platform/createPlatformClient.ts
+++ b/src/shell/platform/createPlatformClient.ts
@@ -110,6 +110,13 @@ export function createPlatformClient(
     async listTeamStorageFiles() {
       const identity = await this.getIdentity();
       if (!identity.ok) return identity;
+      if (!("team" in identity.value)) {
+        return {
+          ok: false,
+          error:
+            "Team storage requires a team API key; organization keys are not supported here.",
+        };
+      }
       return listTeamStorageFiles(
         trpc,
         { teamId: identity.value.team.id },

--- a/src/shell/platform/getIdentity.test.ts
+++ b/src/shell/platform/getIdentity.test.ts
@@ -54,6 +54,16 @@ describe("getIdentity", () => {
     expect(result).toEqual({ ok: true, data: { team } });
   });
 
+  it("returns ok with parsed data for an organization identity", async () => {
+    const organization = { id: "org_1", name: "Acme Org" };
+    const result = await getIdentity("sk_orgkey", {
+      fetch: createFetchMock(jsonResponse({ organization })),
+      baseUrl: "https://test.qawolf.com",
+    });
+
+    expect(result).toEqual({ ok: true, data: { organization } });
+  });
+
   it("returns http WireError with status on auth failure", async () => {
     const result = await getIdentity("qawolf_badkey", {
       fetch: createFetchMock(

--- a/src/shell/platform/getIdentity.ts
+++ b/src/shell/platform/getIdentity.ts
@@ -1,18 +1,10 @@
-import { z } from "zod";
+import { type IdentityResponse, identityResponse } from "@qawolf/api-contracts";
 import { isTimeoutError } from "~/core/errors.js";
 import type { WireResult } from "./createTrpcClient.js";
 import { toError } from "./toError.js";
 
-const identityResponseSchema = z.object({
-  team: z.object({
-    createdAt: z.string(),
-    id: z.string(),
-    name: z.string(),
-    slug: z.string().optional(),
-  }),
-});
-
-export type IdentityResponse = z.infer<typeof identityResponseSchema>;
+export type { IdentityResponse };
+export type TeamIdentity = Extract<IdentityResponse, { team: unknown }>["team"];
 
 type GetIdentityDeps = {
   fetch: typeof globalThis.fetch;
@@ -61,7 +53,7 @@ export async function getIdentity(
     json = undefined;
   }
 
-  const parsed = identityResponseSchema.safeParse(json);
+  const parsed = identityResponse.safeParse(json);
   if (!parsed.success) {
     return { ok: false, error: { kind: "parse", cause: parsed.error } };
   }


### PR DESCRIPTION
## Overview of Problem

`@qawolf/cli` hand-rolled the `/api/v0/identity` schema (drift risk), and `auth whoami` reflected neither organization nor user API keys.

## Overview of Changes

Bump `@qawolf/api-contracts` to `0.17.0` and consume its shared `identityResponse`; `auth whoami` now reports a team, organization, or user identity.

- **Identity schema** — `getIdentity` imports the shared `identityResponse` (`team | organization + user | organization`) instead of a hand-rolled schema, so the CLI can't drift from the contract.
- **whoami** — new user branch surfaces the user (email + organization) for a user API key; the org and team branches are unchanged.
- **Org/user-variant guards** — `flowRuntimeDeps`, `listTeamStorageFiles`, and `validateApiKey` handle non-team identities; the team-storage error string moved to `flowsMessages`.
- **`issue.update`** — skipped in command generation: `0.17.0` added it, and its union input isn't expressible as CLI flags.

## Todo

- [x] Blocked on publishing `@qawolf/api-contracts@0.17.0` to **public npm** — it's on GitHub Packages, but public npm is still at `0.15.0`, so CI is red until the publish. Afterward, `bun install` finalizes the lockfile.
