### PR TITLE
fix(flows): return one canonical path form from flow discovery

### DIFF
--- a/.changeset/windows-glob-path-separators.md
+++ b/.changeset/windows-glob-path-separators.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Stage flow files correctly on Windows. Flow discovery returned forward-slash paths from the glob, while the rest of the CLI builds paths with `node:path` and gets backslashes. The staging step compared the two, never matched, and returned the original source path. `qawolf flows run` then executed flows from the project tree instead of the prepared run directory, so a flow resolved whatever Playwright the project had installed rather than the pinned executor, and a flow importing `#playwright` failed. Flow discovery now returns one canonical path form.

--- a/src/domains/flows/expand.test.ts
+++ b/src/domains/flows/expand.test.ts
@@ -144,10 +144,8 @@ describe("peekFlowMeta", () => {
 });
 
 describe("expandPatterns", () => {
-  // tinyglobby returns forward-slash absolute paths even on win32, where join
-  // uses backslashes; compare on a normalized separator.
-  const toPosix = (p: string) => p.replaceAll("\\", "/");
-
+  // Assertions compare exactly against join-derived paths on purpose: that is
+  // what pins the canonical form on win32, where the glob emits forward slashes.
   let mainTmpDir: string;
   let noQawolfTmpDir: string;
   let multiEnvTmpDir: string;
@@ -197,22 +195,17 @@ describe("expandPatterns", () => {
       undefined,
       defaultFs,
     );
-    expect(result.map(toPosix)).toContain(
-      toPosix(join(noQawolfTmpDir, "a.flow.ts")),
-    );
-    expect(result.map(toPosix)).toContain(
-      toPosix(join(noQawolfTmpDir, "sub", "b.flow.ts")),
-    );
+    expect(result).toContain(join(noQawolfTmpDir, "a.flow.ts"));
+    expect(result).toContain(join(noQawolfTmpDir, "sub", "b.flow.ts"));
   });
 
   it("should return files from the .qawolf env dir alongside cwd flows when no patterns provided", async () => {
     const result = await expandPatterns([], mainTmpDir, undefined, defaultFs);
-    const files = result.map(toPosix);
-    expect(files).toContain(
-      toPosix(join(mainTmpDir, ".qawolf", "staging", "c.flow.ts")),
+    expect(result).toContain(
+      join(mainTmpDir, ".qawolf", "staging", "c.flow.ts"),
     );
-    expect(files).toContain(toPosix(join(mainTmpDir, "a.flow.ts")));
-    expect(files).toContain(toPosix(join(mainTmpDir, "sub", "b.flow.ts")));
+    expect(result).toContain(join(mainTmpDir, "a.flow.ts"));
+    expect(result).toContain(join(mainTmpDir, "sub", "b.flow.ts"));
   });
 
   it("should resolve a pattern relative to each env dir root", async () => {
@@ -222,11 +215,10 @@ describe("expandPatterns", () => {
       undefined,
       defaultFs,
     );
-    const files = result.map(toPosix);
-    expect(files).toContain(
-      toPosix(join(mainTmpDir, ".qawolf", "staging", "c.flow.ts")),
+    expect(result).toContain(
+      join(mainTmpDir, ".qawolf", "staging", "c.flow.ts"),
     );
-    expect(files).toContain(toPosix(join(mainTmpDir, "a.flow.ts")));
+    expect(result).toContain(join(mainTmpDir, "a.flow.ts"));
   });
 
   it("should return empty array when no files match", async () => {
@@ -246,14 +238,13 @@ describe("expandPatterns", () => {
       undefined,
       defaultFs,
     );
-    const files = result.map(toPosix);
-    expect(files).toContain(
-      toPosix(join(multiEnvTmpDir, ".qawolf", "staging", "s.flow.ts")),
+    expect(result).toContain(
+      join(multiEnvTmpDir, ".qawolf", "staging", "s.flow.ts"),
     );
-    expect(files).toContain(
-      toPosix(join(multiEnvTmpDir, ".qawolf", "prod", "p.flow.ts")),
+    expect(result).toContain(
+      join(multiEnvTmpDir, ".qawolf", "prod", "p.flow.ts"),
     );
-    expect(files).toContain(toPosix(join(multiEnvTmpDir, "a.flow.ts")));
+    expect(result).toContain(join(multiEnvTmpDir, "a.flow.ts"));
   });
 
   it("should discover .flow.js files alongside .flow.ts with the default pattern", async () => {
@@ -262,9 +253,8 @@ describe("expandPatterns", () => {
     await writeFile(join(tmp, "b.flow.js"), "// b");
     try {
       const result = await expandPatterns([], tmp, undefined, defaultFs);
-      const files = result.map(toPosix);
-      expect(files).toContain(toPosix(join(tmp, "a.flow.ts")));
-      expect(files).toContain(toPosix(join(tmp, "b.flow.js")));
+      expect(result).toContain(join(tmp, "a.flow.ts"));
+      expect(result).toContain(join(tmp, "b.flow.js"));
     } finally {
       await rm(tmp, { recursive: true, force: true });
     }

--- a/src/domains/flows/expand.test.ts
+++ b/src/domains/flows/expand.test.ts
@@ -144,8 +144,9 @@ describe("peekFlowMeta", () => {
 });
 
 describe("expandPatterns", () => {
-  // Assertions compare exactly against join-derived paths on purpose: that is
-  // what pins the canonical form on win32, where the glob emits forward slashes.
+  // These assertions compare exactly against join-derived paths on purpose.
+  // The glob emits forward slashes on win32. Exact equality is what pins the
+  // canonical form there, so do not normalize either side.
   let mainTmpDir: string;
   let noQawolfTmpDir: string;
   let multiEnvTmpDir: string;

--- a/src/domains/flows/expand.ts
+++ b/src/domains/flows/expand.ts
@@ -1,5 +1,5 @@
 import type { Fs } from "~/shell/fs.js";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { glob } from "tinyglobby";
 import { extractFlowMeta, type PeekFlowMetaFn } from "~/core/flowMeta.js";
 import type { Logger } from "~/shell/logger.js";
@@ -44,7 +44,11 @@ export async function expandPatterns(
       cwd: root,
       absolute: true,
     });
-    for (const file of matches) {
+    for (const match of matches) {
+      // tinyglobby emits forward slashes even on win32; the rest of the CLI
+      // builds paths with node:path. prepareRunDir's remapPath compares the
+      // two forms, so canonicalize here.
+      const file = resolve(match);
       seen.add(file);
       logger?.trace(`found: ${file}`);
     }


### PR DESCRIPTION
tinyglobby emits forward slashes on win32 while the rest of the CLI joins with `node:path`, so `remapPath` in `prepareRunDir` compared two spellings of the same path and never matched. Staging silently fell through and flows ran from the user's tree, outside the prepared run dir — bypassing the pinned executor and the `#playwright` alias.

Fixed at the `expandPatterns` boundary rather than in `remapPath`: I audited eleven consumers of glob output and `remapPath` was the only one that mismatches, so one canonical form at the source covers it. Note the test change only fails on win32 — `sep` is `/` on POSIX — so `windows-smoke` is what verifies this.

Resolves WIZ-11287