### PR TITLE
test(cli): make the test suite win32-clean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The windows-latest runner checks out with core.autocrlf=true. Tests compare
+# committed text to values carrying "\n" (SKILL.md frontmatter, help snapshots),
+# so a CRLF working tree would fail them.
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,6 @@ jobs:
   # win32 spawn regression. WIZ-11274 (`spawn npm ENOENT`) shipped through that
   # gap. `test/spawn/smoke.mjs` explains the mechanism.
   #
-  # TODO WIZ-11279: add `bun run test` here. Around 30 test files assert POSIX
-  # separators or file modes, so the suite fails on win32 today.
-  #
   # Every multi-line step sets `shell: bash`. The windows-latest default is
   # pwsh, which reports only the last command's exit code, so an earlier
   # failure would pass silently.
@@ -125,6 +122,7 @@ jobs:
         with:
           bun-version-file: package.json
       - run: bun install --frozen-lockfile
+      - run: bun run test
       # build:bundle skips the postbuild hook, which shells out to bash to
       # prepend a shebang and chmod dist/cli.js. Windows needs neither to run
       # `node dist/cli.js`.

--- a/src/commands/resolveDepsRoot.test.ts
+++ b/src/commands/resolveDepsRoot.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { join } from "node:path";
+import { join, normalize } from "node:path";
 
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
 import { pinnedPackages } from "~/domains/runtimeEnv/pinnedPackages.js";
@@ -41,7 +41,9 @@ describe("resolveDepsRoot", () => {
     });
 
     expect(result).toEqual({
-      depsRoot: projectDir,
+      // resolveDepsRoot walks up the flow path with node:path, so on win32 it
+      // returns the drive-relative spelling of this POSIX fixture path.
+      depsRoot: normalize(projectDir),
       source: "project",
       installed: false,
     });

--- a/src/domains/config/loadConfig.test.ts
+++ b/src/domains/config/loadConfig.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
 
 import { loadConfig, type LoadConfigDeps } from "./loadConfig.js";
 
 const cwd = "/fake/cwd";
-const configPath = "/fake/cwd/qawolf.config.ts";
+// Match how loadConfig derives the path: on win32 resolve() adds a drive letter
+// and backslashes, so a POSIX literal here would never equal the incoming path.
+const configPath = resolve(cwd, "qawolf.config.ts");
 
 function withConfig(value: unknown): LoadConfigDeps {
   return {

--- a/src/domains/doctor/checks/android.test.ts
+++ b/src/domains/doctor/checks/android.test.ts
@@ -1,19 +1,23 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 import type { SpawnFn } from "~/shell/spawn.js";
 
 import { checkAndroid } from "./android.js";
 import {
-  adbPath,
+  adbPath as adbPosixPath,
   baseDeps,
-  emulatorPath,
+  emulatorPath as emulatorPosixPath,
   envDir,
   findResult,
   sdk,
   spawnRouter,
   success,
 } from "./android.fixtures.js";
+
+// checkAndroid joins these with node:path, so match the OS separator on win32.
+const adbPath = adbPosixPath.replaceAll("/", sep);
+const emulatorPath = emulatorPosixPath.replaceAll("/", sep);
 
 afterEach(() => {
   mock.restore();

--- a/src/domains/doctor/checks/fileAssets.test.ts
+++ b/src/domains/doctor/checks/fileAssets.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
 
 import {
@@ -108,7 +109,7 @@ describe("checkFileAssets", () => {
     const [result] = results;
     expect(result?.name).toBe("file-assets");
     expect(result?.status).toBe("warn");
-    expect(result?.detail).toContain("flows/upload.flow.ts");
+    expect(result?.detail).toContain(join("flows", "upload.flow.ts"));
     expect(result?.detail).toContain("QAWOLF_SCREENSHOTS_DIR");
     expect(result?.detail).toContain("QAWOLF_DOWNLOADS_DIR");
     expect(result?.detail).toContain(fileAssetsWarnReasons["file-asset"]);
@@ -162,7 +163,7 @@ describe("checkFileAssets", () => {
       }),
       cwd: "/repo",
     });
-    expect(result?.detail).toMatch(/^flows\/login\.flow\.ts /);
+    expect(result?.detail).toMatch(/^flows[\\/]login\.flow\.ts /);
   });
 
   it("falls back to the absolute path when cwd is the same as the file", async () => {
@@ -189,7 +190,7 @@ describe("checkFileAssets", () => {
     });
     expect(results).toHaveLength(1);
     expect(results[0]?.status).toBe("warn");
-    expect(results[0]?.detail).toContain("flows/locked.flow.ts");
+    expect(results[0]?.detail).toContain(join("flows", "locked.flow.ts"));
     expect(results[0]?.detail).toContain("could not be read");
     expect(results[0]?.detail).toContain("EACCES");
   });

--- a/src/domains/flows/ensureDeps.test.ts
+++ b/src/domains/flows/ensureDeps.test.ts
@@ -6,7 +6,7 @@ import { makeDefaultFs } from "~/shell/fs.js";
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
 
 import { findEnvDir, resolveUniqueEnvDir } from "./ensureDeps.js";
-import { makeTmpDirTracker } from "~/domains/runtimeEnv/runDirFixtures.testUtils.js";
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 
 const defaultFs = makeDefaultFs();
 

--- a/src/domains/flows/ensureDeps.test.ts
+++ b/src/domains/flows/ensureDeps.test.ts
@@ -1,43 +1,29 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { realpathSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { makeDefaultFs } from "~/shell/fs.js";
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
 
 import { findEnvDir, resolveUniqueEnvDir } from "./ensureDeps.js";
+import { makeTmpDirTracker } from "~/domains/runtimeEnv/runDirFixtures.testUtils.js";
 
 const defaultFs = makeDefaultFs();
 
-const tmpDirs: string[] = [];
+const tracker = makeTmpDirTracker("qawolf-ensuredeps-test-");
 
-afterEach(async () => {
-  await Promise.all(
-    tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
-  );
-  tmpDirs.length = 0;
-});
-
-async function makeTmpDir(): Promise<string> {
-  const d = realpathSync(
-    await mkdtemp(join(tmpdir(), "qawolf-ensuredeps-test-")),
-  );
-  tmpDirs.push(d);
-  return d;
-}
+afterEach(() => tracker.cleanup());
 
 describe("findEnvDir", () => {
   it("should return the directory containing package.json for a direct file", async () => {
-    const root = await makeTmpDir();
+    const root = await tracker.makeTmpDir();
     await writeFile(join(root, "package.json"), "{}");
     const flowPath = join(root, "my.flow.ts");
     expect(findEnvDir(flowPath, defaultFs)).toBe(root);
   });
 
   it("should walk up to find package.json when flow is nested", async () => {
-    const root = await makeTmpDir();
+    const root = await tracker.makeTmpDir();
     await writeFile(join(root, "package.json"), "{}");
     const nested = join(root, "flows", "sub");
     await mkdir(nested, { recursive: true });
@@ -46,7 +32,7 @@ describe("findEnvDir", () => {
   });
 
   it("should return undefined when no package.json exists in any ancestor", async () => {
-    const root = await makeTmpDir();
+    const root = await tracker.makeTmpDir();
     const nested = join(root, "flows");
     await mkdir(nested, { recursive: true });
     const flowPath = join(nested, "my.flow.ts");
@@ -67,7 +53,7 @@ describe("findEnvDir with injected fs", () => {
 
 describe("resolveUniqueEnvDir", () => {
   it("should return the envDir when all files resolve to the same package", async () => {
-    const root = await makeTmpDir();
+    const root = await tracker.makeTmpDir();
     await writeFile(join(root, "package.json"), "{}");
     const nested = join(root, "flows");
     await mkdir(nested, { recursive: true });
@@ -76,7 +62,7 @@ describe("resolveUniqueEnvDir", () => {
   });
 
   it("should return undefined when no files have a package.json ancestor", async () => {
-    const root = await makeTmpDir();
+    const root = await tracker.makeTmpDir();
     const nested = join(root, "flows");
     await mkdir(nested, { recursive: true });
     const files = [join(nested, "a.flow.ts")];
@@ -88,8 +74,8 @@ describe("resolveUniqueEnvDir", () => {
   });
 
   it("should throw when files span multiple packages", async () => {
-    const rootA = await makeTmpDir();
-    const rootB = await makeTmpDir();
+    const rootA = await tracker.makeTmpDir();
+    const rootB = await tracker.makeTmpDir();
     await writeFile(join(rootA, "package.json"), "{}");
     await writeFile(join(rootB, "package.json"), "{}");
     let caughtError: unknown;

--- a/src/domains/flows/expand.test.ts
+++ b/src/domains/flows/expand.test.ts
@@ -144,6 +144,10 @@ describe("peekFlowMeta", () => {
 });
 
 describe("expandPatterns", () => {
+  // tinyglobby returns forward-slash absolute paths even on win32, where join
+  // uses backslashes; compare on a normalized separator.
+  const toPosix = (p: string) => p.replaceAll("\\", "/");
+
   let mainTmpDir: string;
   let noQawolfTmpDir: string;
   let multiEnvTmpDir: string;
@@ -193,17 +197,22 @@ describe("expandPatterns", () => {
       undefined,
       defaultFs,
     );
-    expect(result).toContain(join(noQawolfTmpDir, "a.flow.ts"));
-    expect(result).toContain(join(noQawolfTmpDir, "sub", "b.flow.ts"));
+    expect(result.map(toPosix)).toContain(
+      toPosix(join(noQawolfTmpDir, "a.flow.ts")),
+    );
+    expect(result.map(toPosix)).toContain(
+      toPosix(join(noQawolfTmpDir, "sub", "b.flow.ts")),
+    );
   });
 
   it("should return files from the .qawolf env dir alongside cwd flows when no patterns provided", async () => {
     const result = await expandPatterns([], mainTmpDir, undefined, defaultFs);
-    expect(result).toContain(
-      join(mainTmpDir, ".qawolf", "staging", "c.flow.ts"),
+    const files = result.map(toPosix);
+    expect(files).toContain(
+      toPosix(join(mainTmpDir, ".qawolf", "staging", "c.flow.ts")),
     );
-    expect(result).toContain(join(mainTmpDir, "a.flow.ts"));
-    expect(result).toContain(join(mainTmpDir, "sub", "b.flow.ts"));
+    expect(files).toContain(toPosix(join(mainTmpDir, "a.flow.ts")));
+    expect(files).toContain(toPosix(join(mainTmpDir, "sub", "b.flow.ts")));
   });
 
   it("should resolve a pattern relative to each env dir root", async () => {
@@ -213,10 +222,11 @@ describe("expandPatterns", () => {
       undefined,
       defaultFs,
     );
-    expect(result).toContain(
-      join(mainTmpDir, ".qawolf", "staging", "c.flow.ts"),
+    const files = result.map(toPosix);
+    expect(files).toContain(
+      toPosix(join(mainTmpDir, ".qawolf", "staging", "c.flow.ts")),
     );
-    expect(result).toContain(join(mainTmpDir, "a.flow.ts"));
+    expect(files).toContain(toPosix(join(mainTmpDir, "a.flow.ts")));
   });
 
   it("should return empty array when no files match", async () => {
@@ -236,13 +246,14 @@ describe("expandPatterns", () => {
       undefined,
       defaultFs,
     );
-    expect(result).toContain(
-      join(multiEnvTmpDir, ".qawolf", "staging", "s.flow.ts"),
+    const files = result.map(toPosix);
+    expect(files).toContain(
+      toPosix(join(multiEnvTmpDir, ".qawolf", "staging", "s.flow.ts")),
     );
-    expect(result).toContain(
-      join(multiEnvTmpDir, ".qawolf", "prod", "p.flow.ts"),
+    expect(files).toContain(
+      toPosix(join(multiEnvTmpDir, ".qawolf", "prod", "p.flow.ts")),
     );
-    expect(result).toContain(join(multiEnvTmpDir, "a.flow.ts"));
+    expect(files).toContain(toPosix(join(multiEnvTmpDir, "a.flow.ts")));
   });
 
   it("should discover .flow.js files alongside .flow.ts with the default pattern", async () => {
@@ -251,8 +262,9 @@ describe("expandPatterns", () => {
     await writeFile(join(tmp, "b.flow.js"), "// b");
     try {
       const result = await expandPatterns([], tmp, undefined, defaultFs);
-      expect(result).toContain(join(tmp, "a.flow.ts"));
-      expect(result).toContain(join(tmp, "b.flow.js"));
+      const files = result.map(toPosix);
+      expect(files).toContain(toPosix(join(tmp, "a.flow.ts")));
+      expect(files).toContain(toPosix(join(tmp, "b.flow.js")));
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/src/domains/flows/list.agent.test.ts
+++ b/src/domains/flows/list.agent.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 import type { CommandContext } from "~/shell/commandContext.js";
@@ -68,7 +69,7 @@ describe("flowsList agent mode", () => {
       .join("");
     expect(output).toContain("Login");
     expect(output).toContain("Web - Chrome");
-    expect(output).toContain("src/flows/login.flow.ts");
+    expect(output).toContain(join("src", "flows", "login.flow.ts"));
     expect(ui.intro).not.toHaveBeenCalled();
     expect(ui.outro).not.toHaveBeenCalled();
     expect(ui.json).not.toHaveBeenCalled();

--- a/src/domains/flows/list.json.test.ts
+++ b/src/domains/flows/list.json.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
 import type { CommandContext } from "~/shell/commandContext.js";
@@ -69,7 +70,7 @@ describe("flowsList json mode output", () => {
 
     expect(ui.json).toHaveBeenCalledWith([
       {
-        file: "src/flows/login.flow.ts",
+        file: join("src", "flows", "login.flow.ts"),
         name: "Login",
         tags: [],
         target: "Web - Chrome",
@@ -97,7 +98,7 @@ describe("flowsList json mode output", () => {
 
     expect(ui.json).toHaveBeenCalledWith([
       {
-        file: "src/flows/checkout.flow.ts",
+        file: join("src", "flows", "checkout.flow.ts"),
         name: "checkout",
         tags: [],
         target: "Web - Firefox",
@@ -119,7 +120,7 @@ describe("flowsList json mode output", () => {
 
     expect(ui.json).toHaveBeenCalledWith([
       {
-        file: "src/flows/legacy.flow.js",
+        file: join("src", "flows", "legacy.flow.js"),
         name: "legacy",
         tags: [],
         target: "Web - Chrome",
@@ -144,7 +145,7 @@ describe("flowsList json mode output", () => {
 
     expect(ui.json).toHaveBeenCalledWith([
       {
-        file: "src/flows/mobile.flow.ts",
+        file: join("src", "flows", "mobile.flow.ts"),
         name: "Mobile",
         tags: [],
         target: "Android - Pixel",

--- a/src/domains/flows/list.test.ts
+++ b/src/domains/flows/list.test.ts
@@ -136,10 +136,10 @@ describe("flowsList human mode table", () => {
       /^name\s+target\s+file$/,
     );
     expect(stripAnsi(lines[1])).toMatch(
-      /^Login\s+Web - Chrome\s+src\/flows\/login\.flow\.ts$/,
+      /^Login\s+Web - Chrome\s+src[\\/]flows[\\/]login\.flow\.ts$/,
     );
     expect(stripAnsi(lines[2])).toMatch(
-      /^Checkout\s+Web - Firefox\s+src\/flows\/sub\/checkout\.flow\.ts$/,
+      /^Checkout\s+Web - Firefox\s+src[\\/]flows[\\/]sub[\\/]checkout\.flow\.ts$/,
     );
     expect(ui.intro).toHaveBeenCalledWith("Flows");
     expect(ui.outro).toHaveBeenCalledWith("2 flows");
@@ -163,7 +163,7 @@ describe("flowsList human mode table", () => {
     const lines = output.split("\n").filter((l) => l.length > 0);
 
     expect(stripAnsi(lines[1])).toMatch(
-      /^Untargeted\s+src\/flows\/untargeted\.flow\.ts$/,
+      /^Untargeted\s+src[\\/]flows[\\/]untargeted\.flow\.ts$/,
     );
   });
 });

--- a/src/domains/flows/pull/bundle.test.ts
+++ b/src/domains/flows/pull/bundle.test.ts
@@ -139,7 +139,7 @@ describe("buildManifest", () => {
 
     expect(manifest.flows.map((f) => f.path).sort()).toEqual([
       "a.flow.ts",
-      "nested/b.flow.js",
+      join("nested", "b.flow.js"),
     ]);
     expect(manifest.flows[0]?.contentHash).toMatch(/^[a-f0-9]{64}$/);
   });

--- a/src/domains/flows/pull/envVars.test.ts
+++ b/src/domains/flows/pull/envVars.test.ts
@@ -18,14 +18,23 @@ afterEach(async () => {
 });
 
 describe("writeEnvFile", () => {
-  it("writes the file at <dir>/.env with mode 0600", async () => {
+  it("writes the file at <dir>/.env", async () => {
     await writeEnvFile(workDir, { TOKEN: "abc", URL: "https://example.com" });
 
     const body = await readFile(join(workDir, ".env"), "utf8");
     expect(body).toBe('TOKEN="abc"\nURL="https://example.com"\n');
-    const stats = await stat(join(workDir, ".env"));
-    expect(stats.mode & 0o777).toBe(0o600);
   });
+
+  // Windows has no POSIX mode bits — it reports 0o666/0o444 whatever mode we pass.
+  it.skipIf(process.platform === "win32")(
+    "writes .env with mode 0600",
+    async () => {
+      await writeEnvFile(workDir, { TOKEN: "abc" });
+
+      const stats = await stat(join(workDir, ".env"));
+      expect(stats.mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("skips writing .env when no vars are present", async () => {
     await writeEnvFile(workDir, {});

--- a/src/domains/flows/pull/extract.test.ts
+++ b/src/domains/flows/pull/extract.test.ts
@@ -5,7 +5,6 @@ import {
   readFile,
   readdir,
   rm,
-  symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -31,9 +30,7 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
-type StagedEntry =
-  | { kind: "file"; name: string; data: Buffer | string }
-  | { kind: "symlink"; name: string; target: string };
+type StagedEntry = { kind: "file"; name: string; data: Buffer | string };
 
 async function buildArchive(
   archivePathArg: string,
@@ -44,11 +41,7 @@ async function buildArchive(
     for (const e of entries) {
       const target = join(stage, e.name);
       await mkdir(join(target, ".."), { recursive: true });
-      if (e.kind === "file") {
-        await writeFile(target, e.data);
-      } else {
-        await symlink(e.target, target);
-      }
+      await writeFile(target, e.data);
     }
     await tar.c(
       { gzip: true, file: archivePathArg, cwd: stage },
@@ -59,11 +52,13 @@ async function buildArchive(
   }
 }
 
-// Minimal raw-tar+gzip writer for fixtures we can't build with tar.c
-// (paths with `..`, absolute names — tar.c rejects/strips them).
+// Minimal raw-tar+gzip writer for fixtures we can't build with tar.c (paths
+// with `..`, absolute names — tar.c rejects/strips them) or from a staging dir
+// (a symlink entry, which win32 refuses to create without Developer Mode).
 async function writeRawTarGzWithName(
   archivePathArg: string,
   name: string,
+  linkTarget?: string,
 ): Promise<void> {
   // 512-byte tar header per POSIX ustar format.
   const header = Buffer.alloc(512);
@@ -75,7 +70,11 @@ async function writeRawTarGzWithName(
   Buffer.from("00000000000\0", "utf8").copy(header, 136); // mtime
   // checksum field 148-155: filled with spaces during checksum computation
   header.fill(0x20, 148, 156);
-  Buffer.from("0", "utf8").copy(header, 156); // typeflag = '0' (regular file)
+  // typeflag: '0' regular file, '2' symlink
+  Buffer.from(linkTarget === undefined ? "0" : "2", "utf8").copy(header, 156);
+  if (linkTarget !== undefined) {
+    Buffer.from(linkTarget, "utf8").copy(header, 157); // linkname (100 bytes)
+  }
   // ustar magic ("ustar\0") + version ("00")
   Buffer.from("ustar\x0000", "binary").copy(header, 257);
 
@@ -185,12 +184,10 @@ describe("extractTarGz safety guards", () => {
   });
 
   it("rejects symlink entries", async () => {
-    await buildArchive(archivePath, [
-      { kind: "file", name: "a.txt", data: "ok" },
-      { kind: "symlink", name: "link", target: "/etc/passwd" },
-    ]);
+    // Name carries no "link" substring, so the match can only come from the guard.
+    await writeRawTarGzWithName(archivePath, "notes.txt", "/etc/passwd");
 
-    await expectRejects(extractTarGz(archivePath, destDir), /symlink|link/i);
+    await expectRejects(extractTarGz(archivePath, destDir), /symlink/i);
   });
 
   it("creates intermediate directories for nested file entries", async () => {

--- a/src/domains/flows/pull/handler.test.ts
+++ b/src/domains/flows/pull/handler.test.ts
@@ -116,7 +116,7 @@ describe("handleFlowsPull json mode output", () => {
       "manifestPath",
     ]);
     expect(payload).toEqual({
-      assetsDir: expect.stringContaining("/assets"),
+      assetsDir: expect.stringContaining(join(workDir, "assets")),
       assetDownloadedCount: 0,
       assetReusedCount: 0,
       assetSkippedCount: 0,

--- a/src/domains/flows/pull/stage.test.ts
+++ b/src/domains/flows/pull/stage.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
+import { parseDotenv } from "~/core/dotenv.js";
 import { makeDefaultFs } from "~/shell/fs.js";
 import { readManifest } from "~/shell/manifest/io.js";
 import { buildBundle } from "./pull.fixtures.js";
@@ -58,7 +59,7 @@ describe("stageBundle", () => {
     }
     expect(manifest.flows.map((f) => f.path).sort()).toEqual([
       "checkout.flow.ts",
-      "nested/login.flow.ts",
+      join("nested", "login.flow.ts"),
     ]);
   });
 
@@ -133,9 +134,13 @@ describe("stageBundle", () => {
     });
 
     expect(result.envVarCount).toBe(3);
-    expect(await readFile(join(destDir, ".env"), "utf8")).toBe(
-      `BASE_URL="https://example.com"\nTEAM_STORAGE_DIR="${assetsAbs}"\nTOKEN="abc"\n`,
-    );
+    // Assert the parsed values, not the bytes: serializeDotenv escapes the
+    // backslashes in a win32 path, and dotenv.test.ts already pins that format.
+    expect(parseDotenv(await readFile(join(destDir, ".env"), "utf8"))).toEqual({
+      BASE_URL: "https://example.com",
+      TEAM_STORAGE_DIR: assetsAbs,
+      TOKEN: "abc",
+    });
     // Windows has no POSIX mode bits — it reports 0o666/0o444 whatever mode we pass.
     if (process.platform !== "win32") {
       const stats = await stat(join(destDir, ".env"));
@@ -196,10 +201,7 @@ describe("stageBundle", () => {
       "const p = `${process.env.TEAM_STORAGE_DIR}/${name}.fig`;\n",
     );
     // The written .env overrides the API's TEAM_STORAGE_DIR with assetsAbs.
-    const envContents = await readFile(join(destDir, ".env"), "utf8");
-    expect(envContents).toContain(`TEAM_STORAGE_DIR="${assetsDir}"`);
-    expect(envContents).not.toContain(
-      `TEAM_STORAGE_DIR="/home/wolf/team-storage"`,
-    );
+    const env = parseDotenv(await readFile(join(destDir, ".env"), "utf8"));
+    expect(env["TEAM_STORAGE_DIR"]).toBe(assetsDir);
   });
 });

--- a/src/domains/flows/pull/stage.test.ts
+++ b/src/domains/flows/pull/stage.test.ts
@@ -136,8 +136,11 @@ describe("stageBundle", () => {
     expect(await readFile(join(destDir, ".env"), "utf8")).toBe(
       `BASE_URL="https://example.com"\nTEAM_STORAGE_DIR="${assetsAbs}"\nTOKEN="abc"\n`,
     );
-    const stats = await stat(join(destDir, ".env"));
-    expect(stats.mode & 0o777).toBe(0o600);
+    // Windows has no POSIX mode bits — it reports 0o666/0o444 whatever mode we pass.
+    if (process.platform !== "win32") {
+      const stats = await stat(join(destDir, ".env"));
+      expect(stats.mode & 0o777).toBe(0o600);
+    }
 
     const manifest = await readManifest(destDir);
     if (manifest === "missing" || manifest === "malformed") {

--- a/src/domains/install/android/installAndroid.test.ts
+++ b/src/domains/install/android/installAndroid.test.ts
@@ -134,9 +134,7 @@ describe("installAndroid", () => {
       caught = e;
     }
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toContain(
-      "cmdline-tools/latest/bin/sdkmanager",
-    );
+    expect((caught as Error).message).toContain(sdkManagerPath);
     expect((caught as Error).message).toContain(
       "https://developer.android.com",
     );

--- a/src/domains/runner/createLaunch.contexts.test.ts
+++ b/src/domains/runner/createLaunch.contexts.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { createLaunch } from "./createLaunch.js";
 import type { ContextSetupOptions } from "./web/types.js";
@@ -84,7 +85,7 @@ describe("createLaunch flow-created contexts", () => {
     await result.browser.newContext({});
 
     expect(harPaths[0]).toBe("/out/har/flow.har");
-    expect(harPaths[1]).toBe("/out/har/flow-2.har");
+    expect(harPaths[1]).toBe(join("/out/har", "flow-2.har"));
   });
 
   it("should track flow-created contexts for tracing and teardown", async () => {
@@ -162,7 +163,10 @@ describe("createLaunch flow-created contexts", () => {
     await cleanup();
 
     // Contexts stop in creation order: launch()'s context first.
-    expect(stopPaths).toEqual(["/out/trace/flow.zip", "/out/trace/flow-2.zip"]);
+    expect(stopPaths).toEqual([
+      "/out/trace/flow.zip",
+      join("/out/trace", "flow-2.zip"),
+    ]);
   });
 
   it("should track a caller-provided recordHar path instead of the generated one", async () => {
@@ -227,8 +231,8 @@ describe("createLaunch flow-created contexts", () => {
     await result.browser.newContext({});
 
     expect(artifactPaths()).toEqual({
-      harPaths: ["/out/har/flow.har", "/out/har/flow-2.har"],
-      tracePaths: ["/out/trace/flow.zip", "/out/trace/flow-2.zip"],
+      harPaths: ["/out/har/flow.har", join("/out/har", "flow-2.har")],
+      tracePaths: ["/out/trace/flow.zip", join("/out/trace", "flow-2.zip")],
     });
   });
 });

--- a/src/domains/runner/loadFlowDefault.test.ts
+++ b/src/domains/runner/loadFlowDefault.test.ts
@@ -157,8 +157,10 @@ export default { page, helper };
         "dist",
         "web.js",
       );
-      // @qawolf/flows content is kept external at the absolute on-disk path
-      expect(bundle).toContain(`from "${expectedFlowsPath}"`);
+      // @qawolf/flows content is kept external at the absolute on-disk path.
+      // JSON.stringify matches the bundler's escaped import literal (win32
+      // backslashes are emitted doubled).
+      expect(bundle).toContain(`from ${JSON.stringify(expectedFlowsPath)}`);
       expect(bundle).not.toContain("FLOWS_WEB_MARKER");
       // Non-executor dep is inlined into the bundle
       expect(bundle).toContain("INLINE_DEP_MARKER");

--- a/src/domains/runner/runWebFlow.har.test.ts
+++ b/src/domains/runner/runWebFlow.har.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import type { ContextSetupOptions } from "./web/types.js";
 import {
@@ -56,7 +57,9 @@ describe("runWebFlow HAR", () => {
 
     type Arg = { recordHar?: { path: string; mode: string; content: string } };
     const arg = newContextMock.mock.calls[0]![0] as Arg;
-    expect(arg.recordHar?.path).toContain("/har/launch.har");
+    expect(arg.recordHar?.path).toBe(
+      join("/tmp/test-har", "har", "launch.har"),
+    );
     expect(arg.recordHar?.mode).toBe("minimal");
     expect(arg.recordHar?.content).toBe("omit");
   });
@@ -85,7 +88,9 @@ describe("runWebFlow HAR", () => {
       flowPath: fixturePath("launch"),
     });
 
-    expect(unlinkMock.mock.calls[0]![0]).toContain("/har/");
+    expect(unlinkMock.mock.calls[0]![0]).toBe(
+      join("/tmp/test-har", "har", "launch.har"),
+    );
   });
 
   it("should delete every per-context HAR file on success when har is retain-on-failure", async () => {
@@ -111,8 +116,10 @@ describe("runWebFlow HAR", () => {
     });
 
     const unlinked = unlinkMock.mock.calls.map((c) => c[0]);
-    expect(unlinked).toContain("/tmp/test-har/har/ownContext.har");
-    expect(unlinked).toContain("/tmp/test-har/har/ownContext-2.har");
+    expect(unlinked).toContain(join("/tmp/test-har", "har", "ownContext.har"));
+    expect(unlinked).toContain(
+      join("/tmp/test-har", "har", "ownContext-2.har"),
+    );
   });
 
   it("should not delete the HAR file on failure when har is retain-on-failure", async () => {

--- a/src/domains/runner/runWebFlow.trace.test.ts
+++ b/src/domains/runner/runWebFlow.trace.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import {
   makeBrowser,
@@ -48,7 +49,7 @@ describe("runWebFlow trace", () => {
 
     expect(startMock).toHaveBeenCalledTimes(1);
     const stopArg = stopMock.mock.calls[0]![0];
-    expect(stopArg.path).toContain("/trace/launch.zip");
+    expect(stopArg.path).toBe(join("/tmp/test-trace", "trace", "launch.zip"));
   });
 
   it("should delete the trace file on success when trace is retain-on-failure", async () => {
@@ -74,7 +75,9 @@ describe("runWebFlow trace", () => {
       flowPath: fixturePath("launch"),
     });
 
-    expect(unlinkMock.mock.calls[0]![0]).toContain("/trace/");
+    expect(unlinkMock.mock.calls[0]![0]).toBe(
+      join("/tmp/test-trace", "trace", "launch.zip"),
+    );
   });
 
   it("should not delete the trace file on failure when trace is retain-on-failure", async () => {

--- a/src/domains/runner/runnerDeps.test.ts
+++ b/src/domains/runner/runnerDeps.test.ts
@@ -3,10 +3,14 @@ import { createRunnerDeps } from "./runnerDeps.js";
 import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
 
 describe("createRunnerDeps", () => {
-  it("resolves exitCode to -1 when the binary is missing instead of crashing on an unhandled error event", async () => {
+  it("resolves exitCode to a failure when the binary is missing instead of crashing on an unhandled error event", async () => {
     const deps = createRunnerDeps(makeNoopSignals(), "/tmp/deps");
     const { exitCode } = deps.spawn("__qawolf_nonexistent_binary_xyzzy__", []);
-    expect(await exitCode).toBe(-1);
+    // POSIX surfaces the missing binary as an ENOENT error event (-1); win32
+    // reports it as a cmd.exe exit code (1 or 9009). Pin "failed", not the code.
+    const code = await exitCode;
+    expect(typeof code).toBe("number");
+    expect(code).not.toBe(0);
   });
 
   it("resolves exitCode with the child's exit code on a normal close", async () => {

--- a/src/domains/runner/web/contextSetup.test.ts
+++ b/src/domains/runner/web/contextSetup.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import {
   buildContextSetup,
@@ -13,7 +14,9 @@ afterEach(() => {
 
 describe("harFlowPath", () => {
   it("should return <outputDir>/har/<flowName>.har", () => {
-    expect(harFlowPath("/out", "my-flow")).toBe("/out/har/my-flow.har");
+    expect(harFlowPath("/out", "my-flow")).toBe(
+      join("/out", "har", "my-flow.har"),
+    );
   });
 });
 
@@ -121,8 +124,10 @@ describe("initHar", () => {
       "my-flow",
     );
     expect(result.harMode).toBe("on");
-    expect(result.harPath).toBe("/out/har/my-flow.har");
-    expect(mkdirMock).toHaveBeenCalledWith("/out/har", { recursive: true });
+    expect(result.harPath).toBe(join("/out", "har", "my-flow.har"));
+    expect(mkdirMock).toHaveBeenCalledWith(join("/out", "har"), {
+      recursive: true,
+    });
   });
 
   it("should return harMode and harPath and call mkdir when har is retain-on-failure", async () => {
@@ -134,8 +139,10 @@ describe("initHar", () => {
       "my-flow",
     );
     expect(result.harMode).toBe("retain-on-failure");
-    expect(result.harPath).toBe("/out/har/my-flow.har");
-    expect(mkdirMock).toHaveBeenCalledWith("/out/har", { recursive: true });
+    expect(result.harPath).toBe(join("/out", "har", "my-flow.har"));
+    expect(mkdirMock).toHaveBeenCalledWith(join("/out", "har"), {
+      recursive: true,
+    });
   });
 });
 
@@ -162,7 +169,7 @@ describe("buildContextSetup", () => {
       viewport: { width: 1280, height: 720 },
       screen: { width: 1280, height: 720 },
       recordVideo: {
-        dir: "/out/videos",
+        dir: join("/out", "videos"),
         size: { width: 1280, height: 720 },
       },
     });
@@ -195,7 +202,7 @@ describe("buildContextSetup", () => {
       viewport: { width: 1280, height: 720 },
       screen: { width: 1280, height: 720 },
       recordVideo: {
-        dir: "/out/videos",
+        dir: join("/out", "videos"),
         size: { width: 1280, height: 720 },
       },
       recordHar: {

--- a/src/domains/runner/web/contextSetup.trace.test.ts
+++ b/src/domains/runner/web/contextSetup.trace.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { initTrace, maybeCleanupTrace, traceFlowPath } from "./contextSetup.js";
 
@@ -7,7 +8,9 @@ afterEach(() => {
 
 describe("traceFlowPath", () => {
   it("should return <outputDir>/trace/<flowName>.zip", () => {
-    expect(traceFlowPath("/out", "my-flow")).toBe("/out/trace/my-flow.zip");
+    expect(traceFlowPath("/out", "my-flow")).toBe(
+      join("/out", "trace", "my-flow.zip"),
+    );
   });
 });
 
@@ -30,8 +33,10 @@ describe("initTrace", () => {
       "my-flow",
     );
     expect(result.traceMode).toBe("on");
-    expect(result.tracePath).toBe("/out/trace/my-flow.zip");
-    expect(mkdirMock).toHaveBeenCalledWith("/out/trace", { recursive: true });
+    expect(result.tracePath).toBe(join("/out", "trace", "my-flow.zip"));
+    expect(mkdirMock).toHaveBeenCalledWith(join("/out", "trace"), {
+      recursive: true,
+    });
   });
 
   it("should return traceMode and tracePath and call mkdir when trace is retain-on-failure", async () => {
@@ -43,8 +48,10 @@ describe("initTrace", () => {
       "my-flow",
     );
     expect(result.traceMode).toBe("retain-on-failure");
-    expect(result.tracePath).toBe("/out/trace/my-flow.zip");
-    expect(mkdirMock).toHaveBeenCalledWith("/out/trace", { recursive: true });
+    expect(result.tracePath).toBe(join("/out", "trace", "my-flow.zip"));
+    expect(mkdirMock).toHaveBeenCalledWith(join("/out", "trace"), {
+      recursive: true,
+    });
   });
 });
 

--- a/src/domains/runtimeEnv/execSubpathImports.test.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { type Fs, makeDefaultFs } from "~/shell/fs.js";
 
 import { writeExecSubpathImports } from "./execSubpathImports.js";
-import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 
 const tracker = makeTmpDirTracker("qawolf-subpath-imports-test-");
 

--- a/src/domains/runtimeEnv/execSubpathImports.test.ts
+++ b/src/domains/runtimeEnv/execSubpathImports.test.ts
@@ -1,28 +1,18 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { realpathSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { type Fs, makeDefaultFs } from "~/shell/fs.js";
 
 import { writeExecSubpathImports } from "./execSubpathImports.js";
+import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
 
-const tmpDirs: string[] = [];
+const tracker = makeTmpDirTracker("qawolf-subpath-imports-test-");
 
-afterEach(async () => {
-  await Promise.all(
-    tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
-  );
-  tmpDirs.length = 0;
-});
+afterEach(() => tracker.cleanup());
 
-async function makeExecDir(): Promise<string> {
-  const d = realpathSync(
-    await mkdtemp(join(tmpdir(), "qawolf-subpath-imports-test-")),
-  );
-  tmpDirs.push(d);
-  return d;
+function makeExecDir(): Promise<string> {
+  return tracker.makeTmpDir();
 }
 
 type PackageJson = {

--- a/src/domains/runtimeEnv/innerHop.test.ts
+++ b/src/domains/runtimeEnv/innerHop.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { realpathSync } from "node:fs";
-import { lstat, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { lstat, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { makeDefaultFs } from "~/shell/fs.js";
@@ -12,31 +10,17 @@ import { pinnedPackages } from "./pinnedPackages.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { createDirSymlink } from "./symlinkDir.js";
 import { expectLinkTarget } from "./symlinkDir.testUtils.js";
+import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
 
-const tmpDirs: string[] = [];
+const tracker = makeTmpDirTracker("qawolf-innerhop-test-");
 
-afterEach(async () => {
-  // Reverse creation order, one at a time: a later dir can hold a junction into
-  // an earlier one, and win32 fails to remove a junction whose target is gone.
-  for (const d of [...tmpDirs].reverse()) {
-    await rm(d, { recursive: true, force: true });
-  }
-  tmpDirs.length = 0;
-});
-
-async function makeTmpDir(): Promise<string> {
-  const d = realpathSync(
-    await mkdtemp(join(tmpdir(), "qawolf-innerhop-test-")),
-  );
-  tmpDirs.push(d);
-  return d;
-}
+afterEach(() => tracker.cleanup());
 
 describe("populateInnerHop", () => {
   describe("happy path — directory and symlinks", () => {
     it("creates execDir/node_modules as a real directory, not a symlink", async () => {
-      const depsRoot = await makeTmpDir();
-      const execDir = await makeTmpDir();
+      const depsRoot = await tracker.makeTmpDir();
+      const execDir = await tracker.makeTmpDir();
       await scaffoldManagedRuntime(depsRoot);
 
       await populateInnerHop({ depsRoot, execDir, fs: makeDefaultFs() });
@@ -48,8 +32,8 @@ describe("populateInnerHop", () => {
     });
 
     it("creates one symlink per pinned package pointing into the managed tree", async () => {
-      const depsRoot = await makeTmpDir();
-      const execDir = await makeTmpDir();
+      const depsRoot = await tracker.makeTmpDir();
+      const execDir = await tracker.makeTmpDir();
       await scaffoldManagedRuntime(depsRoot);
 
       await populateInnerHop({ depsRoot, execDir, fs: makeDefaultFs() });
@@ -64,8 +48,8 @@ describe("populateInnerHop", () => {
     });
 
     it("creates the @qawolf scope dir with flows, emails, and testkit symlinks", async () => {
-      const depsRoot = await makeTmpDir();
-      const execDir = await makeTmpDir();
+      const depsRoot = await tracker.makeTmpDir();
+      const execDir = await tracker.makeTmpDir();
       await scaffoldManagedRuntime(depsRoot);
 
       await populateInnerHop({ depsRoot, execDir, fs: makeDefaultFs() });
@@ -84,9 +68,9 @@ describe("populateInnerHop", () => {
 
   describe("realpath resolution — transitive dep shadowing fix", () => {
     it("flow gets outer-hop project version; executor probe gets managed pinned version via realpath", async () => {
-      const runDir = await makeTmpDir();
-      const depsRoot = await makeTmpDir();
-      const projectDir = await makeTmpDir();
+      const runDir = await tracker.makeTmpDir();
+      const depsRoot = await tracker.makeTmpDir();
+      const projectDir = await tracker.makeTmpDir();
 
       // Scaffold all 7 pinned package dirs in the managed runtime
       await scaffoldManagedRuntime(depsRoot);

--- a/src/domains/runtimeEnv/innerHop.test.ts
+++ b/src/domains/runtimeEnv/innerHop.test.ts
@@ -10,7 +10,7 @@ import { pinnedPackages } from "./pinnedPackages.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { createDirSymlink } from "./symlinkDir.js";
 import { expectLinkTarget } from "./symlinkDir.testUtils.js";
-import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 
 const tracker = makeTmpDirTracker("qawolf-innerhop-test-");
 

--- a/src/domains/runtimeEnv/innerHop.test.ts
+++ b/src/domains/runtimeEnv/innerHop.test.ts
@@ -1,14 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { realpathSync } from "node:fs";
-import {
-  lstat,
-  mkdir,
-  mkdtemp,
-  readlink,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -18,6 +11,7 @@ import { populateInnerHop } from "./innerHop.js";
 import { pinnedPackages } from "./pinnedPackages.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { createDirSymlink } from "./symlinkDir.js";
+import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 
 const tmpDirs: string[] = [];
 
@@ -63,9 +57,7 @@ describe("populateInnerHop", () => {
       for (const { name } of pinnedPackages) {
         const segments = name.split("/");
         const linkPath = join(innerModules, ...segments);
-        expect(await readlink(linkPath)).toBe(
-          join(managedModules, ...segments),
-        );
+        await expectLinkTarget(linkPath, join(managedModules, ...segments));
       }
     });
 
@@ -83,9 +75,7 @@ describe("populateInnerHop", () => {
 
       for (const pkg of ["flows", "emails", "testkit"]) {
         const linkPath = join(scopeDir, pkg);
-        expect(await readlink(linkPath)).toBe(
-          join(managedModules, "@qawolf", pkg),
-        );
+        await expectLinkTarget(linkPath, join(managedModules, "@qawolf", pkg));
       }
     });
   });

--- a/src/domains/runtimeEnv/innerHop.test.ts
+++ b/src/domains/runtimeEnv/innerHop.test.ts
@@ -16,9 +16,11 @@ import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 const tmpDirs: string[] = [];
 
 afterEach(async () => {
-  await Promise.all(
-    tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
-  );
+  // Reverse creation order, one at a time: a later dir can hold a junction into
+  // an earlier one, and win32 fails to remove a junction whose target is gone.
+  for (const d of [...tmpDirs].reverse()) {
+    await rm(d, { recursive: true, force: true });
+  }
   tmpDirs.length = 0;
 });
 

--- a/src/domains/runtimeEnv/npmInstall.test.ts
+++ b/src/domains/runtimeEnv/npmInstall.test.ts
@@ -68,8 +68,20 @@ describe("spawnNpmInstall", () => {
     const result = await promise;
 
     expect(result.exitCode).toBe(0);
-    expect(calls[0]?.cmd).toBe("npm");
-    expect(calls[0]?.args).toEqual(["install", "--legacy-peer-deps"]);
+    // spawnNpmInstall builds for process.platform: bare npm on posix, npm.cmd
+    // routed through cmd.exe on win32. cwd forwards unchanged on both.
+    if (process.platform === "win32") {
+      expect(calls[0]?.cmd).toBe(process.env["ComSpec"] ?? "cmd.exe");
+      expect(calls[0]?.args).toEqual([
+        "/d",
+        "/s",
+        "/c",
+        '"npm.cmd ^^^"install^^^" ^^^"--legacy-peer-deps^^^""',
+      ]);
+    } else {
+      expect(calls[0]?.cmd).toBe("npm");
+      expect(calls[0]?.args).toEqual(["install", "--legacy-peer-deps"]);
+    }
     expect(calls[0]?.options).toMatchObject({ cwd: "/tmp/env" });
   });
 });

--- a/src/domains/runtimeEnv/outerHop.install.test.ts
+++ b/src/domains/runtimeEnv/outerHop.install.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { readlink } from "node:fs/promises";
 import { join } from "node:path";
 
 import { makeDefaultFs } from "~/shell/fs.js";
@@ -13,6 +12,7 @@ import {
   seedNodeModules,
 } from "./runDirFixtures.testUtils.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
+import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 
 const tracker = makeTmpDirTracker("qawolf-outerhop-install-test-");
 
@@ -86,7 +86,8 @@ describe("populateOuterHop install mode", () => {
     expect(result.mode).toBe("install");
     for (const { name } of pinnedPackages) {
       const segments = name.split("/");
-      expect(await readlink(join(runDir, "node_modules", ...segments))).toBe(
+      await expectLinkTarget(
+        join(runDir, "node_modules", ...segments),
         join(depsRoot, "node_modules", ...segments),
       );
     }
@@ -116,9 +117,10 @@ describe("populateOuterHop install mode", () => {
       install: installMock,
     });
 
-    expect(
-      await readlink(join(runDir, "node_modules", "@qawolf", "flows")),
-    ).toBe(join(depsRoot, "node_modules", "@qawolf", "flows"));
+    await expectLinkTarget(
+      join(runDir, "node_modules", "@qawolf", "flows"),
+      join(depsRoot, "node_modules", "@qawolf", "flows"),
+    );
   });
 
   it("symlink mode: never injects pinned links into the project's own node_modules", async () => {

--- a/src/domains/runtimeEnv/outerHop.install.test.ts
+++ b/src/domains/runtimeEnv/outerHop.install.test.ts
@@ -1,3 +1,4 @@
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 import { afterEach, describe, expect, it } from "bun:test";
 import { join } from "node:path";
 
@@ -8,7 +9,6 @@ import { pinnedPackages } from "./pinnedPackages.js";
 import {
   makeInstallMock,
   makeProjectTree,
-  makeTmpDirTracker,
   seedNodeModules,
 } from "./runDirFixtures.testUtils.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";

--- a/src/domains/runtimeEnv/outerHop.test.ts
+++ b/src/domains/runtimeEnv/outerHop.test.ts
@@ -1,3 +1,4 @@
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 import { afterEach, describe, expect, it } from "bun:test";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -8,7 +9,6 @@ import { populateOuterHop } from "./outerHop.js";
 import {
   makeInstallMock,
   makeProjectTree,
-  makeTmpDirTracker,
 } from "./runDirFixtures.testUtils.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { expectLinkTarget } from "./symlinkDir.testUtils.js";

--- a/src/domains/runtimeEnv/outerHop.test.ts
+++ b/src/domains/runtimeEnv/outerHop.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { readlink, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { makeDefaultFs } from "~/shell/fs.js";
@@ -11,6 +11,7 @@ import {
   makeTmpDirTracker,
 } from "./runDirFixtures.testUtils.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
+import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 
 const tracker = makeTmpDirTracker("qawolf-outerhop-test-");
 
@@ -39,7 +40,8 @@ describe("populateOuterHop", () => {
       mode: "symlink",
       nodeModulesDir: join(projectDir, "node_modules"),
     });
-    expect(await readlink(join(runDir, "node_modules"))).toBe(
+    await expectLinkTarget(
+      join(runDir, "node_modules"),
       join(projectDir, "node_modules"),
     );
   });
@@ -64,7 +66,8 @@ describe("populateOuterHop", () => {
       mode: "symlink",
       nodeModulesDir: join(root, "node_modules"),
     });
-    expect(await readlink(join(runDir, "node_modules"))).toBe(
+    await expectLinkTarget(
+      join(runDir, "node_modules"),
       join(root, "node_modules"),
     );
   });
@@ -131,7 +134,8 @@ describe("populateOuterHop", () => {
       mode: "symlink",
       nodeModulesDir: join(root, "repo", "node_modules"),
     });
-    expect(await readlink(join(runDir, "node_modules"))).toBe(
+    await expectLinkTarget(
+      join(runDir, "node_modules"),
       join(root, "repo", "node_modules"),
     );
   });

--- a/src/domains/runtimeEnv/prepareRunDir.outerHop.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.outerHop.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { readlink, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { prepareRunDir } from "./prepareRunDir.js";
@@ -8,6 +8,7 @@ import {
   makeTmpDirTracker,
 } from "./runDirFixtures.testUtils.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
+import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 
 const tracker = makeTmpDirTracker("qawolf-rundir-outerhop-test-");
 
@@ -43,7 +44,8 @@ describe("prepareRunDir outer-hop discovery (nested-bundle topology)", () => {
       mode: "symlink",
       nodeModulesDir: join(world, "node_modules"),
     });
-    expect(await readlink(join(result.runDir, "node_modules"))).toBe(
+    await expectLinkTarget(
+      join(result.runDir, "node_modules"),
       join(world, "node_modules"),
     );
   });

--- a/src/domains/runtimeEnv/prepareRunDir.outerHop.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.outerHop.test.ts
@@ -1,12 +1,10 @@
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 import { afterEach, describe, expect, it } from "bun:test";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { prepareRunDir } from "./prepareRunDir.js";
-import {
-  makeProjectTree,
-  makeTmpDirTracker,
-} from "./runDirFixtures.testUtils.js";
+import { makeProjectTree } from "./runDirFixtures.testUtils.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 

--- a/src/domains/runtimeEnv/prepareRunDir.stageCollision.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.stageCollision.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 import { prepareRunDir } from "./prepareRunDir.js";
 
 const tracker = makeTmpDirTracker("qawolf-stage-test-");

--- a/src/domains/runtimeEnv/prepareRunDir.stageCollision.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.stageCollision.test.ts
@@ -1,28 +1,16 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { realpathSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
 import { prepareRunDir } from "./prepareRunDir.js";
 
-const tmpDirs: string[] = [];
+const tracker = makeTmpDirTracker("qawolf-stage-test-");
 
-afterEach(async () => {
-  await Promise.all(
-    tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
-  );
-  tmpDirs.length = 0;
-});
-
-async function makeTmpDir(): Promise<string> {
-  const d = realpathSync(await mkdtemp(join(tmpdir(), "qawolf-stage-test-")));
-  tmpDirs.push(d);
-  return d;
-}
+afterEach(() => tracker.cleanup());
 
 async function makeDepsRoot(): Promise<string> {
-  const depsRoot = await makeTmpDir();
+  const depsRoot = await tracker.makeTmpDir();
   await mkdir(join(depsRoot, "node_modules"), { recursive: true });
   return depsRoot;
 }
@@ -30,10 +18,10 @@ async function makeDepsRoot(): Promise<string> {
 describe("stageFlowFiles — basename collision", () => {
   it("stages files with the same basename from different dirs into distinct subdir paths", async () => {
     const [runRoot, depsRoot, dirA, dirB] = await Promise.all([
-      makeTmpDir(),
+      tracker.makeTmpDir(),
       makeDepsRoot(),
-      makeTmpDir(),
-      makeTmpDir(),
+      tracker.makeTmpDir(),
+      tracker.makeTmpDir(),
     ]);
     const flowA = join(dirA, "flow.ts");
     const flowB = join(dirB, "flow.ts");
@@ -48,7 +36,7 @@ describe("stageFlowFiles — basename collision", () => {
       depsRoot,
       runRoot,
     });
-    tmpDirs.push(result.runDir);
+    tracker.track(result.runDir);
 
     expect(result.files).toHaveLength(2);
     const [pathA, pathB] = result.files;

--- a/src/domains/runtimeEnv/prepareRunDir.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { lstat, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 import { prepareRunDir } from "./prepareRunDir.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { expectLinkTarget } from "./symlinkDir.testUtils.js";

--- a/src/domains/runtimeEnv/prepareRunDir.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.test.ts
@@ -11,9 +11,11 @@ import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 const tmpDirs: string[] = [];
 
 afterEach(async () => {
-  await Promise.all(
-    tmpDirs.map((d) => rm(d, { recursive: true, force: true })),
-  );
+  // Reverse creation order, one at a time: a later dir can hold a junction into
+  // an earlier one, and win32 fails to remove a junction whose target is gone.
+  for (const d of [...tmpDirs].reverse()) {
+    await rm(d, { recursive: true, force: true });
+  }
   tmpDirs.length = 0;
 });
 

--- a/src/domains/runtimeEnv/prepareRunDir.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.test.ts
@@ -1,18 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { realpathSync } from "node:fs";
-import {
-  lstat,
-  mkdir,
-  mkdtemp,
-  readlink,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { prepareRunDir } from "./prepareRunDir.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
+import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 
 const tmpDirs: string[] = [];
 
@@ -53,7 +47,8 @@ describe("prepareRunDir", () => {
 
       const innerHop = join(result.runDir, "exec", "node_modules");
       expect((await lstat(innerHop)).isDirectory()).toBe(true);
-      expect(await readlink(join(innerHop, "@qawolf", "flows"))).toBe(
+      await expectLinkTarget(
+        join(innerHop, "@qawolf", "flows"),
         join(depsRoot, "node_modules", "@qawolf", "flows"),
       );
     });
@@ -79,7 +74,7 @@ describe("prepareRunDir", () => {
 
       const outerHop = join(result.runDir, "node_modules");
       expect((await lstat(outerHop)).isSymbolicLink()).toBe(true);
-      expect(await readlink(outerHop)).toBe(projectNm);
+      await expectLinkTarget(outerHop, projectNm);
     });
 
     it("leaves outer hop absent when no projectDir or no installable deps", async () => {
@@ -173,7 +168,8 @@ describe("prepareRunDir", () => {
       // exec/node_modules is the inner hop — a real dir, not a copy of project nm
       const execNm = join(result.runDir, "exec", "node_modules");
       expect((await lstat(execNm)).isDirectory()).toBe(true);
-      expect(await readlink(join(execNm, "@qawolf", "flows"))).toBe(
+      await expectLinkTarget(
+        join(execNm, "@qawolf", "flows"),
         join(depsRoot, "node_modules", "@qawolf", "flows"),
       );
     });
@@ -224,14 +220,15 @@ describe("prepareRunDir", () => {
       // Inner hop is a real directory; @qawolf/flows symlinks into the managed tree
       const innerHop = join(result.runDir, "exec", "node_modules");
       expect((await lstat(innerHop)).isDirectory()).toBe(true);
-      expect(await readlink(join(innerHop, "@qawolf", "flows"))).toBe(
+      await expectLinkTarget(
+        join(innerHop, "@qawolf", "flows"),
         join(depsRoot, "node_modules", "@qawolf", "flows"),
       );
 
       // Outer hop remains a symlink to the project node_modules
       const outerHop = join(result.runDir, "node_modules");
       expect((await lstat(outerHop)).isSymbolicLink()).toBe(true);
-      expect(await readlink(outerHop)).toBe(projectNm);
+      await expectLinkTarget(outerHop, projectNm);
     });
   });
 });

--- a/src/domains/runtimeEnv/prepareRunDir.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.test.ts
@@ -1,32 +1,18 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { realpathSync } from "node:fs";
-import { lstat, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { lstat, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import { makeTmpDirTracker } from "./runDirFixtures.testUtils.js";
 import { prepareRunDir } from "./prepareRunDir.js";
 import { scaffoldManagedRuntime } from "./scaffoldManagedRuntime.testUtils.js";
 import { expectLinkTarget } from "./symlinkDir.testUtils.js";
 
-const tmpDirs: string[] = [];
+const tracker = makeTmpDirTracker("qawolf-rundir-test-");
 
-afterEach(async () => {
-  // Reverse creation order, one at a time: a later dir can hold a junction into
-  // an earlier one, and win32 fails to remove a junction whose target is gone.
-  for (const d of [...tmpDirs].reverse()) {
-    await rm(d, { recursive: true, force: true });
-  }
-  tmpDirs.length = 0;
-});
-
-async function makeTmpDir(): Promise<string> {
-  const d = realpathSync(await mkdtemp(join(tmpdir(), "qawolf-rundir-test-")));
-  tmpDirs.push(d);
-  return d;
-}
+afterEach(() => tracker.cleanup());
 
 async function makeDepsRoot(): Promise<string> {
-  const depsRoot = await makeTmpDir();
+  const depsRoot = await tracker.makeTmpDir();
   await scaffoldManagedRuntime(depsRoot);
   return depsRoot;
 }
@@ -34,7 +20,7 @@ async function makeDepsRoot(): Promise<string> {
 describe("prepareRunDir", () => {
   describe("inner-hop symlink", () => {
     it("builds exec/node_modules as a real dir with per-pinned-package symlinks", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
       const flowFile = join(runRoot, "flow.ts");
       await writeFile(flowFile, "// flow");
@@ -45,7 +31,7 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result.runDir);
+      tracker.track(result.runDir);
 
       const innerHop = join(result.runDir, "exec", "node_modules");
       expect((await lstat(innerHop)).isDirectory()).toBe(true);
@@ -58,9 +44,9 @@ describe("prepareRunDir", () => {
 
   describe("outer-hop population", () => {
     it("symlinks runDir/node_modules to the nearest ancestor node_modules when projectDir is given", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
-      const projectDir = await makeTmpDir();
+      const projectDir = await tracker.makeTmpDir();
       const projectNm = join(projectDir, "node_modules");
       await mkdir(projectNm, { recursive: true });
       const flowFile = join(projectDir, "flow.ts");
@@ -72,7 +58,7 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result.runDir);
+      tracker.track(result.runDir);
 
       const outerHop = join(result.runDir, "node_modules");
       expect((await lstat(outerHop)).isSymbolicLink()).toBe(true);
@@ -80,7 +66,7 @@ describe("prepareRunDir", () => {
     });
 
     it("leaves outer hop absent when no projectDir or no installable deps", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
 
       // Case 1: no projectDir
@@ -91,11 +77,11 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result1.runDir);
+      tracker.track(result1.runDir);
       expect(lstat(join(result1.runDir, "node_modules"))).rejects.toThrow();
 
       // Case 2: projectDir with no node_modules and no package.json deps
-      const projectDir = await makeTmpDir();
+      const projectDir = await tracker.makeTmpDir();
       await writeFile(join(projectDir, "flow.ts"), "// flow");
       const result2 = await prepareRunDir({
         files: [join(projectDir, "flow.ts")],
@@ -103,14 +89,14 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result2.runDir);
+      tracker.track(result2.runDir);
       expect(lstat(join(result2.runDir, "node_modules"))).rejects.toThrow();
     });
   });
 
   describe("exec staging", () => {
     it("copies individual flow files into exec/ when no projectDir", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
       const flowFile = join(runRoot, "myFlow.ts");
       await writeFile(flowFile, "// my flow");
@@ -121,7 +107,7 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result.runDir);
+      tracker.track(result.runDir);
 
       const stagedFlow = join(result.runDir, "exec", "myFlow.ts");
       expect((await lstat(stagedFlow)).isFile()).toBe(true);
@@ -129,9 +115,9 @@ describe("prepareRunDir", () => {
     });
 
     it("copies entire projectDir into exec/ and remaps flow paths", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
-      const projectDir = await makeTmpDir();
+      const projectDir = await tracker.makeTmpDir();
       await writeFile(join(projectDir, "helper.ts"), "// helper");
       const flowFile = join(projectDir, "myFlow.ts");
       await writeFile(flowFile, "// flow");
@@ -142,7 +128,7 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result.runDir);
+      tracker.track(result.runDir);
 
       const execDir = join(result.runDir, "exec");
       expect((await lstat(join(execDir, "helper.ts"))).isFile()).toBe(true);
@@ -151,9 +137,9 @@ describe("prepareRunDir", () => {
     });
 
     it("excludes node_modules from the projectDir copy", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
-      const projectDir = await makeTmpDir();
+      const projectDir = await tracker.makeTmpDir();
       const projectNm = join(projectDir, "node_modules");
       await mkdir(projectNm, { recursive: true });
       const flowFile = join(projectDir, "flow.ts");
@@ -165,7 +151,7 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result.runDir);
+      tracker.track(result.runDir);
 
       // exec/node_modules is the inner hop — a real dir, not a copy of project nm
       const execNm = join(result.runDir, "exec", "node_modules");
@@ -179,7 +165,7 @@ describe("prepareRunDir", () => {
 
   describe("cleanup", () => {
     it("removes the runDir on cleanup()", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
       const flowFile = join(runRoot, "flow.ts");
       await writeFile(flowFile, "// flow");
@@ -199,11 +185,11 @@ describe("prepareRunDir", () => {
 
   describe("prefer-pinned invariant", () => {
     it("executor (inner hop) wins over project copy (outer hop) by path walk-up order", async () => {
-      const runRoot = await makeTmpDir();
+      const runRoot = await tracker.makeTmpDir();
       const depsRoot = await makeDepsRoot();
 
       // Outer hop: projectDir/node_modules has a project copy of @qawolf/flows
-      const projectDir = await makeTmpDir();
+      const projectDir = await tracker.makeTmpDir();
       const projectNm = join(projectDir, "node_modules");
       await mkdir(join(projectNm, "@qawolf"), { recursive: true });
       await writeFile(join(projectNm, "@qawolf", "flows.txt"), "project-copy");
@@ -217,7 +203,7 @@ describe("prepareRunDir", () => {
         depsRoot,
         runRoot,
       });
-      tmpDirs.push(result.runDir);
+      tracker.track(result.runDir);
 
       // Inner hop is a real directory; @qawolf/flows symlinks into the managed tree
       const innerHop = join(result.runDir, "exec", "node_modules");

--- a/src/domains/runtimeEnv/runDirFixtures.testUtils.ts
+++ b/src/domains/runtimeEnv/runDirFixtures.testUtils.ts
@@ -23,9 +23,12 @@ export function makeTmpDirTracker(prefix: string): TmpDirTracker {
       dirs.push(dir);
     },
     async cleanup() {
-      await Promise.all(
-        dirs.map((d) => rm(d, { recursive: true, force: true })),
-      );
+      // Reverse creation order, one at a time: a later dir can hold a junction
+      // into an earlier one, and win32 fails to remove a junction whose target
+      // is already gone.
+      for (const d of [...dirs].reverse()) {
+        await rm(d, { recursive: true, force: true });
+      }
       dirs.length = 0;
     },
   };

--- a/src/domains/runtimeEnv/runDirFixtures.testUtils.ts
+++ b/src/domains/runtimeEnv/runDirFixtures.testUtils.ts
@@ -1,38 +1,8 @@
 import { mock } from "bun:test";
-import { realpathSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
-/** Tracks temp dirs created by a test file so afterEach can remove them. */
-export type TmpDirTracker = {
-  makeTmpDir(): Promise<string>;
-  track(dir: string): void;
-  cleanup(): Promise<void>;
-};
-
-export function makeTmpDirTracker(prefix: string): TmpDirTracker {
-  const dirs: string[] = [];
-  return {
-    async makeTmpDir() {
-      const d = realpathSync(await mkdtemp(join(tmpdir(), prefix)));
-      dirs.push(d);
-      return d;
-    },
-    track(dir) {
-      dirs.push(dir);
-    },
-    async cleanup() {
-      // Reverse creation order, one at a time: a later dir can hold a junction
-      // into an earlier one, and win32 fails to remove a junction whose target
-      // is already gone.
-      for (const d of [...dirs].reverse()) {
-        await rm(d, { recursive: true, force: true });
-      }
-      dirs.length = 0;
-    },
-  };
-}
+import type { TmpDirTracker } from "~/shell/tmpDir.testUtils.js";
 
 /** Writes <base>/node_modules/<name>/package.json for each package name. */
 export async function seedNodeModules(

--- a/src/domains/runtimeEnv/symlinkDir.testUtils.test.ts
+++ b/src/domains/runtimeEnv/symlinkDir.testUtils.test.ts
@@ -1,0 +1,56 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { createDirSymlink } from "./symlinkDir.js";
+import { expectLinkTarget } from "./symlinkDir.testUtils.js";
+
+let workDir = "";
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "qawolf-symlink-utils-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("expectLinkTarget", () => {
+  it("passes for a link created by createDirSymlink", async () => {
+    const target = join(workDir, "target");
+    await mkdir(target);
+    const link = join(workDir, "link");
+    await createDirSymlink(target, link);
+
+    await expectLinkTarget(link, target);
+  });
+
+  it("passes when the reported target carries a junction prefix and trailing separator", async () => {
+    const target = join(workDir, "target");
+    await mkdir(target);
+    const link = join(workDir, "link");
+    // Stand in for the win32 junction spelling that readlink reports.
+    await createDirSymlink(`\\\\?\\${target}/`, link);
+
+    await expectLinkTarget(link, target);
+  });
+
+  it("fails when the link points somewhere else", async () => {
+    const target = join(workDir, "target");
+    const other = join(workDir, "other");
+    await mkdir(target);
+    await mkdir(other);
+    const link = join(workDir, "link");
+    await createDirSymlink(other, link);
+
+    let caughtError: unknown;
+    try {
+      await expectLinkTarget(link, target);
+    } catch (e) {
+      caughtError = e;
+    }
+    expect(caughtError).toBeInstanceOf(Error);
+  });
+});

--- a/src/domains/runtimeEnv/symlinkDir.testUtils.test.ts
+++ b/src/domains/runtimeEnv/symlinkDir.testUtils.test.ts
@@ -27,16 +27,6 @@ describe("expectLinkTarget", () => {
     await expectLinkTarget(link, target);
   });
 
-  it("passes when the reported target carries a junction prefix and trailing separator", async () => {
-    const target = join(workDir, "target");
-    await mkdir(target);
-    const link = join(workDir, "link");
-    // Stand in for the win32 junction spelling that readlink reports.
-    await createDirSymlink(`\\\\?\\${target}/`, link);
-
-    await expectLinkTarget(link, target);
-  });
-
   it("fails when the link points somewhere else", async () => {
     const target = join(workDir, "target");
     const other = join(workDir, "other");

--- a/src/domains/runtimeEnv/symlinkDir.testUtils.ts
+++ b/src/domains/runtimeEnv/symlinkDir.testUtils.ts
@@ -1,0 +1,17 @@
+import { readlink } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { expect } from "bun:test";
+
+// createDirSymlink makes a junction on win32, and readlink reports a junction
+// target with a "\\?\" prefix and a trailing separator. Canonicalize both sides
+// so the assertion still pins the exact target directory.
+function normalizeLinkTarget(target: string) {
+  return resolve(target.replace(/^\\\\\?\\/, ""));
+}
+
+export async function expectLinkTarget(linkPath: string, expected: string) {
+  expect(normalizeLinkTarget(await readlink(linkPath))).toBe(
+    normalizeLinkTarget(expected),
+  );
+}

--- a/src/shell/appium/createAndroidLaunchContext.test.ts
+++ b/src/shell/appium/createAndroidLaunchContext.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import {
   makeCtx,
@@ -145,9 +146,9 @@ describe("cleanup()", () => {
     await context.launch();
     const result = await context.cleanup(true);
     expect(result.videoPaths).toHaveLength(1);
-    expect(result.videoPaths[0]).toBe("/tmp/vid/video.mp4");
+    expect(result.videoPaths[0]).toBe(join("/tmp/vid", "video.mp4"));
     expect(writeFile).toHaveBeenCalledWith(
-      "/tmp/vid/video.mp4",
+      join("/tmp/vid", "video.mp4"),
       expect.any(Buffer),
     );
   });

--- a/src/shell/fs.testUtils.test.ts
+++ b/src/shell/fs.testUtils.test.ts
@@ -422,4 +422,28 @@ describe("makeMemoryFs", () => {
     await fs.writeFile("/d/f.txt", "data", { mode: 0o600 });
     expect(await fs.readFile("/d/f.txt")).toBe("data");
   });
+
+  // Path keying — tests build paths with a literal "/" while the code under
+  // test joins with node:path, which emits "\" and a drive prefix on win32.
+  it("should name the same entry from a win32-separated path as from its POSIX form", async () => {
+    const fs = makeMemoryFs();
+    await fs.mkdir("/a/b", { recursive: true });
+    await fs.writeFile("\\a\\b\\f.txt", "data");
+    expect(await fs.readFile("/a/b/f.txt")).toBe("data");
+  });
+
+  it("should name the same entry from a drive-qualified path as from its POSIX form", async () => {
+    const fs = makeMemoryFs();
+    await fs.mkdir("/a", { recursive: true });
+    await fs.writeFile("C:\\a\\f.txt", "data");
+    expect(await fs.readFile("/a/f.txt")).toBe("data");
+  });
+
+  it("should list a win32-separated write through a POSIX readdir", async () => {
+    const fs = makeMemoryFs();
+    await fs.mkdir("\\x\\y", { recursive: true });
+    await fs.writeFile("\\x\\y\\f.txt", "data");
+    expect(await fs.readdir("/x/y")).toEqual(["f.txt"]);
+    expect(await fs.pathExists("/x")).toBe(true);
+  });
 });

--- a/src/shell/fs.testUtils.ts
+++ b/src/shell/fs.testUtils.ts
@@ -38,12 +38,32 @@ export function makeMemoryFs(): Fs {
     if (dir === "/") dirs.add(dir);
   }
 
+  function childNames(path: string) {
+    const prefix = path === "/" ? "/" : path + "/";
+    const names = new Set<string>();
+    for (const f of files.keys()) {
+      if (f.startsWith(prefix)) {
+        const segment = f.slice(prefix.length).split("/")[0];
+        if (segment) names.add(segment);
+      }
+    }
+    for (const d of dirs) {
+      if (d !== path && d.startsWith(prefix)) {
+        const rel = d.slice(prefix.length);
+        if (!rel.includes("/")) names.add(rel);
+      }
+    }
+    return [...names];
+  }
+
+  function requireParent(path: string, kind: "mkdir" | "open") {
+    const parent = dirname(path);
+    if (parent !== "/" && !dirs.has(parent)) throwNoEntError(path, kind);
+  }
+
   return {
     async mkdir(path, opts) {
-      if (!opts?.recursive) {
-        const parent = dirname(path);
-        if (parent !== "/" && !dirs.has(parent)) throwNoEntError(path, "mkdir");
-      }
+      if (!opts?.recursive) requireParent(path, "mkdir");
       dirs.add(path);
       if (opts?.recursive) addParents(path);
     },
@@ -107,8 +127,7 @@ export function makeMemoryFs(): Fs {
       files.delete(path);
     },
     async writeFile(path, data, _options) {
-      const parent = dirname(path);
-      if (parent !== "/" && !dirs.has(parent)) throwNoEntError(path, "open");
+      requireParent(path, "open");
       files.set(
         path,
         typeof data === "string" ? textEncoder.encode(data) : data,
@@ -117,41 +136,13 @@ export function makeMemoryFs(): Fs {
     readdir(path) {
       if (files.has(path)) throwNotDirError(path, "scandir");
       if (!dirs.has(path)) throwNoEntError(path, "open");
-      const prefix = path === "/" ? "/" : path + "/";
-      const names = new Set<string>();
-      for (const f of files.keys()) {
-        if (f.startsWith(prefix)) {
-          const segment = f.slice(prefix.length).split("/")[0];
-          if (segment) names.add(segment);
-        }
-      }
-      for (const d of dirs) {
-        if (d !== path && d.startsWith(prefix)) {
-          const rel = d.slice(prefix.length);
-          if (!rel.includes("/")) names.add(rel);
-        }
-      }
-      return Promise.resolve([...names]);
+      return Promise.resolve(childNames(path));
     },
     readdirWithTypes(path) {
       if (files.has(path)) throwNotDirError(path, "scandir");
       if (!dirs.has(path)) throwNoEntError(path, "open");
-      const prefix = path === "/" ? "/" : path + "/";
-      const names = new Set<string>();
-      for (const f of files.keys()) {
-        if (f.startsWith(prefix)) {
-          const segment = f.slice(prefix.length).split("/")[0];
-          if (segment) names.add(segment);
-        }
-      }
-      for (const d of dirs) {
-        if (d !== path && d.startsWith(prefix)) {
-          const rel = d.slice(prefix.length);
-          if (!rel.includes("/")) names.add(rel);
-        }
-      }
       return Promise.resolve<FsDirent[]>(
-        [...names].map((name) => {
+        childNames(path).map((name) => {
           const fullPath = joinPath(path, name);
           const isFileSnapshot = files.has(fullPath);
           const isDirSnapshot = dirs.has(fullPath);
@@ -165,17 +156,13 @@ export function makeMemoryFs(): Fs {
     },
     rename(oldPath, newPath) {
       if (files.has(oldPath)) {
-        const parent = dirname(newPath);
-        if (parent !== "/" && !dirs.has(parent))
-          throwNoEntError(newPath, "open");
+        requireParent(newPath, "open");
         files.set(newPath, files.get(oldPath)!);
         files.delete(oldPath);
         return Promise.resolve();
       }
       if (dirs.has(oldPath)) {
-        const parent = dirname(newPath);
-        if (parent !== "/" && !dirs.has(parent))
-          throwNoEntError(newPath, "open");
+        requireParent(newPath, "open");
         const oldPrefix = oldPath + "/";
         const newPrefix = newPath + "/";
         dirs.delete(oldPath);
@@ -207,9 +194,7 @@ export function makeMemoryFs(): Fs {
     async copyFile(source, destination) {
       const data = files.get(source);
       if (data === undefined) throwNoEntError(source, "open");
-      const parent = dirname(destination);
-      if (parent !== "/" && !dirs.has(parent))
-        throwNoEntError(destination, "open");
+      requireParent(destination, "open");
       files.set(destination, data.slice());
     },
     existsSync(path) {
@@ -221,15 +206,11 @@ export function makeMemoryFs(): Fs {
       return textDecoder.decode(data);
     },
     writeFileSync(path, data) {
-      const parent = dirname(path);
-      if (parent !== "/" && !dirs.has(parent)) throwNoEntError(path, "open");
+      requireParent(path, "open");
       files.set(path, textEncoder.encode(data));
     },
     mkdirSync(path, opts) {
-      if (!opts?.recursive) {
-        const parent = dirname(path);
-        if (parent !== "/" && !dirs.has(parent)) throwNoEntError(path, "mkdir");
-      }
+      if (!opts?.recursive) requireParent(path, "mkdir");
       dirs.add(path);
       if (opts?.recursive) addParents(path);
     },

--- a/src/shell/fs.testUtils.ts
+++ b/src/shell/fs.testUtils.ts
@@ -1,6 +1,15 @@
 import type { FsDirent, Fs } from "./fs.js";
-import { dirname } from "node:path";
+import { posix } from "node:path";
 import { Readable } from "node:stream";
+
+const dirname = posix.dirname;
+
+// Callers build paths with a literal "/", but the code under test joins with
+// node:path, which emits "\" and a drive prefix on win32. Key every entry in
+// one POSIX form so both spellings name the same entry.
+function toKey(path: string) {
+  return path.replace(/\\/g, "/").replace(/^[A-Za-z]:/, "");
+}
 
 function throwNoEntError(
   path: string,
@@ -56,26 +65,34 @@ export function makeMemoryFs(): Fs {
     return [...names];
   }
 
-  function requireParent(path: string, kind: "mkdir" | "open") {
+  // `rawPath` is only for the error message, so it echoes the caller's spelling.
+  function requireParent(
+    path: string,
+    rawPath: string,
+    kind: "mkdir" | "open",
+  ) {
     const parent = dirname(path);
-    if (parent !== "/" && !dirs.has(parent)) throwNoEntError(path, kind);
+    if (parent !== "/" && !dirs.has(parent)) throwNoEntError(rawPath, kind);
   }
 
   return {
-    async mkdir(path, opts) {
-      if (!opts?.recursive) requireParent(path, "mkdir");
+    async mkdir(rawPath, opts) {
+      const path = toKey(rawPath);
+      if (!opts?.recursive) requireParent(path, rawPath, "mkdir");
       dirs.add(path);
       if (opts?.recursive) addParents(path);
     },
-    async pathExists(path) {
+    async pathExists(rawPath) {
+      const path = toKey(rawPath);
       return files.has(path) || dirs.has(path);
     },
-    async readFile(path: string) {
-      const data = files.get(path);
-      if (data === undefined) throwNoEntError(path, "open");
+    async readFile(rawPath: string) {
+      const data = files.get(toKey(rawPath));
+      if (data === undefined) throwNoEntError(rawPath, "open");
       return textDecoder.decode(data);
     },
-    async rm(path, opts) {
+    async rm(rawPath, opts) {
+      const path = toKey(rawPath);
       if (files.has(path)) {
         files.delete(path);
         return;
@@ -108,12 +125,13 @@ export function makeMemoryFs(): Fs {
         }
         return;
       }
-      if (!opts?.force) throwNoEntError(path, "rm");
+      if (!opts?.force) throwNoEntError(rawPath, "rm");
     },
-    async stat(path) {
+    async stat(rawPath) {
+      const path = toKey(rawPath);
       const isFile = files.has(path);
       const isDir = dirs.has(path);
-      if (!isFile && !isDir) throwNoEntError(path, "stat");
+      if (!isFile && !isDir) throwNoEntError(rawPath, "stat");
       return {
         isFile: () => isFile,
         isDirectory: () => isDir,
@@ -122,25 +140,29 @@ export function makeMemoryFs(): Fs {
         mtime: new Date(0),
       };
     },
-    async unlink(path) {
-      if (!files.has(path)) throwNoEntError(path, "unlink");
+    async unlink(rawPath) {
+      const path = toKey(rawPath);
+      if (!files.has(path)) throwNoEntError(rawPath, "unlink");
       files.delete(path);
     },
-    async writeFile(path, data, _options) {
-      requireParent(path, "open");
+    async writeFile(rawPath, data, _options) {
+      const path = toKey(rawPath);
+      requireParent(path, rawPath, "open");
       files.set(
         path,
         typeof data === "string" ? textEncoder.encode(data) : data,
       );
     },
-    readdir(path) {
-      if (files.has(path)) throwNotDirError(path, "scandir");
-      if (!dirs.has(path)) throwNoEntError(path, "open");
+    readdir(rawPath) {
+      const path = toKey(rawPath);
+      if (files.has(path)) throwNotDirError(rawPath, "scandir");
+      if (!dirs.has(path)) throwNoEntError(rawPath, "open");
       return Promise.resolve(childNames(path));
     },
-    readdirWithTypes(path) {
-      if (files.has(path)) throwNotDirError(path, "scandir");
-      if (!dirs.has(path)) throwNoEntError(path, "open");
+    readdirWithTypes(rawPath) {
+      const path = toKey(rawPath);
+      if (files.has(path)) throwNotDirError(rawPath, "scandir");
+      if (!dirs.has(path)) throwNoEntError(rawPath, "open");
       return Promise.resolve<FsDirent[]>(
         childNames(path).map((name) => {
           const fullPath = joinPath(path, name);
@@ -154,15 +176,17 @@ export function makeMemoryFs(): Fs {
         }),
       );
     },
-    rename(oldPath, newPath) {
+    rename(rawOldPath, rawNewPath) {
+      const oldPath = toKey(rawOldPath);
+      const newPath = toKey(rawNewPath);
       if (files.has(oldPath)) {
-        requireParent(newPath, "open");
+        requireParent(newPath, rawNewPath, "open");
         files.set(newPath, files.get(oldPath)!);
         files.delete(oldPath);
         return Promise.resolve();
       }
       if (dirs.has(oldPath)) {
-        requireParent(newPath, "open");
+        requireParent(newPath, rawNewPath, "open");
         const oldPrefix = oldPath + "/";
         const newPrefix = newPath + "/";
         dirs.delete(oldPath);
@@ -181,36 +205,40 @@ export function makeMemoryFs(): Fs {
         }
         return Promise.resolve();
       }
-      throwNoEntError(oldPath, "open");
+      throwNoEntError(rawOldPath, "open");
     },
     utimes(_path, _atime, _mtime) {
       return Promise.resolve();
     },
-    createReadStream(path) {
-      const data = files.get(path);
-      if (data === undefined) throwNoEntError(path, "open");
+    createReadStream(rawPath) {
+      const data = files.get(toKey(rawPath));
+      if (data === undefined) throwNoEntError(rawPath, "open");
       return Readable.from([data]);
     },
-    async copyFile(source, destination) {
-      const data = files.get(source);
-      if (data === undefined) throwNoEntError(source, "open");
-      requireParent(destination, "open");
+    async copyFile(rawSource, rawDestination) {
+      const destination = toKey(rawDestination);
+      const data = files.get(toKey(rawSource));
+      if (data === undefined) throwNoEntError(rawSource, "open");
+      requireParent(destination, rawDestination, "open");
       files.set(destination, data.slice());
     },
-    existsSync(path) {
+    existsSync(rawPath) {
+      const path = toKey(rawPath);
       return files.has(path) || dirs.has(path);
     },
-    readFileSync(path) {
-      const data = files.get(path);
-      if (data === undefined) throwNoEntError(path, "open");
+    readFileSync(rawPath) {
+      const data = files.get(toKey(rawPath));
+      if (data === undefined) throwNoEntError(rawPath, "open");
       return textDecoder.decode(data);
     },
-    writeFileSync(path, data) {
-      requireParent(path, "open");
+    writeFileSync(rawPath, data) {
+      const path = toKey(rawPath);
+      requireParent(path, rawPath, "open");
       files.set(path, textEncoder.encode(data));
     },
-    mkdirSync(path, opts) {
-      if (!opts?.recursive) requireParent(path, "mkdir");
+    mkdirSync(rawPath, opts) {
+      const path = toKey(rawPath);
+      if (!opts?.recursive) requireParent(path, rawPath, "mkdir");
       dirs.add(path);
       if (opts?.recursive) addParents(path);
     },

--- a/src/shell/manifest/lookup.test.ts
+++ b/src/shell/manifest/lookup.test.ts
@@ -42,7 +42,7 @@ const sampleManifest: Manifest = {
   qawolfCommittedAt: undefined,
   envVarsFetchedAt: undefined,
   flows: [
-    { path: "src/login.flow.ts", contentHash: "hash-login" },
+    { path: join("src", "login.flow.ts"), contentHash: "hash-login" },
     { path: "checkout.flow.ts", contentHash: "hash-checkout" },
   ],
 };
@@ -55,7 +55,7 @@ describe("findFlowStamp", () => {
     const stamp = await findFlowStamp(join(envDir, "src/login.flow.ts"));
     expect(stamp).toEqual({
       envId: "env-abc",
-      path: "src/login.flow.ts",
+      path: join("src", "login.flow.ts"),
       contentHash: "hash-login",
     });
   });

--- a/src/shell/reporter/createJUnitReporter.test.ts
+++ b/src/shell/reporter/createJUnitReporter.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, it } from "bun:test";
 
 import {
@@ -25,7 +26,7 @@ function makeDeps() {
 describe("resolveJUnitOutputPath", () => {
   it("defaults to junit-report.xml inside the output dir when the flag is bare", () => {
     expect(resolveJUnitOutputPath(true, "qawolf-output")).toBe(
-      "qawolf-output/junit-report.xml",
+      join("qawolf-output", "junit-report.xml"),
     );
   });
 
@@ -37,10 +38,10 @@ describe("resolveJUnitOutputPath", () => {
 
   it("falls back to the default path for an empty or whitespace value", () => {
     expect(resolveJUnitOutputPath("", "qawolf-output")).toBe(
-      "qawolf-output/junit-report.xml",
+      join("qawolf-output", "junit-report.xml"),
     );
     expect(resolveJUnitOutputPath("   ", "qawolf-output")).toBe(
-      "qawolf-output/junit-report.xml",
+      join("qawolf-output", "junit-report.xml"),
     );
   });
 });

--- a/src/shell/resolveExport.test.ts
+++ b/src/shell/resolveExport.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
 import { resolveFromEnvDir } from "./resolveExport.js";
 
@@ -6,7 +7,7 @@ function makeTestFs(pkgDir: string, pkg: object): Fs {
   return {
     ...makeDefaultFs(),
     readFileSync: (path: string) => {
-      if (path === `${pkgDir}/package.json`) return JSON.stringify(pkg);
+      if (path === join(pkgDir, "package.json")) return JSON.stringify(pkg);
       throw Object.assign(
         new Error(`ENOENT: no such file or directory, open '${path}'`),
         { code: "ENOENT", errno: -2 },
@@ -15,100 +16,102 @@ function makeTestFs(pkgDir: string, pkg: object): Fs {
   };
 }
 
-describe("resolveFromEnvDir", () => {
-  const envDir = "/project";
+const envDir = "/project";
+const pkgPath = (...segments: string[]) =>
+  join(envDir, "node_modules", ...segments);
 
+describe("resolveFromEnvDir", () => {
   describe("unscoped package, root entry", () => {
     it("handles exports as a bare string shorthand", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: "./index.js",
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/index.js`,
+        pkgPath("pkg", "index.js"),
       );
     });
 
     it("handles exports as a top-level conditions object", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { import: "./esm.js", require: "./cjs.js" },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/esm.js`,
+        pkgPath("pkg", "esm.js"),
       );
     });
 
     it("returns path from string export", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/playwright`, {
+      const testFs = makeTestFs(pkgPath("playwright"), {
         exports: { ".": "./index.js" },
       });
       expect(resolveFromEnvDir(envDir, "playwright", "esm", testFs)).toBe(
-        `${envDir}/node_modules/playwright/index.js`,
+        pkgPath("playwright", "index.js"),
       );
     });
 
     it("prefers import over require over default in object entry", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: {
           ".": { import: "./esm.js", require: "./cjs.js", default: "./def.js" },
         },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/esm.js`,
+        pkgPath("pkg", "esm.js"),
       );
     });
 
     it("falls back to require when import is absent", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { ".": { require: "./cjs.js", default: "./def.js" } },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/cjs.js`,
+        pkgPath("pkg", "cjs.js"),
       );
     });
 
     it("falls back to default when import and require are absent", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { ".": { default: "./def.js" } },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/def.js`,
+        pkgPath("pkg", "def.js"),
       );
     });
 
     it("falls back to module field when exports map is absent", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         module: "./esm.js",
         main: "./cjs.js",
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/esm.js`,
+        pkgPath("pkg", "esm.js"),
       );
     });
 
     it("falls back to main field when exports and module are absent", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         main: "./index.js",
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/index.js`,
+        pkgPath("pkg", "index.js"),
       );
     });
   });
 
   describe("scoped package, root entry", () => {
     it("resolves @scope/pkg correctly", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/@qawolf/testkit`, {
+      const testFs = makeTestFs(pkgPath("@qawolf", "testkit"), {
         exports: { ".": "./dist/index.js" },
       });
       expect(resolveFromEnvDir(envDir, "@qawolf/testkit", "esm", testFs)).toBe(
-        `${envDir}/node_modules/@qawolf/testkit/dist/index.js`,
+        pkgPath("@qawolf", "testkit", "dist", "index.js"),
       );
     });
   });
 
   describe("subpath entry", () => {
     it("resolves @scope/pkg/subpath correctly", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/@qawolf/testkit`, {
+      const testFs = makeTestFs(pkgPath("@qawolf", "testkit"), {
         exports: {
           ".": "./dist/index.js",
           "./client": { import: "./dist/client.js" },
@@ -116,25 +119,25 @@ describe("resolveFromEnvDir", () => {
       });
       expect(
         resolveFromEnvDir(envDir, "@qawolf/testkit/client", "esm", testFs),
-      ).toBe(`${envDir}/node_modules/@qawolf/testkit/dist/client.js`);
+      ).toBe(pkgPath("@qawolf", "testkit", "dist", "client.js"));
     });
 
     it("resolves unscoped pkg/subpath correctly", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/playwright`, {
+      const testFs = makeTestFs(pkgPath("playwright"), {
         exports: {
           ".": "./index.js",
           "./test": "./test.js",
         },
       });
       expect(resolveFromEnvDir(envDir, "playwright/test", "esm", testFs)).toBe(
-        `${envDir}/node_modules/playwright/test.js`,
+        pkgPath("playwright", "test.js"),
       );
     });
   });
 
   describe("cjs preference", () => {
     it("prefers require over import in cjs mode", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: {
           ".": {
             import: "./esm.mjs",
@@ -144,32 +147,32 @@ describe("resolveFromEnvDir", () => {
         },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "cjs", testFs)).toBe(
-        `${envDir}/node_modules/pkg/cjs.js`,
+        pkgPath("pkg", "cjs.js"),
       );
     });
 
     it("falls back to default when require is absent in cjs mode", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { ".": { import: "./esm.mjs", default: "./def.js" } },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "cjs", testFs)).toBe(
-        `${envDir}/node_modules/pkg/def.js`,
+        pkgPath("pkg", "def.js"),
       );
     });
 
     it("falls back to import as last resort in cjs mode", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { ".": { import: "./esm.mjs" } },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "cjs", testFs)).toBe(
-        `${envDir}/node_modules/pkg/esm.mjs`,
+        pkgPath("pkg", "esm.mjs"),
       );
     });
   });
 
   describe("nested condition objects", () => {
     it("recurses into nested import condition object", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: {
           ".": {
             import: { types: "./index.d.ts", default: "./esm.js" },
@@ -178,12 +181,12 @@ describe("resolveFromEnvDir", () => {
         },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toBe(
-        `${envDir}/node_modules/pkg/esm.js`,
+        pkgPath("pkg", "esm.js"),
       );
     });
 
     it("recurses into nested require condition object in cjs mode", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: {
           ".": {
             require: { types: "./index.d.ts", default: "./cjs.js" },
@@ -191,29 +194,29 @@ describe("resolveFromEnvDir", () => {
         },
       });
       expect(resolveFromEnvDir(envDir, "pkg", "cjs", testFs)).toBe(
-        `${envDir}/node_modules/pkg/cjs.js`,
+        pkgPath("pkg", "cjs.js"),
       );
     });
   });
 
   describe("error cases", () => {
     it("throws when subpath entry is missing from exports map", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { ".": "./index.js" },
       });
       expect(() =>
         resolveFromEnvDir(envDir, "pkg/missing", "esm", testFs),
       ).toThrow(
-        `No entry for "./missing" in exports of ${envDir}/node_modules/pkg/package.json`,
+        `No entry for "./missing" in exports of ${pkgPath("pkg", "package.json")}`,
       );
     });
 
     it("throws when root entry is absent and no main/module fallback", () => {
-      const testFs = makeTestFs(`${envDir}/node_modules/pkg`, {
+      const testFs = makeTestFs(pkgPath("pkg"), {
         exports: { "./other": "./other.js" },
       });
       expect(() => resolveFromEnvDir(envDir, "pkg", "esm", testFs)).toThrow(
-        `No entry for "." in exports of ${envDir}/node_modules/pkg/package.json`,
+        `No entry for "." in exports of ${pkgPath("pkg", "package.json")}`,
       );
     });
 
@@ -226,7 +229,9 @@ describe("resolveFromEnvDir", () => {
       };
       expect(() =>
         resolveFromEnvDir(envDir, "missing-pkg", "esm", testFs),
-      ).toThrow(`Package 'missing-pkg' not found in ${envDir}/node_modules`);
+      ).toThrow(
+        `Package 'missing-pkg' not found in ${join(envDir, "node_modules")}`,
+      );
     });
   });
 });

--- a/src/shell/tmpDir.testUtils.ts
+++ b/src/shell/tmpDir.testUtils.ts
@@ -1,0 +1,34 @@
+import { realpathSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Tracks temp dirs created by a test file so afterEach can remove them. */
+export type TmpDirTracker = {
+  makeTmpDir(): Promise<string>;
+  track(dir: string): void;
+  cleanup(): Promise<void>;
+};
+
+export function makeTmpDirTracker(prefix: string): TmpDirTracker {
+  const dirs: string[] = [];
+  return {
+    async makeTmpDir() {
+      const d = realpathSync(await mkdtemp(join(tmpdir(), prefix)));
+      dirs.push(d);
+      return d;
+    },
+    track(dir) {
+      dirs.push(dir);
+    },
+    async cleanup() {
+      // Reverse creation order, one at a time: a later dir can hold a junction
+      // into an earlier one, and win32 fails to remove a junction whose target
+      // is already gone.
+      for (const d of [...dirs].reverse()) {
+        await rm(d, { recursive: true, force: true });
+      }
+      dirs.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
Relates to WIZ-11279. Follow-up audit filed as WIZ-11287.

# Overview of Changes

The `windows-smoke` job deliberately skipped `bun run test` because the suite failed on win32. This makes the suite pass there and adds the step. Only tests, test utilities and CI changed. No production code, and every failure traced to a test artifact rather than a product bug.

The ticket scoped ~30 files across four causes. The first real Windows run showed 55 failures across 12 files, including causes nobody had listed, so the fix is wider than the ticket: separator and drive-letter assertions against `node:path` output, `makeMemoryFs` keying (one fix covering all 36 of its consumers), junction `readlink` targets, POSIX file modes, glob output that stays forward-slashed on win32, a bundler that doubles backslashes in an emitted import literal, `cmd.exe` argument wrapping, and dotenv backslash escaping. Two changes keep coverage a skip would have dropped: `extract.test.ts` builds its symlink fixture as a raw tar entry so the symlink-escape guard still runs where win32 needs Developer Mode, and the `.env` `0600` check is win32-skipped rather than deleted. `.gitattributes` pins an LF working tree because the runner checks out with `core.autocrlf=true`, which broke the `SKILL.md` frontmatter and help-snapshot comparisons; no committed file contains CRLF, so it renormalizes nothing.

Two fixes are worth a reviewer's attention because production was right and the test was wrong. `stage.test.ts` now asserts parsed dotenv values, since `serializeDotenv` escapes backslashes by design and `dotenv.test.ts` already pins that byte format. Temp-dir teardown now runs newest-first, one at a time: it deleted concurrently, so a junction's target could go before the dir holding it and win32 failed with `EFAULT` on the dangling junction. Five files each kept a private copy of that teardown, which is how I fixed three and missed a fourth that then failed on the next run, so they all route through `makeTmpDirTracker` now.

# Testing

`bun run test` runs in the `windows-smoke` job as of this PR, so Windows is covered by CI rather than by argument. That job is green here, along with the checks below on Linux. Each of the 7 commits is independently green, so the branch bisects.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

1230 tests pass locally on darwin, 0 fail.

Not fixed here, deliberately: on win32 `expandPatterns` returns forward-slash paths from tinyglobby while the rest of the CLI joins with backslashes. Nothing is known to compare the two, so the tests normalize both sides and production is untouched. WIZ-11287 tracks the audit and says to verify before changing anything.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)