### PR TITLE
fix(cli): unify the "tool not found" remedies on `qawolf install`

### DIFF
--- a/src/commands/resolveDepsRoot.test.ts
+++ b/src/commands/resolveDepsRoot.test.ts
@@ -9,8 +9,8 @@ import { resolveDepsRoot } from "./resolveDepsRoot.js";
 
 type MemFs = ReturnType<typeof makeMemoryFs>;
 
-// Materializes every pinned package at its exact version plus the .bin/playwright
-// shim so allPinnedResolved(dir) returns true for `dir`.
+// Materializes every pinned package at its exact version plus the .bin CLI
+// shims so allPinnedResolved(dir) returns true for `dir`.
 function seedFullEnv(fs: MemFs, dir: string): void {
   for (const { name, version } of pinnedPackages) {
     const pkgDir = join(dir, "node_modules", ...name.split("/"));
@@ -20,6 +20,7 @@ function seedFullEnv(fs: MemFs, dir: string): void {
   const binDir = join(dir, "node_modules", ".bin");
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(join(binDir, "playwright"), "#!/bin/sh");
+  fs.writeFileSync(join(binDir, "appium"), "#!/bin/sh");
 }
 
 function seedPackageJson(fs: MemFs, dir: string): void {

--- a/src/core/messages/doctor.ts
+++ b/src/core/messages/doctor.ts
@@ -1,3 +1,5 @@
+import { clearAndRetry, toolNotInstalled } from "./toolNotFound.js";
+
 export const doctorMessages = {
   intro: "qawolf doctor",
   agentLine: (
@@ -53,19 +55,16 @@ export const doctorMessages = {
     notInstalled: "npm is not installed or not on PATH",
   },
   playwright: {
-    notFound:
-      "Could not find Playwright. Run `qawolf flows run` to install it, or run `npm install playwright` in your flow directory.",
+    notFound: (path?: string) => toolNotInstalled("Playwright", path),
     launchFailed:
       "Could not launch Playwright. Try reinstalling the qawolf CLI.",
     versionUnparseable: "Could not parse playwright version output",
   },
   appium: {
-    noEnvDir:
-      "No env dir found. Run `qawolf flows run` to install Appium dependencies.",
-    binaryMissing: (bin: string) =>
-      `Appium binary missing at ${bin}. Run \`qawolf flows run\` to install.`,
+    notFound: (path?: string) => toolNotInstalled("Appium", path),
     driverListFailed: (detail: string) =>
-      `Could not run \`appium driver list\` (${detail}). The Appium binary may be broken — try \`qawolf flows run\` to reinstall.`,
+      `Could not run \`appium driver list\` (${detail}). ` +
+      `The Appium binary may be broken. ${clearAndRetry}`,
     cannotCheckDriverList: "Cannot check driver list without Appium binary.",
     uiautomator2NotInstalled:
       "uiautomator2 driver not installed. Run `qawolf install android` to install it.",

--- a/src/core/messages/doctor.ts
+++ b/src/core/messages/doctor.ts
@@ -1,4 +1,4 @@
-import { clearAndRetry, toolNotInstalled } from "./toolNotFound.js";
+import { toolNotInstalled, toolNotRunnable } from "./toolNotFound.js";
 
 export const doctorMessages = {
   intro: "qawolf doctor",
@@ -63,8 +63,7 @@ export const doctorMessages = {
   appium: {
     notFound: (path?: string) => toolNotInstalled("Appium", path),
     driverListFailed: (detail: string) =>
-      `Could not run \`appium driver list\` (${detail}). ` +
-      `The Appium binary may be broken. ${clearAndRetry}`,
+      toolNotRunnable("Could not run `appium driver list`", detail),
     cannotCheckDriverList: "Cannot check driver list without Appium binary.",
     uiautomator2NotInstalled:
       "uiautomator2 driver not installed. Run `qawolf install android` to install it.",

--- a/src/core/messages/index.ts
+++ b/src/core/messages/index.ts
@@ -4,3 +4,4 @@ export { flowsMessages } from "./flows.js";
 export { initMessages } from "./init.js";
 export { installMessages } from "./install.js";
 export { runnerMessages } from "./runner.js";
+export { packageLoadFailed } from "./toolNotFound.js";

--- a/src/core/messages/install.ts
+++ b/src/core/messages/install.ts
@@ -1,5 +1,7 @@
 import { pluralize } from "~/core/pluralize.js";
 
+import { toolMissingFromDepsRoot } from "./toolNotFound.js";
+
 export const installMessages = {
   noFlowsFound: "No flows requiring installation were found.",
   iosNotSupported: "iOS targets are not supported in v0.1.",
@@ -11,8 +13,8 @@ export const installMessages = {
   installingBrowser: (browser: string) => `Install ${browser}`,
   browsersInstalled: (count: number) =>
     `Installed ${pluralize(count, "browser")}.`,
-  playwrightNotFound:
-    "Could not find Playwright. Install it in your project (`npm install playwright` or `bun add playwright`).",
+  playwrightNotFound: (playwrightPath: string) =>
+    toolMissingFromDepsRoot("Playwright", playwrightPath),
   playwrightInstallFailed: (browser: string, detail: string) =>
     `playwright install ${browser} failed: ${detail}`,
   playwrightInstallLaunchFailed: (browser: string) =>
@@ -49,7 +51,6 @@ export const installMessages = {
     uiautomator2InstallFailed: (detail: string) =>
       `appium driver install uiautomator2 failed: ${detail}`,
     appiumNotFound: (appiumPath: string) =>
-      `appium not found at ${appiumPath}.\n` +
-      `Reinstall the runtime dependencies with \`qawolf install\`.`,
+      toolMissingFromDepsRoot("Appium", appiumPath),
   },
 } as const;

--- a/src/core/messages/install.ts
+++ b/src/core/messages/install.ts
@@ -1,6 +1,6 @@
 import { pluralize } from "~/core/pluralize.js";
 
-import { toolMissingFromDepsRoot } from "./toolNotFound.js";
+import { toolNotInstalled } from "./toolNotFound.js";
 
 export const installMessages = {
   noFlowsFound: "No flows requiring installation were found.",
@@ -14,7 +14,7 @@ export const installMessages = {
   browsersInstalled: (count: number) =>
     `Installed ${pluralize(count, "browser")}.`,
   playwrightNotFound: (playwrightPath: string) =>
-    toolMissingFromDepsRoot("Playwright", playwrightPath),
+    toolNotInstalled("Playwright", playwrightPath),
   playwrightInstallFailed: (browser: string, detail: string) =>
     `playwright install ${browser} failed: ${detail}`,
   playwrightInstallLaunchFailed: (browser: string) =>
@@ -51,6 +51,6 @@ export const installMessages = {
     uiautomator2InstallFailed: (detail: string) =>
       `appium driver install uiautomator2 failed: ${detail}`,
     appiumNotFound: (appiumPath: string) =>
-      toolMissingFromDepsRoot("Appium", appiumPath),
+      toolNotInstalled("Appium", appiumPath),
   },
 } as const;

--- a/src/core/messages/runner.ts
+++ b/src/core/messages/runner.ts
@@ -1,10 +1,10 @@
 import { pluralize } from "~/core/pluralize.js";
 
-import { depsRootIncomplete } from "./toolNotFound.js";
+import { packageLoadFailed } from "./toolNotFound.js";
 
 export const runnerMessages = {
-  playwrightLoadFailed: (depsRoot: string) =>
-    `Could not load Playwright from ${depsRoot}.\n${depsRootIncomplete}`,
+  playwrightLoadFailed: (envDir: string, detail: string) =>
+    packageLoadFailed("Playwright", envDir, detail),
   androidWorkersUnsupported:
     "Android flows are not yet supported with --workers > 1; rerun Android flows with --workers 1.",
   noFlowsMatched: "No flows matched.",

--- a/src/core/messages/runner.ts
+++ b/src/core/messages/runner.ts
@@ -1,6 +1,10 @@
 import { pluralize } from "~/core/pluralize.js";
 
+import { depsRootIncomplete } from "./toolNotFound.js";
+
 export const runnerMessages = {
+  playwrightLoadFailed: (depsRoot: string) =>
+    `Could not load Playwright from ${depsRoot}.\n${depsRootIncomplete}`,
   androidWorkersUnsupported:
     "Android flows are not yet supported with --workers > 1; rerun Android flows with --workers 1.",
   noFlowsMatched: "No flows matched.",

--- a/src/core/messages/toolNotFound.test.ts
+++ b/src/core/messages/toolNotFound.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+
+import { toolMissingFromDepsRoot, toolNotInstalled } from "./toolNotFound.js";
+
+describe("toolNotInstalled", () => {
+  it("names the path it looked for and points at `qawolf install`", () => {
+    expect(
+      toolNotInstalled("Playwright", "/env/node_modules/.bin/playwright"),
+    ).toBe(
+      "Playwright not found at /env/node_modules/.bin/playwright.\n" +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
+  });
+
+  it("keeps the same remedy when no path is known", () => {
+    expect(toolNotInstalled("Appium")).toBe(
+      "Appium is not installed.\n" +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
+  });
+});
+
+describe("toolMissingFromDepsRoot", () => {
+  it("blames the resolved deps root instead of repeating `qawolf install`", () => {
+    expect(
+      toolMissingFromDepsRoot("Appium", "/env/node_modules/.bin/appium"),
+    ).toBe(
+      "Appium not found at /env/node_modules/.bin/appium.\n" +
+        "The resolved dependencies directory is incomplete. " +
+        "Run `qawolf install clear`, then retry.",
+    );
+  });
+});

--- a/src/core/messages/toolNotFound.test.ts
+++ b/src/core/messages/toolNotFound.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { toolNotInstalled, toolNotRunnable } from "./toolNotFound.js";
+import {
+  packageLoadFailed,
+  toolNotInstalled,
+  toolNotRunnable,
+} from "./toolNotFound.js";
 
 describe("toolNotInstalled", () => {
   it("names the path it looked for", () => {
@@ -26,6 +30,17 @@ describe("toolNotRunnable", () => {
       toolNotRunnable("Could not run `appium driver list`", "ENOENT"),
     ).toBe(
       "Could not run `appium driver list` (ENOENT).\n" +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
+  });
+});
+
+describe("packageLoadFailed", () => {
+  it("names the package, the env dir and the underlying detail", () => {
+    expect(
+      packageLoadFailed("@qawolf/emails", "/env", "Package not found"),
+    ).toBe(
+      "Could not load @qawolf/emails from /env (Package not found).\n" +
         "Run `qawolf install` to install the runtime dependencies.",
     );
   });

--- a/src/core/messages/toolNotFound.test.ts
+++ b/src/core/messages/toolNotFound.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { toolMissingFromDepsRoot, toolNotInstalled } from "./toolNotFound.js";
+import { toolNotInstalled, toolNotRunnable } from "./toolNotFound.js";
 
 describe("toolNotInstalled", () => {
-  it("names the path it looked for and points at `qawolf install`", () => {
+  it("names the path it looked for", () => {
     expect(
       toolNotInstalled("Playwright", "/env/node_modules/.bin/playwright"),
     ).toBe(
@@ -20,14 +20,13 @@ describe("toolNotInstalled", () => {
   });
 });
 
-describe("toolMissingFromDepsRoot", () => {
-  it("blames the resolved deps root instead of repeating `qawolf install`", () => {
+describe("toolNotRunnable", () => {
+  it("keeps the failure detail and gives the same remedy", () => {
     expect(
-      toolMissingFromDepsRoot("Appium", "/env/node_modules/.bin/appium"),
+      toolNotRunnable("Could not run `appium driver list`", "ENOENT"),
     ).toBe(
-      "Appium not found at /env/node_modules/.bin/appium.\n" +
-        "The resolved dependencies directory is incomplete. " +
-        "Run `qawolf install clear`, then retry.",
+      "Could not run `appium driver list` (ENOENT).\n" +
+        "Run `qawolf install` to install the runtime dependencies.",
     );
   });
 });

--- a/src/core/messages/toolNotFound.ts
+++ b/src/core/messages/toolNotFound.ts
@@ -1,0 +1,22 @@
+const installRemedy =
+  "Run `qawolf install` to install the runtime dependencies.";
+
+export const clearAndRetry = "Run `qawolf install clear`, then retry.";
+
+// Callers reached after the deps root resolved cannot tell the user to run
+// `qawolf install` — that is the step which already ran.
+export const depsRootIncomplete = `The resolved dependencies directory is incomplete. ${clearAndRetry}`;
+
+function located(tool: string, path: string | undefined): string {
+  return path === undefined
+    ? `${tool} is not installed.`
+    : `${tool} not found at ${path}.`;
+}
+
+export function toolNotInstalled(tool: string, path?: string): string {
+  return `${located(tool, path)}\n${installRemedy}`;
+}
+
+export function toolMissingFromDepsRoot(tool: string, path: string): string {
+  return `${located(tool, path)}\n${depsRootIncomplete}`;
+}

--- a/src/core/messages/toolNotFound.ts
+++ b/src/core/messages/toolNotFound.ts
@@ -1,22 +1,22 @@
 const installRemedy =
   "Run `qawolf install` to install the runtime dependencies.";
 
-export const clearAndRetry = "Run `qawolf install clear`, then retry.";
-
-// Callers reached after the deps root resolved cannot tell the user to run
-// `qawolf install` — that is the step which already ran.
-export const depsRootIncomplete = `The resolved dependencies directory is incomplete. ${clearAndRetry}`;
-
-function located(tool: string, path: string | undefined): string {
-  return path === undefined
-    ? `${tool} is not installed.`
-    : `${tool} not found at ${path}.`;
-}
-
 export function toolNotInstalled(tool: string, path?: string): string {
-  return `${located(tool, path)}\n${installRemedy}`;
+  const located =
+    path === undefined
+      ? `${tool} is not installed.`
+      : `${tool} not found at ${path}.`;
+  return `${located}\n${installRemedy}`;
 }
 
-export function toolMissingFromDepsRoot(tool: string, path: string): string {
-  return `${located(tool, path)}\n${depsRootIncomplete}`;
+export function toolNotRunnable(what: string, detail: string): string {
+  return `${what} (${detail}).\n${installRemedy}`;
+}
+
+export function packageLoadFailed(
+  pkg: string,
+  envDir: string,
+  detail: string,
+): string {
+  return toolNotRunnable(`Could not load ${pkg} from ${envDir}`, detail);
 }

--- a/src/domains/doctor/checks/androidAppium.test.ts
+++ b/src/domains/doctor/checks/androidAppium.test.ts
@@ -85,7 +85,7 @@ describe("checkAndroid: appium and uiautomator2-driver", () => {
     expect(driver?.detail).toContain("ENOENT");
     // Must NOT recommend `qawolf install android` since Appium itself is broken.
     expect(driver?.detail).not.toContain("qawolf install android");
-    expect(driver?.detail).toContain("Run `qawolf install clear`, then retry.");
+    expect(driver?.detail).toContain("Run `qawolf install`");
     expect(driver?.detail).not.toContain("qawolf flows run");
   });
 

--- a/src/domains/doctor/checks/androidAppium.test.ts
+++ b/src/domains/doctor/checks/androidAppium.test.ts
@@ -21,7 +21,10 @@ describe("checkAndroid: appium and uiautomator2-driver", () => {
     const appium = findResult(results, "appium");
     const driver = findResult(results, "uiautomator2-driver");
     expect(appium?.status).toBe("warn");
-    expect(appium?.detail).toContain("qawolf flows run");
+    expect(appium?.detail).toBe(
+      "Appium is not installed.\n" +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
     expect(driver?.status).toBe("warn");
   });
 
@@ -30,7 +33,10 @@ describe("checkAndroid: appium and uiautomator2-driver", () => {
     const results = await checkAndroid(baseDeps({ checkExists }));
     const appium = findResult(results, "appium");
     expect(appium?.status).toBe("warn");
-    expect(appium?.detail).toContain(appiumBin);
+    expect(appium?.detail).toBe(
+      `Appium not found at ${appiumBin}.\n` +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
   });
 
   it("passes uiautomator2-driver when 'appium driver list' output mentions uiautomator2", async () => {
@@ -79,6 +85,8 @@ describe("checkAndroid: appium and uiautomator2-driver", () => {
     expect(driver?.detail).toContain("ENOENT");
     // Must NOT recommend `qawolf install android` since Appium itself is broken.
     expect(driver?.detail).not.toContain("qawolf install android");
+    expect(driver?.detail).toContain("Run `qawolf install clear`, then retry.");
+    expect(driver?.detail).not.toContain("qawolf flows run");
   });
 
   it("warns uiautomator2-driver with an Appium-failure message when the driver list exits non-zero", async () => {

--- a/src/domains/doctor/checks/androidAppium.ts
+++ b/src/domains/doctor/checks/androidAppium.ts
@@ -23,24 +23,14 @@ export function checkAppium(
   platform: NodeJS.Platform,
   checkExists: (path: string) => boolean,
 ): { appium: CheckResult; bin: string | undefined } {
-  if (!envDir) {
-    return {
-      appium: {
-        name: "appium",
-        status: "warn",
-        detail: doctorMessages.appium.noEnvDir,
-      },
-      bin: undefined,
-    };
-  }
-  const candidates = appiumCliCandidates(envDir, platform);
+  const candidates = envDir ? appiumCliCandidates(envDir, platform) : [];
   const bin = candidates.find(checkExists);
   if (!bin) {
     return {
       appium: {
         name: "appium",
         status: "warn",
-        detail: doctorMessages.appium.binaryMissing(candidates[0] ?? envDir),
+        detail: doctorMessages.appium.notFound(candidates[0]),
       },
       bin: undefined,
     };

--- a/src/domains/doctor/checks/playwright.test.ts
+++ b/src/domains/doctor/checks/playwright.test.ts
@@ -75,7 +75,10 @@ describe("checkPlaywright", () => {
       checkExists: () => true,
     });
     expect(r.status).toBe("fail");
-    expect(r.detail).toContain("Could not find");
+    expect(r.detail).toBe(
+      "Playwright is not installed.\n" +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
     expect(spawn).not.toHaveBeenCalled();
   });
 
@@ -90,7 +93,10 @@ describe("checkPlaywright", () => {
       checkExists: () => false,
     });
     expect(r.status).toBe("fail");
-    expect(r.detail).toContain("Could not find");
+    expect(r.detail).toBe(
+      `Playwright not found at ${fakeCli}.\n` +
+        "Run `qawolf install` to install the runtime dependencies.",
+    );
     expect(spawn).not.toHaveBeenCalled();
   });
 

--- a/src/domains/doctor/checks/playwright.ts
+++ b/src/domains/doctor/checks/playwright.ts
@@ -14,15 +14,16 @@ type PlaywrightDeps = {
 export async function checkPlaywright(
   deps: PlaywrightDeps,
 ): Promise<CheckResult> {
-  const cliPath = deps.envDir
-    ? playwrightCliCandidates(deps.envDir, deps.platform).find(deps.checkExists)
-    : undefined;
+  const candidates = deps.envDir
+    ? playwrightCliCandidates(deps.envDir, deps.platform)
+    : [];
+  const cliPath = candidates.find(deps.checkExists);
 
   if (cliPath === undefined) {
     return {
       name: "playwright",
       status: "fail",
-      detail: doctorMessages.playwright.notFound,
+      detail: doctorMessages.playwright.notFound(candidates[0]),
     };
   }
 

--- a/src/domains/emails/configureEmails.test.ts
+++ b/src/domains/emails/configureEmails.test.ts
@@ -126,3 +126,22 @@ describe("configureEmails", () => {
     expect((caughtError as Error).message).toBe("registration failed");
   });
 });
+
+describe("configureEmails: load failure", () => {
+  it("names the env dir and points at `qawolf install`", async () => {
+    let caught: unknown;
+    try {
+      await configureEmails({ emailerUrl: "https://x" }, "/nonexistent/env");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toStartWith(
+      "Could not load @qawolf/emails from /nonexistent/env (",
+    );
+    expect((caught as Error).message).toEndWith(
+      "Run `qawolf install` to install the runtime dependencies.",
+    );
+  });
+});

--- a/src/domains/emails/configureEmails.ts
+++ b/src/domains/emails/configureEmails.ts
@@ -5,6 +5,8 @@ import type {
 } from "@qawolf/emails";
 
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
+import { packageLoadFailed } from "~/core/messages/index.js";
+import { errorMessage } from "~/core/errors.js";
 
 type EmailsModule = {
   createEmailsClient: typeof createEmailsClient;
@@ -27,7 +29,7 @@ async function loadSdkDeps(cwd: string): Promise<EmailsModule> {
     return (await import(emailsPath)) as EmailsModule;
   } catch (err) {
     throw new Error(
-      "Could not load @qawolf/emails. Install it in your project: `npm install @qawolf/emails` or `bun add @qawolf/emails`.",
+      packageLoadFailed("@qawolf/emails", cwd, errorMessage(err)),
       { cause: err },
     );
   }

--- a/src/domains/install/android/driver.test.ts
+++ b/src/domains/install/android/driver.test.ts
@@ -126,9 +126,7 @@ describe("installUiautomator2Driver", () => {
     }
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toContain("Appium not found at ");
-    expect((caught as Error).message).toContain(
-      "Run `qawolf install clear`, then retry.",
-    );
+    expect((caught as Error).message).toContain("Run `qawolf install`");
     expect(calls).toHaveLength(0);
   });
 

--- a/src/domains/install/android/driver.test.ts
+++ b/src/domains/install/android/driver.test.ts
@@ -125,7 +125,10 @@ describe("installUiautomator2Driver", () => {
       caught = e;
     }
     expect(caught).toBeInstanceOf(Error);
-    expect((caught as Error).message).toContain("appium not found");
+    expect((caught as Error).message).toContain("Appium not found at ");
+    expect((caught as Error).message).toContain(
+      "Run `qawolf install clear`, then retry.",
+    );
     expect(calls).toHaveLength(0);
   });
 

--- a/src/domains/install/browsers.test.ts
+++ b/src/domains/install/browsers.test.ts
@@ -31,10 +31,10 @@ describe("installBrowserList", () => {
       caught = e;
     }
 
+    expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe(
       `Playwright not found at ${playwrightBin}.\n` +
-        "The resolved dependencies directory is incomplete. " +
-        "Run `qawolf install clear`, then retry.",
+        "Run `qawolf install` to install the runtime dependencies.",
     );
   });
 });

--- a/src/domains/install/browsers.test.ts
+++ b/src/domains/install/browsers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import type { CommandContext } from "~/shell/commandContext.js";
+import type { SpawnFn } from "~/shell/spawn.js";
+
+import { installBrowserList } from "./browsers.js";
+
+const envDir = "/fake/env";
+const playwrightBin = join(envDir, "node_modules", ".bin", "playwright");
+
+const ctx = {
+  ui: { withProgress: () => Promise.resolve() },
+} as unknown as CommandContext;
+
+const spawn: SpawnFn = () =>
+  Promise.resolve({ exitCode: 0, stdout: "", stderr: "" });
+
+describe("installBrowserList", () => {
+  it("blames the resolved deps root when the Playwright shim is missing", async () => {
+    let caught: unknown;
+    try {
+      await installBrowserList(ctx, ["chromium"], {
+        spawn,
+        platform: "linux",
+        browserDeps: false,
+        envDir,
+        checkExists: () => false,
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect((caught as Error).message).toBe(
+      `Playwright not found at ${playwrightBin}.\n` +
+        "The resolved dependencies directory is incomplete. " +
+        "Run `qawolf install clear`, then retry.",
+    );
+  });
+});

--- a/src/domains/install/browsers.ts
+++ b/src/domains/install/browsers.ts
@@ -37,10 +37,13 @@ export async function installBrowserList(
   browsers: BrowserName[],
   deps: InstallBrowserListDeps,
 ): Promise<void> {
-  const cliPath = playwrightCliCandidates(deps.envDir, deps.platform).find(
-    deps.checkExists,
-  );
-  if (!cliPath) throw new Error(installMessages.playwrightNotFound);
+  const candidates = playwrightCliCandidates(deps.envDir, deps.platform);
+  const cliPath = candidates.find(deps.checkExists);
+  if (!cliPath) {
+    throw new Error(
+      installMessages.playwrightNotFound(candidates[0] ?? deps.envDir),
+    );
+  }
 
   await ctx.ui.withProgress(
     browsers.map((browser) => ({

--- a/src/domains/runner/runWebFlowDeps.test.ts
+++ b/src/domains/runner/runWebFlowDeps.test.ts
@@ -5,18 +5,21 @@ import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.j
 import { defaultRunWebFlowDeps } from "./runWebFlowDeps.js";
 
 describe("defaultRunWebFlowDeps", () => {
-  it("blames the resolved deps root when Playwright cannot be loaded", async () => {
+  it("names the env dir and the underlying cause when Playwright cannot load", async () => {
     let caught: unknown;
     try {
-      await defaultRunWebFlowDeps("/nonexistent/project", makeNoopSignals());
+      await defaultRunWebFlowDeps("/nonexistent/env", makeNoopSignals());
     } catch (e) {
       caught = e;
     }
 
-    expect((caught as Error).message).toBe(
-      "Could not load Playwright from /nonexistent/project.\n" +
-        "The resolved dependencies directory is incomplete. " +
-        "Run `qawolf install clear`, then retry.",
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toStartWith(
+      "Could not load Playwright from /nonexistent/env (",
     );
+    expect((caught as Error).message).toEndWith(
+      "Run `qawolf install` to install the runtime dependencies.",
+    );
+    expect((caught as Error).cause).toBeDefined();
   });
 });

--- a/src/domains/runner/runWebFlowDeps.test.ts
+++ b/src/domains/runner/runWebFlowDeps.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+
+import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
+
+import { defaultRunWebFlowDeps } from "./runWebFlowDeps.js";
+
+describe("defaultRunWebFlowDeps", () => {
+  it("blames the resolved deps root when Playwright cannot be loaded", async () => {
+    let caught: unknown;
+    try {
+      await defaultRunWebFlowDeps("/nonexistent/project", makeNoopSignals());
+    } catch (e) {
+      caught = e;
+    }
+
+    expect((caught as Error).message).toBe(
+      "Could not load Playwright from /nonexistent/project.\n" +
+        "The resolved dependencies directory is incomplete. " +
+        "Run `qawolf install clear`, then retry.",
+    );
+  });
+});

--- a/src/domains/runner/runWebFlowDeps.ts
+++ b/src/domains/runner/runWebFlowDeps.ts
@@ -2,6 +2,7 @@ import { createRunnerDeps } from "./runnerDeps.js";
 import type { RunWebFlowDeps } from "./runWebFlow.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
+import { runnerMessages } from "~/core/messages/index.js";
 
 export async function defaultRunWebFlowDeps(
   cwd = process.cwd(),
@@ -24,10 +25,7 @@ export async function defaultRunWebFlowDeps(
       "chromium" | "firefox" | "webkit"
     >;
   } catch (err) {
-    throw new Error(
-      "Could not load Playwright. Install it in your project: `npm install playwright` or `bun add playwright`.",
-      { cause: err },
-    );
+    throw new Error(runnerMessages.playwrightLoadFailed(cwd), { cause: err });
   }
   const { chromium, firefox, webkit } = playwright;
   return {

--- a/src/domains/runner/runWebFlowDeps.ts
+++ b/src/domains/runner/runWebFlowDeps.ts
@@ -3,9 +3,10 @@ import type { RunWebFlowDeps } from "./runWebFlow.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
 import { runnerMessages } from "~/core/messages/index.js";
+import { errorMessage } from "~/core/errors.js";
 
 export async function defaultRunWebFlowDeps(
-  cwd = process.cwd(),
+  envDir = process.cwd(),
   signals: SignalRegistry,
 ): Promise<RunWebFlowDeps> {
   // Loaded via resolveFromEnvDir + import() so the binary finds playwright in
@@ -19,19 +20,24 @@ export async function defaultRunWebFlowDeps(
   // (the runner only reads .path() / .delete() on the video).
   let playwright: Pick<RunWebFlowDeps, "chromium" | "firefox" | "webkit">;
   try {
-    const playwrightPath = resolveFromEnvDir(cwd, "playwright");
+    const playwrightPath = resolveFromEnvDir(envDir, "playwright");
     playwright = (await import(playwrightPath)) as Pick<
       RunWebFlowDeps,
       "chromium" | "firefox" | "webkit"
     >;
   } catch (err) {
-    throw new Error(runnerMessages.playwrightLoadFailed(cwd), { cause: err });
+    throw new Error(
+      runnerMessages.playwrightLoadFailed(envDir, errorMessage(err)),
+      {
+        cause: err,
+      },
+    );
   }
   const { chromium, firefox, webkit } = playwright;
   return {
     chromium,
     firefox,
     webkit,
-    ...createRunnerDeps(signals, cwd),
+    ...createRunnerDeps(signals, envDir),
   };
 }

--- a/src/domains/runtimeEnv/ensureRuntimeEnv.test.ts
+++ b/src/domains/runtimeEnv/ensureRuntimeEnv.test.ts
@@ -17,6 +17,7 @@ function seedFullEnv(fs: ReturnType<typeof makeMemoryFs>, dir: string): void {
   const binDir = join(dir, "node_modules", ".bin");
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(join(binDir, "playwright"), "#!/bin/sh");
+  fs.writeFileSync(join(binDir, "appium"), "#!/bin/sh");
 }
 
 function makeNoopInstall() {

--- a/src/domains/runtimeEnv/installPinned.test.ts
+++ b/src/domains/runtimeEnv/installPinned.test.ts
@@ -14,7 +14,7 @@ function makeSpawnInstall(exitCode: number, stderr = "") {
 }
 
 // Seeds a dir so allPinnedResolved returns true: every pinned package at its
-// exact version plus the .bin/playwright shim.
+// exact version plus the .bin CLI shims.
 function seedFullEnv(fs: ReturnType<typeof makeMemoryFs>, dir: string): void {
   for (const { name, version } of pinnedPackages) {
     const pkgDir = join(dir, "node_modules", ...name.split("/"));
@@ -24,6 +24,7 @@ function seedFullEnv(fs: ReturnType<typeof makeMemoryFs>, dir: string): void {
   const binDir = join(dir, "node_modules", ".bin");
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(join(binDir, "playwright"), "#!/bin/sh");
+  fs.writeFileSync(join(binDir, "appium"), "#!/bin/sh");
 }
 
 describe("installPinned", () => {

--- a/src/domains/runtimeEnv/installPinned.ts
+++ b/src/domains/runtimeEnv/installPinned.ts
@@ -42,7 +42,7 @@ export async function installPinned(
   await shimFlowsDeps(tempDir, deps.fs);
 
   // Atomic publish: the first shard to rename wins; others detect the completed
-  // .bin/playwright shim and quietly remove their own temp dir.
+  // CLI shims and quietly remove their own temp dir.
   try {
     await deps.fs.rename(tempDir, targetDir);
   } catch (err) {

--- a/src/domains/runtimeEnv/resolveDepsRootIfPresent.test.ts
+++ b/src/domains/runtimeEnv/resolveDepsRootIfPresent.test.ts
@@ -16,6 +16,7 @@ function seedFullEnv(fs: ReturnType<typeof makeMemoryFs>, dir: string): void {
   const binDir = join(dir, "node_modules", ".bin");
   fs.mkdirSync(binDir, { recursive: true });
   fs.writeFileSync(join(binDir, "playwright"), "#!/bin/sh");
+  fs.writeFileSync(join(binDir, "appium"), "#!/bin/sh");
 }
 
 describe("resolveDepsRootIfPresent", () => {

--- a/src/domains/runtimeEnv/resolvePinned.test.ts
+++ b/src/domains/runtimeEnv/resolvePinned.test.ts
@@ -77,7 +77,7 @@ function seedShim(
 }
 
 describe("allPinnedResolved", () => {
-  it("returns true when all packages match and .bin/playwright exists", () => {
+  it("returns true when all packages match and both shims exist", () => {
     const fs = makeMemoryFs();
     seedAllPackages(fs);
 
@@ -97,12 +97,12 @@ describe("allPinnedResolved", () => {
     expect(allPinnedResolved(dir, fs, "linux")).toBe(false);
   });
 
-  it("returns false when .bin/playwright shim is absent", () => {
+  it("returns false when the .bin/playwright shim is absent", () => {
     const fs = makeMemoryFs();
     for (const { name, version } of pinnedPackages) {
       seedPackage(fs, name, version);
     }
-    // No .bin/playwright
+    seedShim(fs, "appium", "#!/bin/sh");
 
     expect(allPinnedResolved(dir, fs, "linux")).toBe(false);
   });
@@ -119,7 +119,7 @@ describe("allPinnedResolved", () => {
     expect(allPinnedResolved(dir, fs, "linux")).toBe(false);
   });
 
-  it("returns true when only the Windows .bin/playwright.cmd shim exists", () => {
+  it("returns true when only the Windows .cmd shims exist", () => {
     const fs = makeMemoryFs();
     for (const { name, version } of pinnedPackages) {
       seedPackage(fs, name, version);
@@ -130,7 +130,7 @@ describe("allPinnedResolved", () => {
     expect(allPinnedResolved(dir, fs, "win32")).toBe(true);
   });
 
-  it("returns true when only the Windows .bin/playwright.exe shim exists", () => {
+  it("returns true when only the Windows .exe shims exist", () => {
     const fs = makeMemoryFs();
     for (const { name, version } of pinnedPackages) {
       seedPackage(fs, name, version);

--- a/src/domains/runtimeEnv/resolvePinned.test.ts
+++ b/src/domains/runtimeEnv/resolvePinned.test.ts
@@ -23,10 +23,9 @@ function seedAllPackages(fs: ReturnType<typeof makeMemoryFs>): void {
     seedPackage(fs, name, version);
   }
   fs.mkdirSync(join(dir, "node_modules", ".bin"), { recursive: true });
-  fs.writeFileSync(
-    join(dir, "node_modules", ".bin", "playwright"),
-    "#!/bin/sh",
-  );
+  for (const name of ["playwright", "appium"]) {
+    fs.writeFileSync(join(dir, "node_modules", ".bin", name), "#!/bin/sh");
+  }
 }
 
 describe("readInstalledVersion", () => {
@@ -108,12 +107,25 @@ describe("allPinnedResolved", () => {
     expect(allPinnedResolved(dir, fs, "linux")).toBe(false);
   });
 
+  it("returns false when the .bin/appium shim is absent", () => {
+    const fs = makeMemoryFs();
+    for (const { name, version } of pinnedPackages) {
+      seedPackage(fs, name, version);
+    }
+    seedShim(fs, "playwright", "#!/bin/sh");
+    // No .bin/appium — the state that used to leave a resolved root with no
+    // runnable Appium, so `flows run` failed after install reported success.
+
+    expect(allPinnedResolved(dir, fs, "linux")).toBe(false);
+  });
+
   it("returns true when only the Windows .bin/playwright.cmd shim exists", () => {
     const fs = makeMemoryFs();
     for (const { name, version } of pinnedPackages) {
       seedPackage(fs, name, version);
     }
     seedShim(fs, "playwright.cmd", "@echo off");
+    seedShim(fs, "appium.cmd", "@echo off");
 
     expect(allPinnedResolved(dir, fs, "win32")).toBe(true);
   });
@@ -124,6 +136,7 @@ describe("allPinnedResolved", () => {
       seedPackage(fs, name, version);
     }
     seedShim(fs, "playwright.exe", "MZ");
+    seedShim(fs, "appium.exe", "MZ");
 
     expect(allPinnedResolved(dir, fs, "win32")).toBe(true);
   });

--- a/src/domains/runtimeEnv/resolvePinned.ts
+++ b/src/domains/runtimeEnv/resolvePinned.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 
+import { appiumCliCandidates } from "~/core/appiumBins.js";
 import { playwrightCliCandidates } from "~/core/playwrightBins.js";
 import type { Fs } from "~/shell/fs.js";
 
@@ -32,18 +33,21 @@ export function readInstalledVersion(
 
 /**
  * Returns true when every pinned package is installed at its exact pinned
- * version AND a Playwright shim exists (required by installBrowserList).
+ * version AND both CLI shims exist. A matching package version does not imply
+ * a runnable shim, so checking versions alone can resolve a root that later
+ * fails to spawn the binary.
  */
 export function allPinnedResolved(
   dir: string,
   fs: Fs,
   platform: NodeJS.Platform,
 ): boolean {
-  // Same list installBrowserList resolves from, so the two cannot disagree.
-  const hasPlaywrightShim = playwrightCliCandidates(dir, platform).some(
-    (path) => fs.existsSync(path),
+  // The same candidate lists installBrowserList and createAppiumServer resolve
+  // from, so this check and those two cannot disagree.
+  const shimsPresent = [playwrightCliCandidates, appiumCliCandidates].every(
+    (candidates) => candidates(dir, platform).some((p) => fs.existsSync(p)),
   );
-  if (!hasPlaywrightShim) {
+  if (!shimsPresent) {
     return false;
   }
   return pinnedPackages.every(

--- a/src/shell/appium/createAppiumServer.test.ts
+++ b/src/shell/appium/createAppiumServer.test.ts
@@ -211,8 +211,7 @@ describe("createAppiumServer", () => {
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe(
       `Appium not found at ${join("/fake/env", "node_modules", ".bin", "appium")}.\n` +
-        "The resolved dependencies directory is incomplete. " +
-        "Run `qawolf install clear`, then retry.",
+        "Run `qawolf install` to install the runtime dependencies.",
     );
     expect(spawnCalls).toEqual([]);
   });

--- a/src/shell/appium/createAppiumServer.test.ts
+++ b/src/shell/appium/createAppiumServer.test.ts
@@ -210,8 +210,9 @@ describe("createAppiumServer", () => {
     }
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toBe(
-      `appium not found at ${join("/fake/env", "node_modules", ".bin", "appium")}.\n` +
-        "Reinstall the runtime dependencies with `qawolf install`.",
+      `Appium not found at ${join("/fake/env", "node_modules", ".bin", "appium")}.\n` +
+        "The resolved dependencies directory is incomplete. " +
+        "Run `qawolf install clear`, then retry.",
     );
     expect(spawnCalls).toEqual([]);
   });

--- a/src/shell/testkit.test.ts
+++ b/src/shell/testkit.test.ts
@@ -171,3 +171,22 @@ describe("configureTestkit", () => {
     expect((caughtError as Error).message).toBe("registration failed");
   });
 });
+
+describe("configureTestkit: load failure", () => {
+  it("names the env dir and points at `qawolf install`", async () => {
+    let caught: unknown;
+    try {
+      await configureTestkit("/nonexistent/env");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toStartWith(
+      "Could not load @qawolf/testkit from /nonexistent/env (",
+    );
+    expect((caught as Error).message).toEndWith(
+      "Run `qawolf install` to install the runtime dependencies.",
+    );
+  });
+});

--- a/src/shell/testkit.ts
+++ b/src/shell/testkit.ts
@@ -4,6 +4,8 @@ import type { configureTestkitClient } from "@qawolf/testkit";
 
 import { runnerMessages } from "~/core/messages/index.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
+import { packageLoadFailed } from "~/core/messages/index.js";
+import { errorMessage } from "~/core/errors.js";
 type TestkitModule = {
   createTestkitClient: typeof createTestkitClient;
   configureTestkitClient: typeof configureTestkitClient;
@@ -46,7 +48,7 @@ async function loadSdkDeps(cwd: string): Promise<TestkitModule> {
     };
   } catch (err) {
     throw new Error(
-      "Could not load @qawolf/testkit. Install it in your project: `npm install @qawolf/testkit` or `bun add @qawolf/testkit`.",
+      packageLoadFailed("@qawolf/testkit", cwd, errorMessage(err)),
       { cause: err },
     );
   }


### PR DESCRIPTION
Relates to [WIZ-11284](https://linear.app/qawolf/issue/WIZ-11284/five-could-not-find-the-tool-messages-with-four-different-remedies)

# Overview of Changes

Ten messages described one state — a pinned binary missing from the resolved deps root — and gave four different remedies between them. Two told the user to `npm install playwright`, which is wrong: the CLI pins and installs playwright and appium itself, so a user's project never needs a copy. Every site now names the path it looked for and gives one remedy, `qawolf install`.

Getting there needed a resolution fix first. `allPinnedResolved` required the playwright shim but checked only appium's package *version*, and a matching version does not imply a runnable shim — so a partial install resolved as complete and `flows run` failed to spawn appium after install had reported success. Requiring both shims makes that state self-heal, which is what lets every caller give the same remedy instead of splitting on whether it can safely say "run `qawolf install`". Kept as three commits: the original two-variant pass, the shim fix, then the collapse.

The ticket listed five messages; the sweep found ten. `@qawolf/emails` and `@qawolf/testkit` carried the same wrong `npm install` advice for packages the CLI pins, and neither had a test. `moduleNotFoundHint` keeps its `npm install` advice on purpose — that one is about a user's own flow dependency.

# Testing

All ten failure paths were driven against an empty deps directory and the rendered output read by hand, not just asserted in tests. Four seams gained first-time coverage: `installBrowserList`, `defaultRunWebFlowDeps`, `configureEmails`, and `configureTestkit`.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test    # 1239 pass
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

`allPinnedResolved` is stricter, so a deps root whose appium shim is missing but whose package version matches no longer resolves. That root previously produced a runtime spawn failure, so the change trades a late failure for an install. This also tightens what `qawolf flows run --deps <dir>` accepts: a prepared directory now needs the appium shim, not just a matching appium version. `ensureRuntimeEnv.ts:56` rejects such a directory without naming the missing packages — left out of scope and tracked separately.
