### PR TITLE
fix(cli): drop the unlaunchable extension-less shim on Windows

### DIFF
--- a/.changeset/windows-drop-extensionless-shim.md
+++ b/.changeset/windows-drop-extensionless-shim.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Stop accepting the extension-less Playwright and Appium shims on Windows. Windows cannot launch those shims. `CreateProcess` reports `ENOENT` for a path with no executable extension, even when the file is present. The CLI still counted such a shim as usable. So `qawolf doctor` reported Playwright as installed, and `qawolf flows run` then failed with an error naming a file the user can see on disk. The runtime check also read such a directory as fully installed. The CLI now looks only for the `.cmd` and `.exe` shims on Windows. A project directory that holds only the extension-less shim is now rejected, and the CLI installs its managed runtime instead. This affects a `node_modules` directory installed on Linux or macOS and then used from Windows, through a bind mount, a copied tree, or WSL. A project installed on Windows by npm or bun is unaffected.

--- a/src/core/appiumBins.test.ts
+++ b/src/core/appiumBins.test.ts
@@ -16,11 +16,10 @@ describe("appiumCliCandidates", () => {
     ]);
   });
 
-  it("includes the bun-written .exe on win32, after the npm .cmd shim", () => {
+  it("lists the npm .cmd then the bun .exe on win32, and nothing else", () => {
     expect(appiumCliCandidates(envDir, "win32")).toEqual([
       join(binDir, "appium.cmd"),
       join(binDir, "appium.exe"),
-      join(binDir, "appium"),
     ]);
   });
 });

--- a/src/core/appiumBins.ts
+++ b/src/core/appiumBins.ts
@@ -1,13 +1,14 @@
 import { join } from "node:path";
 
-// Windows cannot execute the extension-less POSIX shim. The package managers
-// write different Windows shims: npm a .cmd, bun an .exe.
+// Windows cannot execute the extension-less POSIX shim. CreateProcess reports
+// ENOENT for it. The package managers write different Windows shims: npm a
+// .cmd, bun an .exe.
 export function appiumCliCandidates(
   envDir: string,
   platform: NodeJS.Platform,
 ): string[] {
   const binDir = join(envDir, "node_modules", ".bin");
   const names =
-    platform === "win32" ? ["appium.cmd", "appium.exe", "appium"] : ["appium"];
+    platform === "win32" ? ["appium.cmd", "appium.exe"] : ["appium"];
   return names.map((name) => join(binDir, name));
 }

--- a/src/core/playwrightBins.test.ts
+++ b/src/core/playwrightBins.test.ts
@@ -16,11 +16,10 @@ describe("playwrightCliCandidates", () => {
     ]);
   });
 
-  it("includes the bun-written .exe on win32, after the npm .cmd shim", () => {
+  it("lists the npm .cmd then the bun .exe on win32, and nothing else", () => {
     expect(playwrightCliCandidates(envDir, "win32")).toEqual([
       join(binDir, "playwright.cmd"),
       join(binDir, "playwright.exe"),
-      join(binDir, "playwright"),
     ]);
   });
 });

--- a/src/core/playwrightBins.ts
+++ b/src/core/playwrightBins.ts
@@ -1,7 +1,8 @@
 import { join } from "node:path";
 
-// Windows cannot execute the extension-less POSIX shim. The package managers
-// write different Windows shims: npm a .cmd, bun an .exe.
+// Windows cannot execute the extension-less POSIX shim. CreateProcess reports
+// ENOENT for it. The package managers write different Windows shims: npm a
+// .cmd, bun an .exe.
 export function playwrightCliCandidates(
   envDir: string,
   platform: NodeJS.Platform,
@@ -9,7 +10,7 @@ export function playwrightCliCandidates(
   const binDir = join(envDir, "node_modules", ".bin");
   const names =
     platform === "win32"
-      ? ["playwright.cmd", "playwright.exe", "playwright"]
+      ? ["playwright.cmd", "playwright.exe"]
       : ["playwright"];
   return names.map((name) => join(binDir, name));
 }

--- a/src/domains/runtimeEnv/resolvePinned.test.ts
+++ b/src/domains/runtimeEnv/resolvePinned.test.ts
@@ -128,6 +128,18 @@ describe("allPinnedResolved", () => {
     expect(allPinnedResolved(dir, fs, "win32")).toBe(true);
   });
 
+  // CreateProcess reports ENOENT for the extension-less shim, measured on
+  // windows-latest in WIZ-11286.
+  it("returns false on win32 when only the extension-less POSIX shim exists", () => {
+    const fs = makeMemoryFs();
+    for (const { name, version } of pinnedPackages) {
+      seedPackage(fs, name, version);
+    }
+    seedShim(fs, "playwright", "#!/bin/sh");
+
+    expect(allPinnedResolved(dir, fs, "win32")).toBe(false);
+  });
+
   it("ignores a .cmd shim off win32", () => {
     const fs = makeMemoryFs();
     for (const { name, version } of pinnedPackages) {


### PR DESCRIPTION
The win32 candidate lists ended with the extension-less POSIX shim. A probe on `windows-latest` showed `CreateProcess` reports `ENOENT` for that path even though the file exists, so the entry was never a working route — it let `allPinnedResolved` accept a directory the CLI could not launch from, which turned a clear "not found" into an obscure failure naming a file the user can see.

Removing it is a behavior change, not a cleanup: a project dir holding only that shim is now rejected, so the run falls back to the managed runtime and npm writes a `.cmd`. Measurements and the full reasoning are on the ticket.

Resolves WIZ-11286