### PR TITLE
refactor(cli): rename the colliding SpawnFn and delete the dead RunnerSpawnFn seam

### DIFF
--- a/src/domains/runner/createRunner.guards.test.ts
+++ b/src/domains/runner/createRunner.guards.test.ts
@@ -11,10 +11,6 @@ function makeDeps(): RunnerDeps {
       writeFile: async () => {},
       unlink: async () => {},
     },
-    spawn: () => ({
-      exitCode: Promise.resolve(0),
-      kill: () => {},
-    }),
     signals: makeNoopSignals(),
     depsRoot: "/tmp",
     createStorage: <T>() => ({

--- a/src/domains/runner/createRunner.test.ts
+++ b/src/domains/runner/createRunner.test.ts
@@ -11,10 +11,6 @@ function makeDeps(): RunnerDeps {
       writeFile: async () => {},
       unlink: async () => {},
     },
-    spawn: () => ({
-      exitCode: Promise.resolve(0),
-      kill: () => {},
-    }),
     signals: makeNoopSignals(),
     depsRoot: "/tmp",
     createStorage: <T>() => ({

--- a/src/domains/runner/runAndroidFlow.test.ts
+++ b/src/domains/runner/runAndroidFlow.test.ts
@@ -23,7 +23,6 @@ function makeRunnerDeps() {
       writeFile: async () => {},
       unlink: async () => {},
     },
-    spawn: () => ({ exitCode: Promise.resolve(0), kill: () => {} }),
     signals: makeNoopSignals(),
     // Point to the CLI project root where @qawolf/flows is installed in tests.
     depsRoot: join(import.meta.dirname, "../../.."),

--- a/src/domains/runner/runWebFlow.fixtures.ts
+++ b/src/domains/runner/runWebFlow.fixtures.ts
@@ -18,7 +18,6 @@ export function makeRunnerDeps(): RunnerDeps {
       writeFile: async () => {},
       unlink: async () => {},
     },
-    spawn: () => ({ exitCode: Promise.resolve(0), kill: () => {} }),
     signals: makeNoopSignals(),
     // Point to the CLI project root where @qawolf/flows is installed in tests.
     depsRoot: join(import.meta.dirname, "../../.."),

--- a/src/domains/runner/runnerDeps.test.ts
+++ b/src/domains/runner/runnerDeps.test.ts
@@ -3,25 +3,6 @@ import { createRunnerDeps } from "./runnerDeps.js";
 import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
 
 describe("createRunnerDeps", () => {
-  it("resolves exitCode to a failure when the binary is missing instead of crashing on an unhandled error event", async () => {
-    const deps = createRunnerDeps(makeNoopSignals(), "/tmp/deps");
-    const { exitCode } = deps.spawn("__qawolf_nonexistent_binary_xyzzy__", []);
-    // POSIX surfaces the missing binary as an ENOENT error event (-1); win32
-    // reports it as a cmd.exe exit code (1 or 9009). Pin "failed", not the code.
-    const code = await exitCode;
-    expect(typeof code).toBe("number");
-    expect(code).not.toBe(0);
-  });
-
-  it("resolves exitCode with the child's exit code on a normal close", async () => {
-    const deps = createRunnerDeps(makeNoopSignals(), "/tmp/deps");
-    const { exitCode } = deps.spawn(process.execPath, [
-      "-e",
-      "process.exit(7)",
-    ]);
-    expect(await exitCode).toBe(7);
-  });
-
   it("includes the provided depsRoot in the returned deps", () => {
     const deps = createRunnerDeps(makeNoopSignals(), "/tmp/my-deps-root");
     expect(deps.depsRoot).toBe("/tmp/my-deps-root");

--- a/src/domains/runner/runnerDeps.ts
+++ b/src/domains/runner/runnerDeps.ts
@@ -1,6 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { makeDefaultFs } from "~/shell/fs.js";
-import { spawn as nodeSpawn } from "~/shell/spawn.js";
 import type { RunnerDeps } from "./types.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
@@ -10,21 +9,6 @@ export function createRunnerDeps(
 ): RunnerDeps {
   return {
     fs: makeDefaultFs(),
-    spawn: (cmd, args) => {
-      const child = nodeSpawn(cmd, args);
-      const exitCode = new Promise<number>((resolve) => {
-        // ENOENT (missing binary) fires `error`, not `close` — without a
-        // listener the event would be unhandled and crash the process.
-        child.on("error", () => resolve(-1));
-        child.on("close", (code) => resolve(code ?? -1));
-      });
-      return {
-        exitCode,
-        kill: () => {
-          child.kill();
-        },
-      };
-    },
     signals,
     depsRoot,
     createStorage: <T>() => {

--- a/src/domains/runner/types.ts
+++ b/src/domains/runner/types.ts
@@ -36,19 +36,8 @@ export type AsyncStorage<T> = {
 
 export type RunnerFs = Pick<Fs, "mkdir" | "writeFile" | "unlink">;
 
-export type RunnerSpawnResult = {
-  exitCode: Promise<number>;
-  kill: () => void;
-};
-
-export type RunnerSpawnFn = (
-  command: string,
-  args: string[],
-) => RunnerSpawnResult;
-
 export type RunnerDeps = {
   fs: RunnerFs;
-  spawn: RunnerSpawnFn;
   signals: SignalRegistry;
   createStorage: <T>() => AsyncStorage<T>;
   // Directory the flow runtime resolves @qawolf/flows + playwright from.

--- a/src/shell/appium/createAndroidEmulator.test.ts
+++ b/src/shell/appium/createAndroidEmulator.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import type { AdbFn } from "./adb.js";
-import type { SpawnFn } from "./createAndroidEmulator.js";
+import type { SpawnEmulatorFn } from "./createAndroidEmulator.js";
 import { createAndroidEmulator } from "./createAndroidEmulator.js";
 
 afterEach(() => {
@@ -19,7 +19,7 @@ function makeAdb(bootCompleted = true): AdbFn {
 describe("createAndroidEmulator", () => {
   it("resolves with serial and stop when adb confirms boot", async () => {
     const stopFn = mock(() => {});
-    const spawnFn: SpawnFn = (_bin, _args) => ({ stop: stopFn });
+    const spawnFn: SpawnEmulatorFn = (_bin, _args) => ({ stop: stopFn });
 
     const result = await createAndroidEmulator({
       avdName: "Pixel_4",
@@ -33,7 +33,7 @@ describe("createAndroidEmulator", () => {
 
   it("calls proc stop when stop() is invoked", async () => {
     const stopFn = mock(() => {});
-    const spawnFn: SpawnFn = (_bin, _args) => ({ stop: stopFn });
+    const spawnFn: SpawnEmulatorFn = (_bin, _args) => ({ stop: stopFn });
 
     const result = await createAndroidEmulator({
       avdName: "Pixel_4",
@@ -47,7 +47,7 @@ describe("createAndroidEmulator", () => {
 
   it("kills proc and rethrows when boot times out", async () => {
     const stopFn = mock(() => {});
-    const spawnFn: SpawnFn = (_bin, _args) => ({ stop: stopFn });
+    const spawnFn: SpawnEmulatorFn = (_bin, _args) => ({ stop: stopFn });
     const hangingAdb: AdbFn = async (args) => {
       if (args.includes("wait-for-device")) return { stdout: "" };
       return { stdout: "0\n" }; // never signals boot_completed=1
@@ -71,7 +71,7 @@ describe("createAndroidEmulator", () => {
   });
 
   it("serial uses the provided port", async () => {
-    const spawnFn: SpawnFn = (_bin, _args) => ({ stop: () => {} });
+    const spawnFn: SpawnEmulatorFn = (_bin, _args) => ({ stop: () => {} });
 
     const result = await createAndroidEmulator({
       avdName: "Pixel_7",
@@ -84,7 +84,7 @@ describe("createAndroidEmulator", () => {
 
   it("rejects and kills proc when boot sequence throws", async () => {
     const stopFn = mock(() => {});
-    const spawnFn: SpawnFn = (_bin, _args) => ({ stop: stopFn });
+    const spawnFn: SpawnEmulatorFn = (_bin, _args) => ({ stop: stopFn });
     const failingAdb: AdbFn = async (args) => {
       if (args.includes("wait-for-device")) throw new Error("adb server died");
       return { stdout: "" };
@@ -107,7 +107,7 @@ describe("createAndroidEmulator", () => {
   });
 
   it("does not crash when adb wait-for-device rejects after timeout", async () => {
-    const spawnFn: SpawnFn = (_bin, _args) => ({ stop: () => {} });
+    const spawnFn: SpawnEmulatorFn = (_bin, _args) => ({ stop: () => {} });
     // wait-for-device outlasts the boot timeout, then rejects — simulates adb server
     // dying after Promise.race has already settled with the deadline error.
     const adbWithDelayedRejection: AdbFn = (args) => {

--- a/src/shell/appium/createAndroidEmulator.ts
+++ b/src/shell/appium/createAndroidEmulator.ts
@@ -10,9 +10,12 @@ function androidHome(): string | undefined {
   return process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"];
 }
 
-export type SpawnFn = (bin: string, args: string[]) => { stop: () => void };
+export type SpawnEmulatorFn = (
+  bin: string,
+  args: string[],
+) => { stop: () => void };
 
-const defaultSpawn: SpawnFn = (bin, args) => {
+const defaultSpawnEmulator: SpawnEmulatorFn = (bin, args) => {
   const child = spawn(bin, args, { stdio: "ignore" });
   child.unref();
   return { stop: () => child.kill() };
@@ -73,11 +76,11 @@ function waitForBoot(
 export async function createAndroidEmulator(params: {
   avdName: string;
   port: number;
-  deps?: { spawn?: SpawnFn; adb?: AdbFn };
+  deps?: { spawn?: SpawnEmulatorFn; adb?: AdbFn };
   options?: { bootTimeoutMs?: number };
 }): Promise<{ serial: string; stop: () => void }> {
   const { avdName, port } = params;
-  const spawnFn = params.deps?.spawn ?? defaultSpawn;
+  const spawnFn = params.deps?.spawn ?? defaultSpawnEmulator;
   const adbFn = params.deps?.adb ?? defaultAdb;
   const timeoutMs = params.options?.bootTimeoutMs ?? defaultBootTimeoutMs;
   const serial = `emulator-${port}`;

--- a/src/shell/appium/createEmulatorPool.test.ts
+++ b/src/shell/appium/createEmulatorPool.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import type { AdbFn } from "./adb.js";
-import type { SpawnFn } from "./createAndroidEmulator.js";
+import type { SpawnEmulatorFn } from "./createAndroidEmulator.js";
 import { createEmulatorPool } from "./createEmulatorPool.js";
 import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
 
@@ -17,7 +17,7 @@ function makeAdb(): AdbFn {
   };
 }
 
-function makeSpawn(onStop?: () => void): SpawnFn {
+function makeSpawn(onStop?: () => void): SpawnEmulatorFn {
   return (_bin, _args) => ({ stop: onStop ?? (() => {}) });
 }
 
@@ -40,7 +40,7 @@ describe("createEmulatorPool", () => {
 
   it("bootForAvd is a no-op when called twice for the same AVD", async () => {
     let spawnCount = 0;
-    const countingSpawn: SpawnFn = (_bin, _args) => {
+    const countingSpawn: SpawnEmulatorFn = (_bin, _args) => {
       spawnCount++;
       return { stop: () => {} };
     };
@@ -93,7 +93,7 @@ describe("createEmulatorPool", () => {
 
   it("closeAll stops all emulators and resets state", async () => {
     const stops: ReturnType<typeof mock<() => void>>[] = [];
-    const trackingSpawn: SpawnFn = (_bin, _args) => {
+    const trackingSpawn: SpawnEmulatorFn = (_bin, _args) => {
       const s = mock(() => {});
       stops.push(s);
       return { stop: s };
@@ -135,7 +135,7 @@ describe("createEmulatorPool", () => {
 
   it("bootForAvd works again for same AVD after closeAll", async () => {
     let spawnCount = 0;
-    const countingSpawn: SpawnFn = (_bin, _args) => {
+    const countingSpawn: SpawnEmulatorFn = (_bin, _args) => {
       spawnCount++;
       return { stop: () => {} };
     };

--- a/src/shell/appium/createEmulatorPool.ts
+++ b/src/shell/appium/createEmulatorPool.ts
@@ -1,6 +1,6 @@
 import {
   createAndroidEmulator,
-  type SpawnFn,
+  type SpawnEmulatorFn,
 } from "./createAndroidEmulator.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import type { AdbFn } from "./adb.js";
@@ -11,7 +11,7 @@ const baseConsolePort = 5554;
 
 export function createEmulatorPool(params: {
   signals: SignalRegistry;
-  deps?: { spawn?: SpawnFn; adb?: AdbFn };
+  deps?: { spawn?: SpawnEmulatorFn; adb?: AdbFn };
 }): {
   bootForAvd: (avdName: string, count: number) => Promise<void>;
   checkOut: (avdName: string) => Promise<EmulatorSlot>;


### PR DESCRIPTION
Resolves WIZ-11294

# Overview of Changes

Two structural changes, no behavior change. The emulator seam exported a type named `SpawnFn` that collided with the routed `SpawnFn` in `shell/spawn.ts`; the shapes differ, so a wrong import type-checks against a deps field and fails at runtime. It is now `SpawnEmulatorFn`, matching the sibling `SpawnAppiumFn`.

The second commit deletes `RunnerSpawnFn`, `RunnerSpawnResult`, and the `spawn` field on `RunnerDeps`. Nothing read that field — `createRunner` never touched it and only test fixtures set it. The ticket asked to route this seam through `buildSpawnCommand`, but an audit found no seam can reach a `.cmd`/`.bat`: `withExeSuffix` guarantees `.exe` for `adb` and `emulator`, and the `.bat` names from `androidBins.ts` reach only `install/android/avd.ts`, which is already routed. Deleting an unrouted dead seam beats routing it. The `npmInstall` platform fix from the same ticket moves to WIZ-11298, which rewrites that signature anyway.

# Testing

All green locally. Typecheck passing with the `spawn` field removed is the actual proof the seam had no production consumer — a real caller would break the build.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

Suite goes 1241 → 1239, exactly the two deleted `runnerDeps` tests. One of them asserted a cmd.exe exit code on a path that never started cmd.exe.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)

No behavior change. `SpawnEmulatorFn` is exported, but only three files inside `shell/appium/` import it, all updated here.
