### PR TITLE
fix(clients): report a request that ran out of time as a timeout

### DIFF
--- a/.changeset/patient-requests-explain.md
+++ b/.changeset/patient-requests-explain.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": patch
+---
+
+A request that runs out of time now says it timed out and how long it waited, instead of reporting an unreachable host and sending you to check your network and `QAWOLF_HOST_URL`.
+
+Behind that, a call can now carry its own deadline rather than sharing one fifteen-second limit with everything else. Nothing changes for calls the platform answers from its database, which is all of them today; the endpoints whose work genuinely takes longer can ask for the time they need.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,9 @@ src/
 │   ├── androidBins.ts   # Android SDK binary paths per platform
 │   ├── androidTargets.ts # Android target parsing helpers
 │   ├── batchMap.ts      # bounded-concurrency async map
-│   ├── errors.ts        # errorMessage, isNoEntError
+│   ├── errors.ts        # errorMessage, isNoEntError, isTimeoutError
 │   ├── flowMeta.ts      # extractFlowMeta, targetToBrowser, flowBasename
+│   ├── formatSeconds.ts # formatSeconds
 │   ├── messages/        # user-facing strings (auth, doctor, flows, init, install, runner)
 │   ├── nodeModulesBins.ts # node_modules/.bin shim candidates per platform
 │   ├── paths.ts         # getConfigDir

--- a/src/core/errors.test.ts
+++ b/src/core/errors.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it } from "bun:test";
 
-import { errorCode, extractMissingPackage, isNoEntError } from "./errors.js";
+import {
+  errorCode,
+  extractMissingPackage,
+  isNoEntError,
+  isTimeoutError,
+} from "./errors.js";
+
+describe("isTimeoutError", () => {
+  it("recognizes the abort a reached AbortSignal.timeout throws", () => {
+    expect(
+      isTimeoutError(
+        new DOMException("The operation timed out.", "TimeoutError"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not claim a failed connection or a caller's abort", () => {
+    expect(isTimeoutError(new TypeError("fetch failed"))).toBe(false);
+    expect(
+      isTimeoutError(
+        new DOMException("This operation was aborted", "AbortError"),
+      ),
+    ).toBe(false);
+    expect(isTimeoutError("TimeoutError")).toBe(false);
+  });
+});
 
 describe("errorCode", () => {
   it("returns the string code of an error-like value", () => {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -18,6 +18,15 @@ export function isNoEntError(err: unknown): boolean {
   return errorCode(err) === "ENOENT";
 }
 
+/**
+ * Whether a thrown value is a request aborted by `AbortSignal.timeout` rather
+ * than a connection that failed. The runtime names that abort `TimeoutError`,
+ * which is what separates "we stopped waiting" from "we could not reach it".
+ */
+export function isTimeoutError(err: unknown): boolean {
+  return err instanceof Error && err.name === "TimeoutError";
+}
+
 const missingPackagePattern = /Cannot find (?:package|module) '([^']+)'/;
 const pathLikeSpecifierPattern = /^(?:\.|\/|[A-Za-z]:[\\/])/;
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -18,11 +18,6 @@ export function isNoEntError(err: unknown): boolean {
   return errorCode(err) === "ENOENT";
 }
 
-/**
- * Whether a thrown value is a request aborted by `AbortSignal.timeout` rather
- * than a connection that failed. The runtime names that abort `TimeoutError`,
- * which is what separates "we stopped waiting" from "we could not reach it".
- */
 export function isTimeoutError(err: unknown): boolean {
   return err instanceof Error && err.name === "TimeoutError";
 }

--- a/src/core/formatSeconds.ts
+++ b/src/core/formatSeconds.ts
@@ -1,0 +1,7 @@
+/**
+ * A millisecond duration as whole seconds, for messages about deadlines the
+ * caller chose in seconds and should recognize as the number they set.
+ */
+export function formatSeconds(ms: number): string {
+  return `${Math.round(ms / 1000)}s`;
+}

--- a/src/core/formatSeconds.ts
+++ b/src/core/formatSeconds.ts
@@ -1,7 +1,3 @@
-/**
- * A millisecond duration as whole seconds, for messages about deadlines the
- * caller chose in seconds and should recognize as the number they set.
- */
 export function formatSeconds(ms: number): string {
   return `${Math.round(ms / 1000)}s`;
 }

--- a/src/core/messages/auth.ts
+++ b/src/core/messages/auth.ts
@@ -1,3 +1,5 @@
+import { formatSeconds } from "~/core/formatSeconds.js";
+
 export const authMessages = {
   title: "QA Wolf Authentication",
   promptApiKey: "Paste your QA Wolf API Key",
@@ -36,6 +38,8 @@ export const authMessages = {
         `Could not verify API key: ${detail || `HTTP ${status}`}`,
       couldNotVerifyNetwork: (cause: string) =>
         `Could not verify API key: ${cause}`,
+      timedOut: (timeoutMs: number) =>
+        `Could not verify API key: the QA Wolf API did not answer within ${formatSeconds(timeoutMs)}.`,
     },
     request: {
       rejected401: (noun: string | undefined) =>
@@ -48,6 +52,8 @@ export const authMessages = {
         `QA Wolf API${noun ? ` ${noun}` : ""} request failed (HTTP ${status}).`,
       networkUnreachable: (baseUrl: string, noun: string | undefined) =>
         `Could not reach the QA Wolf API at ${baseUrl}${noun ? ` to fetch ${noun}` : ""}. Check your network connection and QAWOLF_HOST_URL.`,
+      timedOut: (timeoutMs: number, noun: string | undefined) =>
+        `The QA Wolf API${noun ? ` ${noun}` : ""} request timed out after ${formatSeconds(timeoutMs)}. The work may still be finishing on the platform.`,
       unexpectedResponse: (noun: string | undefined) =>
         `Unexpected${noun ? ` ${noun}` : ""} response from the QA Wolf API.`,
     },
@@ -58,6 +64,8 @@ export const authMessages = {
         `Could not download the flow bundle (HTTP ${status}).`,
       networkUnreachable:
         "Could not reach the flow bundle storage. Check your network connection and try again.",
+      timedOut: (timeoutMs: number) =>
+        `Downloading the flow bundle timed out after ${formatSeconds(timeoutMs)}. Please try again.`,
       malformed:
         "The flow bundle download was malformed. Please run `qawolf flows pull` again.",
     },

--- a/src/shell/platform/callPublicApi.test.ts
+++ b/src/shell/platform/callPublicApi.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { createTrpcClient } from "./createTrpcClient.js";
 import { callPublicApi } from "./callPublicApi.js";
+import { makeHangingFetch } from "./slowFetch.testUtils.js";
 
 afterEach(() => {
   mock.restore();
@@ -76,6 +77,26 @@ describe("callPublicApi", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(result).toEqual({ ok: true, data: { status: "completed" } });
+  });
+
+  it("hands the caller's timeout to the wire call", async () => {
+    const trpc = createTrpcClient(apiKey, {
+      baseUrl,
+      defaultTimeoutMs: 60_000,
+      fetch: makeHangingFetch(),
+    });
+
+    const result = await callPublicApi(
+      trpc,
+      publicContractsV1.run.create,
+      { environmentId: "environment-id", flowIds: ["flow-id"] },
+      { timeoutMs: 20 },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "timeout", timeoutMs: 20 },
+    });
   });
 
   it("returns a parse error when the response does not match the output schema", async () => {

--- a/src/shell/platform/callPublicApi.ts
+++ b/src/shell/platform/callPublicApi.ts
@@ -2,7 +2,11 @@ import { type PublicApiContractKind } from "@qawolf/api-contracts/v1";
 import type { z } from "zod";
 
 import { describeRequestError } from "./describeErrors.js";
-import type { TrpcClient, WireResult } from "./createTrpcClient.js";
+import type {
+  RequestOptions,
+  TrpcClient,
+  WireResult,
+} from "./createTrpcClient.js";
 import { type PlatformResult, requestWithRetry } from "./requestWithRetry.js";
 
 // Structural view of a public API contract, parameterized by the wire
@@ -24,17 +28,19 @@ export function callPublicApi<Input, Output>(
   trpc: TrpcClient,
   contract: PublicApiContractOf<Input, Output>,
   input: Input,
+  options?: RequestOptions,
 ): Promise<WireResult<Output>> {
   const path = `public.${contract.name}`;
   if (contract.kind === "read") {
-    return trpc.query(path, input, contract.output);
+    return trpc.query(path, input, contract.output, options);
   }
-  return trpc.mutation(path, input, contract.output);
+  return trpc.mutation(path, input, contract.output, options);
 }
 
 export type CallPublicApiMethod = <Input, Output>(
   contract: PublicApiContractOf<Input, Output>,
   input: Input,
+  options?: RequestOptions,
 ) => Promise<PlatformResult<Output>>;
 
 type MethodDeps = {
@@ -50,9 +56,9 @@ export function makeCallPublicApiMethod(
   deps: MethodDeps,
   readBackoffMs: readonly number[],
 ): CallPublicApiMethod {
-  return async (contract, input) =>
+  return async (contract, input, options) =>
     requestWithRetry({
-      call: () => callPublicApi(trpc, contract, input),
+      call: () => callPublicApi(trpc, contract, input, options),
       backoffMs: contract.kind === "read" ? readBackoffMs : [],
       describe: (err) => describeRequestError(err, deps.baseUrl, contract.name),
       sleep: deps.sleep,

--- a/src/shell/platform/createPlatformClient.testUtils.ts
+++ b/src/shell/platform/createPlatformClient.testUtils.ts
@@ -2,11 +2,13 @@ import { mock, type Mock } from "bun:test";
 import type { AnyPublicApiContract } from "@qawolf/api-contracts/v1";
 
 import type { PlatformClient } from "./createPlatformClient.js";
+import type { RequestOptions } from "./createTrpcClient.js";
 import type { PlatformResult } from "./requestWithRetry.js";
 
 type CallPublicApiFn = (
   contract: AnyPublicApiContract,
   input: unknown,
+  options?: RequestOptions,
 ) => Promise<PlatformResult<unknown>>;
 
 // callPublicApi is a generic method, which bun's mock() cannot express;

--- a/src/shell/platform/createPlatformClient.timeout.test.ts
+++ b/src/shell/platform/createPlatformClient.timeout.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, mock, type Mock } from "bun:test";
+
+import { createPlatformClient } from "./createPlatformClient.js";
+import { timeoutAbortError } from "./slowFetch.testUtils.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+const baseUrl = "https://test.qawolf.com";
+const apiKey = "qawolf_key";
+const noSleep = async (): Promise<void> => {};
+
+function callCount(f: typeof fetch): number {
+  return (f as unknown as Mock<typeof fetch>).mock.calls.length;
+}
+
+describe("a request that reached its deadline", () => {
+  // As transient as a refused connection, so it is retried — but reported as the
+  // wait it was rather than as a host that could not be reached, which would
+  // send the caller to look at their network.
+  it("is retried, then reported as a timeout naming how long it waited", async () => {
+    const f = mock<typeof fetch>().mockRejectedValue(
+      timeoutAbortError(),
+    ) as unknown as typeof fetch;
+
+    const result = await createPlatformClient(apiKey, {
+      fetch: f,
+      baseUrl,
+      sleep: noSleep,
+    }).getIdentity();
+
+    expect(callCount(f)).toBe(3);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/did not answer within 10s/);
+  });
+});

--- a/src/shell/platform/createPlatformClient.timeout.test.ts
+++ b/src/shell/platform/createPlatformClient.timeout.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, mock, type Mock } from "bun:test";
 
 import { createPlatformClient } from "./createPlatformClient.js";
-import { timeoutAbortError } from "./slowFetch.testUtils.js";
+import {
+  makeTimingOutBodyFetch,
+  timeoutAbortError,
+} from "./slowFetch.testUtils.js";
 
 afterEach(() => {
   mock.restore();
@@ -23,6 +26,23 @@ describe("a request that reached its deadline", () => {
     const f = mock<typeof fetch>().mockRejectedValue(
       timeoutAbortError(),
     ) as unknown as typeof fetch;
+
+    const result = await createPlatformClient(apiKey, {
+      fetch: f,
+      baseUrl,
+      sleep: noSleep,
+    }).getIdentity();
+
+    expect(callCount(f)).toBe(3);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/did not answer within 10s/);
+  });
+
+  // Identity answers its headers first, so this is the deadline landing while the
+  // body is still arriving — retried like any other timeout, not read as a team
+  // the API described in a shape we did not recognize.
+  it("is retried and named a timeout when the body is what ran out of time", async () => {
+    const f = makeTimingOutBodyFetch();
 
     const result = await createPlatformClient(apiKey, {
       fetch: f,

--- a/src/shell/platform/createTrpcClient.timeout.test.ts
+++ b/src/shell/platform/createTrpcClient.timeout.test.ts
@@ -5,7 +5,11 @@ import { z } from "zod";
 import type { Logger } from "~/shell/logger.js";
 
 import { createTrpcClient } from "./createTrpcClient.js";
-import { makeDelayedFetch, makeHangingFetch } from "./slowFetch.testUtils.js";
+import {
+  makeDelayedFetch,
+  makeHangingFetch,
+  makeTimingOutBodyFetch,
+} from "./slowFetch.testUtils.js";
 
 afterEach(() => {
   mock.restore();
@@ -75,6 +79,23 @@ describe("createTrpcClient timeouts", () => {
     );
 
     expect(result).toEqual({ ok: true, data: { ok: true } });
+  });
+
+  // The deadline outlives the headers. Calling this a parse error would cost the
+  // caller both the retry and the true reason.
+  it("calls a deadline reached while reading the body a timeout, not a parse error", async () => {
+    const client = createTrpcClient(apiKey, {
+      baseUrl,
+      defaultTimeoutMs: 20,
+      fetch: makeTimingOutBodyFetch(),
+    });
+
+    const result = await client.query(path, {}, z.unknown());
+
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "timeout", timeoutMs: 20 },
+    });
   });
 
   it("logs the deadline it reached rather than an absent cause", async () => {

--- a/src/shell/platform/createTrpcClient.timeout.test.ts
+++ b/src/shell/platform/createTrpcClient.timeout.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import superjson from "superjson";
+import { z } from "zod";
+
+import type { Logger } from "~/shell/logger.js";
+
+import { createTrpcClient } from "./createTrpcClient.js";
+import { makeDelayedFetch, makeHangingFetch } from "./slowFetch.testUtils.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+const baseUrl = "https://test.qawolf.com";
+const apiKey = "qawolf_mykey";
+const path = "environment.getEnvironmentWithVariables";
+
+function wrapped(value: unknown): { result: { data: unknown } } {
+  return { result: { data: superjson.serialize(value) } };
+}
+
+describe("createTrpcClient timeouts", () => {
+  it("gives up after the client's default and says it timed out", async () => {
+    const client = createTrpcClient(apiKey, {
+      baseUrl,
+      defaultTimeoutMs: 20,
+      fetch: makeHangingFetch(),
+    });
+
+    const result = await client.query(path, {}, z.unknown());
+
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "timeout", timeoutMs: 20 },
+    });
+  });
+
+  it("gives up after the timeout the call asked for instead of the default", async () => {
+    const client = createTrpcClient(apiKey, {
+      baseUrl,
+      defaultTimeoutMs: 60_000,
+      fetch: makeHangingFetch(),
+    });
+
+    const result = await client.mutation(path, {}, z.unknown(), {
+      timeoutMs: 20,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "timeout", timeoutMs: 20 },
+    });
+  });
+
+  // The point of the per-call timeout: a slow answer the client would otherwise
+  // have abandoned is waited for, and arrives.
+  it("waits for an answer that outlasts the default when the call asked for longer", async () => {
+    const client = createTrpcClient(apiKey, {
+      baseUrl,
+      defaultTimeoutMs: 5,
+      fetch: makeDelayedFetch(
+        () =>
+          new Response(JSON.stringify(wrapped({ ok: true })), {
+            headers: { "content-type": "application/json" },
+          }),
+        40,
+      ),
+    });
+
+    const result = await client.mutation(
+      path,
+      {},
+      z.object({ ok: z.boolean() }),
+      { timeoutMs: 5_000 },
+    );
+
+    expect(result).toEqual({ ok: true, data: { ok: true } });
+  });
+
+  it("logs the deadline it reached rather than an absent cause", async () => {
+    const logger: Logger = {
+      debug: mock(() => {}),
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      trace: mock(() => {}),
+    };
+    const client = createTrpcClient(apiKey, {
+      baseUrl,
+      defaultTimeoutMs: 20,
+      fetch: makeHangingFetch(),
+      logger,
+    });
+
+    await client.query(path, {}, z.unknown());
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      `← ${path} error (timeout): timed out after 20ms`,
+    );
+  });
+});

--- a/src/shell/platform/createTrpcClient.ts
+++ b/src/shell/platform/createTrpcClient.ts
@@ -1,22 +1,37 @@
-import superjson, { type SuperJSONResult } from "superjson";
+import superjson from "superjson";
 import type { z } from "zod";
 import type { Logger } from "~/shell/logger.js";
 
-import { toError } from "./toError.js";
+import { sendWireRequest } from "./sendWireRequest.js";
 
 export type WireError =
   | { kind: "http"; status: number; body: string }
   | { kind: "network"; cause: Error }
+  | { kind: "timeout"; timeoutMs: number }
   | { kind: "parse"; cause: Error };
 
 export type WireResult<T> =
   | { ok: true; data: T }
   | { ok: false; error: WireError };
 
+/** Per-call overrides, for the calls that differ from the client's defaults. */
+export type RequestOptions = {
+  /**
+   * How long to wait for the whole request before aborting it. Left out by
+   * nearly every caller. Set it where the work behind the endpoint is known to
+   * outlast an ordinary read — starting a container, say — and declare the number
+   * beside that knowledge, in the domain making the call, rather than here.
+   */
+  timeoutMs?: number;
+};
+
 type Deps = {
   fetch: typeof globalThis.fetch;
   baseUrl: string;
   logger?: Logger;
+  // Baseline for calls that name no timeout of their own. Production callers
+  // omit it; tests set a small one so a deadline can be reached in a test.
+  defaultTimeoutMs?: number;
 };
 
 export type TrpcClient = {
@@ -24,19 +39,23 @@ export type TrpcClient = {
     path: string,
     input: unknown,
     schema: z.ZodType<T>,
+    options?: RequestOptions,
   ) => Promise<WireResult<T>>;
   mutation: <T>(
     path: string,
     input: unknown,
     schema: z.ZodType<T>,
+    options?: RequestOptions,
   ) => Promise<WireResult<T>>;
 };
 
-const timeoutMs = 15_000;
+/** Fits a call the platform answers from its database, which is most of them. */
+const defaultRequestTimeoutMs = 15_000;
 
 export function createTrpcClient(apiKey: string, deps: Deps): TrpcClient {
   const authHeader = { Authorization: `Bearer ${apiKey}` };
   const { logger } = deps;
+  const defaultTimeoutMs = deps.defaultTimeoutMs ?? defaultRequestTimeoutMs;
 
   async function withLogging<T>(
     path: string,
@@ -48,101 +67,53 @@ export function createTrpcClient(apiKey: string, deps: Deps): TrpcClient {
       logger?.debug(`← ${path} ok`);
     } else {
       const e = result.error;
-      const raw = e.kind === "http" ? e.body : e.cause.message;
-      const clipped = raw.length > 200 ? raw.slice(0, 200) + "…" : raw;
-      const msg = e.kind === "http" ? `${e.status} ${clipped}` : clipped;
-      logger?.warn(`← ${path} error (${e.kind}): ${msg}`);
+      logger?.warn(`← ${path} error (${e.kind}): ${summarize(e)}`);
     }
     return result;
   }
 
   return {
-    query: (path, input, schema) => {
+    query: (path, input, schema, options) => {
       const encoded = encodeURIComponent(
         JSON.stringify(superjson.serialize(input)),
       );
       const url = `${deps.baseUrl}/api/trpc/${path}?input=${encoded}`;
       return withLogging(path, () =>
-        send(
+        sendWireRequest(
           deps.fetch,
           url,
-          {
-            headers: authHeader,
-            method: "GET",
-            signal: AbortSignal.timeout(timeoutMs),
-          },
+          { headers: authHeader, method: "GET" },
           schema,
+          options?.timeoutMs ?? defaultTimeoutMs,
         ),
       );
     },
-    mutation: (path, input, schema) => {
+    mutation: (path, input, schema, options) => {
       const url = `${deps.baseUrl}/api/trpc/${path}`;
       const body = JSON.stringify(superjson.serialize(input));
       return withLogging(path, () =>
-        send(
+        sendWireRequest(
           deps.fetch,
           url,
           {
             body,
             headers: { ...authHeader, "content-type": "application/json" },
             method: "POST",
-            signal: AbortSignal.timeout(timeoutMs),
           },
           schema,
+          options?.timeoutMs ?? defaultTimeoutMs,
         ),
       );
     },
   };
 }
 
-async function send<T>(
-  fetchFn: typeof globalThis.fetch,
-  url: string,
-  init: RequestInit,
-  schema: z.ZodType<T>,
-): Promise<WireResult<T>> {
-  let response: Response;
-  try {
-    response = await fetchFn(url, init);
-  } catch (error: unknown) {
-    return { ok: false, error: { cause: toError(error), kind: "network" } };
-  }
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    return {
-      ok: false,
-      error: { body, kind: "http", status: response.status },
-    };
-  }
-
-  let body: unknown;
-  try {
-    body = await response.json();
-  } catch (error: unknown) {
-    return { ok: false, error: { cause: toError(error), kind: "parse" } };
-  }
-
-  try {
-    const data = unwrap(body);
-    const parsed = schema.safeParse(data);
-    if (!parsed.success) {
-      return { ok: false, error: { cause: parsed.error, kind: "parse" } };
-    }
-    return { ok: true, data: parsed.data };
-  } catch (error: unknown) {
-    return { ok: false, error: { cause: toError(error), kind: "parse" } };
-  }
+function clip(text: string): string {
+  return text.length > 200 ? text.slice(0, 200) + "…" : text;
 }
 
-function unwrap(body: unknown): unknown {
-  if (!isRecord(body) || !isRecord(body["result"])) return body;
-  const data = body["result"]["data"];
-  if (isSuperJSONResult(data)) return superjson.deserialize(data);
-  return data;
+function summarize(error: WireError): string {
+  if (error.kind === "http") return `${error.status} ${clip(error.body)}`;
+  if (error.kind === "timeout") return `timed out after ${error.timeoutMs}ms`;
+  return clip(error.cause.message);
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> =>
-  typeof v === "object" && v !== null;
-const isSuperJSONResult = (v: unknown): v is SuperJSONResult =>
-  isRecord(v) && "json" in v;

--- a/src/shell/platform/createTrpcClient.ts
+++ b/src/shell/platform/createTrpcClient.ts
@@ -16,12 +16,6 @@ export type WireResult<T> =
 
 /** Per-call overrides, for the calls that differ from the client's defaults. */
 export type RequestOptions = {
-  /**
-   * How long to wait for the whole request before aborting it. Left out by
-   * nearly every caller. Set it where the work behind the endpoint is known to
-   * outlast an ordinary read — starting a container, say — and declare the number
-   * beside that knowledge, in the domain making the call, rather than here.
-   */
   timeoutMs?: number;
 };
 
@@ -29,8 +23,6 @@ type Deps = {
   fetch: typeof globalThis.fetch;
   baseUrl: string;
   logger?: Logger;
-  // Baseline for calls that name no timeout of their own. Production callers
-  // omit it; tests set a small one so a deadline can be reached in a test.
   defaultTimeoutMs?: number;
 };
 

--- a/src/shell/platform/describeErrors.ts
+++ b/src/shell/platform/describeErrors.ts
@@ -1,3 +1,4 @@
+import { formatSeconds } from "~/core/formatSeconds.js";
 import { authMessages } from "~/core/messages/index.js";
 import type { WireError } from "./createTrpcClient.js";
 
@@ -13,6 +14,7 @@ export function describeIdentityError(err: WireError): string {
   if (err.kind === "network") {
     return m.identity.couldNotVerifyNetwork(err.cause.message);
   }
+  if (err.kind === "timeout") return m.identity.timedOut(err.timeoutMs);
   return m.identity.unexpectedFormat;
 }
 
@@ -48,6 +50,7 @@ export function describeRequestError(
   if (err.kind === "network") {
     return m.request.networkUnreachable(baseUrl, noun);
   }
+  if (err.kind === "timeout") return m.request.timedOut(err.timeoutMs, noun);
   return m.request.unexpectedResponse(noun);
 }
 
@@ -57,6 +60,7 @@ export function describeBundleDownloadError(err: WireError): string {
     return m.bundle.failedWithStatus(err.status);
   }
   if (err.kind === "network") return m.bundle.networkUnreachable;
+  if (err.kind === "timeout") return m.bundle.timedOut(err.timeoutMs);
   return m.bundle.malformed;
 }
 
@@ -72,6 +76,9 @@ export function describeTeamStorageDownloadError(
   }
   if (err.kind === "network") {
     return `Could not reach team-storage while downloading ${path}. Check your network connection and try again.`;
+  }
+  if (err.kind === "timeout") {
+    return `Downloading the team-storage asset ${path} timed out after ${formatSeconds(err.timeoutMs)}. Please try again.`;
   }
   return `The team-storage download for ${path} was malformed. Please run \`qawolf flows pull\` again.`;
 }

--- a/src/shell/platform/fetchSignedUrl.test.ts
+++ b/src/shell/platform/fetchSignedUrl.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
 import { fetchSignedUrl } from "./fetchSignedUrl.js";
+import { makeTimingOutBodyFetch } from "./slowFetch.testUtils.js";
 
 const cleanups: (() => void)[] = [];
 
@@ -106,5 +107,35 @@ describe("fetchSignedUrl", () => {
       ok: false,
       error: { cause, kind: "network" },
     });
+  });
+
+  // A download stalls part-way far more often than it fails to start, and the
+  // deadline covers the bytes as well as the headers.
+  it("returns a timeout when the download stalls part-way through the body", async () => {
+    const dest = createTempDest();
+
+    const result = await fetchSignedUrl(
+      { dest, url },
+      { fetch: makeTimingOutBodyFetch() },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "timeout", timeoutMs: 30_000 },
+    });
+  });
+
+  // The split that made the timeout visible must not reclassify a failed write.
+  it("still returns a network error when the body arrives but the write fails", async () => {
+    const fs = makeMemoryFs();
+    const cause = new Error("disk full");
+    fs.writeFile = mock(() => Promise.reject(cause));
+
+    const result = await fetchSignedUrl(
+      { dest: "/assets/file.txt", url },
+      { fetch: asFetch(createFetchMock(new Response("bytes"))), fs },
+    );
+
+    expect(result).toEqual({ ok: false, error: { cause, kind: "network" } });
   });
 });

--- a/src/shell/platform/fetchSignedUrl.ts
+++ b/src/shell/platform/fetchSignedUrl.ts
@@ -1,3 +1,4 @@
+import { isTimeoutError } from "~/core/errors.js";
 import { makeDefaultFs, type Fs } from "~/shell/fs.js";
 import type { WireResult } from "./createTrpcClient.js";
 import { toError } from "./toError.js";
@@ -19,6 +20,9 @@ export async function fetchSignedUrl(
       signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error: unknown) {
+    if (isTimeoutError(error)) {
+      return { ok: false, error: { kind: "timeout", timeoutMs } };
+    }
     return { ok: false, error: { cause: toError(error), kind: "network" } };
   }
 

--- a/src/shell/platform/fetchSignedUrl.ts
+++ b/src/shell/platform/fetchSignedUrl.ts
@@ -41,10 +41,22 @@ export async function fetchSignedUrl(
     };
   }
 
+  // Read the body before writing it: the deadline covers the download, so a
+  // stall part-way through the body is a timeout, while a failed write is local.
+  let downloaded: ArrayBuffer;
+  try {
+    downloaded = await response.arrayBuffer();
+  } catch (error: unknown) {
+    if (isTimeoutError(error)) {
+      return { ok: false, error: { kind: "timeout", timeoutMs } };
+    }
+    return { ok: false, error: { cause: toError(error), kind: "network" } };
+  }
+
   try {
     await (deps.fs ?? makeDefaultFs()).writeFile(
       args.dest,
-      new Uint8Array(await response.arrayBuffer()),
+      new Uint8Array(downloaded),
     );
   } catch (error: unknown) {
     return { ok: false, error: { cause: toError(error), kind: "network" } };

--- a/src/shell/platform/getIdentity.ts
+++ b/src/shell/platform/getIdentity.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isTimeoutError } from "~/core/errors.js";
 import type { WireResult } from "./createTrpcClient.js";
 import { toError } from "./toError.js";
 
@@ -18,6 +19,8 @@ type GetIdentityDeps = {
   baseUrl: string;
 };
 
+const timeoutMs = 10_000;
+
 export async function getIdentity(
   apiKey: string,
   deps: GetIdentityDeps,
@@ -28,9 +31,12 @@ export async function getIdentity(
   try {
     response = await deps.fetch(url, {
       headers: { Authorization: `Bearer ${apiKey}` },
-      signal: AbortSignal.timeout(10_000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error: unknown) {
+    if (isTimeoutError(error)) {
+      return { ok: false, error: { kind: "timeout", timeoutMs } };
+    }
     return {
       ok: false,
       error: { kind: "network", cause: toError(error) },

--- a/src/shell/platform/getIdentity.ts
+++ b/src/shell/platform/getIdentity.ts
@@ -51,7 +51,16 @@ export async function getIdentity(
     };
   }
 
-  const json: unknown = await response.json().catch(() => undefined);
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch (error: unknown) {
+    if (isTimeoutError(error)) {
+      return { ok: false, error: { kind: "timeout", timeoutMs } };
+    }
+    json = undefined;
+  }
+
   const parsed = identityResponseSchema.safeParse(json);
   if (!parsed.success) {
     return { ok: false, error: { kind: "parse", cause: parsed.error } };

--- a/src/shell/platform/requestWithRetry.ts
+++ b/src/shell/platform/requestWithRetry.ts
@@ -18,10 +18,10 @@ type RequestWithRetryArgs<T> = {
   sleep: ((ms: number) => Promise<void>) | undefined;
 };
 
-// Retries `call` on transient network errors only; HTTP/parse errors are
-// deterministic and surface immediately. The infinite loop is bounded by the
-// `backoffMs` array: once `backoffMs[attempt]` is undefined, the next non-ok
-// result surfaces the error.
+// Retries `call` on transient network errors and reached deadlines only;
+// HTTP/parse errors are deterministic and surface immediately. The infinite loop
+// is bounded by the `backoffMs` array: once `backoffMs[attempt]` is undefined,
+// the next non-ok result surfaces the error.
 export async function requestWithRetry<T>(
   args: RequestWithRetryArgs<T>,
 ): Promise<PlatformResult<T>> {
@@ -31,7 +31,8 @@ export async function requestWithRetry<T>(
     if (result.ok) return { ok: true, value: result.data };
 
     const backoff = args.backoffMs[attempt];
-    const retryable = result.error.kind === "network";
+    const retryable =
+      result.error.kind === "network" || result.error.kind === "timeout";
     if (backoff === undefined || !retryable) {
       return { ok: false, error: args.describe(result.error) };
     }

--- a/src/shell/platform/sendWireRequest.ts
+++ b/src/shell/platform/sendWireRequest.ts
@@ -66,7 +66,7 @@ function unwrap(body: unknown): unknown {
   return data;
 }
 
-const isRecord = (v: unknown): v is Record<string, unknown> =>
-  typeof v === "object" && v !== null;
-const isSuperJSONResult = (v: unknown): v is SuperJSONResult =>
-  isRecord(v) && "json" in v;
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+const isSuperJSONResult = (value: unknown): value is SuperJSONResult =>
+  isRecord(value) && "json" in value;

--- a/src/shell/platform/sendWireRequest.ts
+++ b/src/shell/platform/sendWireRequest.ts
@@ -1,0 +1,72 @@
+import superjson, { type SuperJSONResult } from "superjson";
+import type { z } from "zod";
+
+import { isTimeoutError } from "~/core/errors.js";
+
+import type { WireResult } from "./createTrpcClient.js";
+import { toError } from "./toError.js";
+
+/**
+ * Makes one request under a deadline and returns its body parsed by `schema`,
+ * as a WireResult — this never throws, so a caller reads the failure rather than
+ * catching it. The deadline is applied here so that reaching it is reported as
+ * the wait it was, distinct from a host that could not be reached.
+ */
+export async function sendWireRequest<T>(
+  fetchFn: typeof globalThis.fetch,
+  url: string,
+  init: RequestInit,
+  schema: z.ZodType<T>,
+  timeoutMs: number,
+): Promise<WireResult<T>> {
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error: unknown) {
+    if (isTimeoutError(error)) {
+      return { ok: false, error: { kind: "timeout", timeoutMs } };
+    }
+    return { ok: false, error: { cause: toError(error), kind: "network" } };
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    return {
+      ok: false,
+      error: { body, kind: "http", status: response.status },
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error: unknown) {
+    return { ok: false, error: { cause: toError(error), kind: "parse" } };
+  }
+
+  try {
+    const data = unwrap(body);
+    const parsed = schema.safeParse(data);
+    if (!parsed.success) {
+      return { ok: false, error: { cause: parsed.error, kind: "parse" } };
+    }
+    return { ok: true, data: parsed.data };
+  } catch (error: unknown) {
+    return { ok: false, error: { cause: toError(error), kind: "parse" } };
+  }
+}
+
+function unwrap(body: unknown): unknown {
+  if (!isRecord(body) || !isRecord(body["result"])) return body;
+  const data = body["result"]["data"];
+  if (isSuperJSONResult(data)) return superjson.deserialize(data);
+  return data;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null;
+const isSuperJSONResult = (v: unknown): v is SuperJSONResult =>
+  isRecord(v) && "json" in v;

--- a/src/shell/platform/sendWireRequest.ts
+++ b/src/shell/platform/sendWireRequest.ts
@@ -44,6 +44,11 @@ export async function sendWireRequest<T>(
   try {
     body = await response.json();
   } catch (error: unknown) {
+    // The deadline outlives the headers, so a stall part-way through the body
+    // reaches it here — a timeout rather than a body we could not make sense of.
+    if (isTimeoutError(error)) {
+      return { ok: false, error: { kind: "timeout", timeoutMs } };
+    }
     return { ok: false, error: { cause: toError(error), kind: "parse" } };
   }
 

--- a/src/shell/platform/slowFetch.testUtils.ts
+++ b/src/shell/platform/slowFetch.testUtils.ts
@@ -1,0 +1,45 @@
+import { mock } from "bun:test";
+
+// The shape a fetch mock implements. `typeof fetch` carries statics (preconnect)
+// that a plain function cannot, so implementations are typed against this and
+// cast once here.
+type FetchImpl = (
+  url: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/** What `AbortSignal.timeout` raises once its deadline passes. */
+export function timeoutAbortError(): DOMException {
+  return new DOMException("The operation timed out.", "TimeoutError");
+}
+
+/**
+ * A fetch that never answers on its own and settles only when its signal aborts,
+ * so the deadline under test is the only thing that can end the call.
+ */
+export function makeHangingFetch(): typeof fetch {
+  return mock<FetchImpl>(
+    (_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(timeoutAbortError()),
+        );
+      }),
+  ) as unknown as typeof fetch;
+}
+
+/** A fetch that answers after `delayMs`, unless its deadline arrives first. */
+export function makeDelayedFetch(
+  makeResponse: () => Response,
+  delayMs: number,
+): typeof fetch {
+  return mock<FetchImpl>(
+    (_url, init) =>
+      new Promise<Response>((resolve, reject) => {
+        setTimeout(() => resolve(makeResponse()), delayMs);
+        init?.signal?.addEventListener("abort", () =>
+          reject(timeoutAbortError()),
+        );
+      }),
+  ) as unknown as typeof fetch;
+}

--- a/src/shell/platform/slowFetch.testUtils.ts
+++ b/src/shell/platform/slowFetch.testUtils.ts
@@ -28,6 +28,25 @@ export function makeHangingFetch(): typeof fetch {
   ) as unknown as typeof fetch;
 }
 
+/**
+ * A fetch whose headers arrive but whose body never does: the response is ok and
+ * reading it raises the timeout, which is what a stall part-way through a
+ * download looks like to a caller.
+ */
+export function makeTimingOutBodyFetch(): typeof fetch {
+  return mock<FetchImpl>(
+    async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.error(timeoutAbortError());
+          },
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+  ) as unknown as typeof fetch;
+}
+
 /** A fetch that answers after `delayMs`, unless its deadline arrives first. */
 export function makeDelayedFetch(
   makeResponse: () => Response,


### PR DESCRIPTION
Relates to NOVA-1403

# Overview of Changes

Every call the CLI makes to the platform shares one fifteen-second deadline, and reaching it was indistinguishable from a dead host — so a request the CLI simply stopped waiting for printed "Check your network connection and QAWOLF_HOST_URL", sending the caller to look in the wrong place. A reached deadline is now its own wire-error kind carrying how long it waited, described as a timeout everywhere `WireError` is turned into a message, and applied at all three fetch sites (tRPC calls, identity, signed-URL downloads).

A call can also carry its own deadline now: `RequestOptions.timeoutMs` threads from `callPublicApi` through the tRPC client to the request. Nothing asks for one yet, so every call keeps today's fifteen seconds; the point is that an endpoint whose work outlasts a database read — starting a container, say — can ask for the time it needs, with the number declared in the domain that knows why. Retry behavior is unchanged: timeouts stay retryable exactly where network errors were, and writes still never retry.

The transport moved into `sendWireRequest.ts` to stay under the file-length limit, and the timeout tests live in their own `*.timeout.test.ts` files for the same reason.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)