### PR TITLE
refactor(cli): dedupe android SDK and appium home lookups

### DIFF
--- a/src/commands/doctor/handler.ts
+++ b/src/commands/doctor/handler.ts
@@ -9,6 +9,7 @@ import type { CheckResult } from "~/domains/doctor/types.js";
 import { resolveProjectDirSafe } from "~/domains/flows/ensureDeps.js";
 import { expandPatterns, makePeekFlowMeta } from "~/domains/flows/expand.js";
 import { resolveDepsRootIfPresent } from "~/domains/runtimeEnv/index.js";
+import { androidSdkHome } from "~/shell/androidSdkHome.js";
 import {
   type CommandContext,
   type CommandResult,
@@ -73,7 +74,7 @@ export async function handleDoctor(
     readFile: (path) => ctx.fs.readFile(path),
     cwd,
     runAndroidChecks,
-    androidHome: process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"],
+    androidHome: androidSdkHome(),
     checkExists: (path: string) => ctx.fs.existsSync(path),
     envDir,
     requiredAvds,

--- a/src/commands/install/android.ts
+++ b/src/commands/install/android.ts
@@ -5,6 +5,7 @@ import {
 import { resolveDepsRoot as resolveDepsRootHelper } from "~/commands/resolveDepsRoot.js";
 import { installMessages } from "~/core/messages/index.js";
 import type { CommandContext, CommandResult } from "~/shell/commandContext.js";
+import { androidSdkHome } from "~/shell/androidSdkHome.js";
 import { defaultSpawn } from "~/shell/spawn.js";
 import { installAndroid } from "~/domains/install/android/index.js";
 
@@ -13,8 +14,7 @@ export async function handleInstallAndroid(
   pattern: string | undefined,
   envDir?: string,
 ): Promise<CommandResult> {
-  const androidHome =
-    process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"];
+  const androidHome = androidSdkHome();
   if (!androidHome) {
     return { error: installMessages.androidSdkNotFound };
   }

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,3 +1,5 @@
+import { join } from "node:path";
+
 import envPaths from "env-paths";
 
 /**
@@ -27,4 +29,13 @@ export function getConfigDir(): string {
 export function getDataDir(): string {
   _paths ??= envPaths("qawolf");
   return _paths.data;
+}
+
+/**
+ * `APPIUM_HOME` for every Appium invocation. The server, the driver installer,
+ * and doctor must all pass the same value. Otherwise doctor reads one driver
+ * registry while install writes another.
+ */
+export function getAppiumHome(): string {
+  return join(getDataDir(), "appium");
 }

--- a/src/domains/doctor/checks/androidAppium.ts
+++ b/src/domains/doctor/checks/androidAppium.ts
@@ -1,9 +1,6 @@
-import { join } from "node:path";
-
-import envPaths from "env-paths";
-
 import { doctorMessages } from "~/core/messages/index.js";
 import { appiumCliCandidates } from "~/core/nodeModulesBins.js";
+import { getAppiumHome } from "~/core/paths.js";
 import type { CheckResult } from "~/domains/doctor/types.js";
 import type { SpawnFn, SpawnResult } from "~/shell/spawn.js";
 
@@ -13,10 +10,6 @@ function firstLine(result: SpawnResult): string {
     `exit code ${result.exitCode}`
   );
 }
-
-// Must match the APPIUM_HOME used by createAppiumServer and install android,
-// so the driver registry doctor inspects is the same one install populates.
-const appiumHome = join(envPaths("qawolf").data, "appium");
 
 export function checkAppium(
   envDir: string | undefined,
@@ -51,7 +44,7 @@ export async function checkUiautomator2(
     };
   }
   const result = await spawn(appiumBin, ["driver", "list", "--installed"], {
-    env: { APPIUM_HOME: appiumHome },
+    env: { APPIUM_HOME: getAppiumHome() },
     platform,
   });
   if (result.exitCode !== 0) {

--- a/src/domains/install/android/driver.ts
+++ b/src/domains/install/android/driver.ts
@@ -1,5 +1,4 @@
-import { join } from "node:path";
-import envPaths from "env-paths";
+import { getAppiumHome } from "~/core/paths.js";
 import type { CommandContext } from "~/shell/commandContext.js";
 import type { SpawnFn } from "~/shell/spawn.js";
 import { installMessages } from "~/core/messages/index.js";
@@ -13,16 +12,11 @@ export type InstallDriverDeps = {
   readonly checkExists: (path: string) => boolean;
 };
 
-// Must match the APPIUM_HOME used by createAppiumServer so that drivers
-// installed here are found when the server starts during flows run.
-const appiumEnv = {
-  APPIUM_HOME: join(envPaths("qawolf").data, "appium"),
-};
-
 export async function installUiautomator2Driver(
   ctx: CommandContext,
   deps: InstallDriverDeps,
 ): Promise<void> {
+  const appiumEnv = { APPIUM_HOME: getAppiumHome() };
   const candidates = appiumCliCandidates(deps.envDir, deps.platform);
   const appiumBinPath = candidates.find(deps.checkExists);
   if (!appiumBinPath) {

--- a/src/domains/runner/runAndroidFlowDeps.ts
+++ b/src/domains/runner/runAndroidFlowDeps.ts
@@ -2,6 +2,7 @@ import { createAppiumServer } from "~/shell/appium/createAppiumServer.js";
 import { createEmulatorPool } from "~/shell/appium/createEmulatorPool.js";
 import { defaultAdb } from "~/shell/appium/adb.js";
 import type { AppiumDriver } from "~/shell/appium/types.js";
+import { androidSdkHome } from "~/shell/androidSdkHome.js";
 import type { RunAndroidFlowDeps } from "./runAndroidFlow.js";
 import { createRunnerDeps } from "./runnerDeps.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
@@ -67,9 +68,7 @@ export function createAndroidDeps(
   };
 
   const boot = async (avdNames: string[]) => {
-    const androidHome =
-      process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"];
-    if (!androidHome) {
+    if (!androidSdkHome()) {
       throw new Error(
         "ANDROID_HOME is not set. Set it to the Android SDK path.\n" +
           "Install Android Studio and open Tools > SDK Manager.",

--- a/src/domains/runtimeEnv/npmInstall.test.ts
+++ b/src/domains/runtimeEnv/npmInstall.test.ts
@@ -1,18 +1,14 @@
 import { EventEmitter } from "node:events";
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
+import { restoreComSpecAfterEach } from "~/shell/spawn.testUtils.js";
 import {
   buildNpmInstallSpawn,
   type NpmSpawnFn,
   spawnNpmInstall,
 } from "./npmInstall.js";
 
-const originalComSpec = process.env["ComSpec"];
-
-afterEach(() => {
-  if (originalComSpec === undefined) delete process.env["ComSpec"];
-  else process.env["ComSpec"] = originalComSpec;
-});
+restoreComSpecAfterEach();
 
 describe("buildNpmInstallSpawn", () => {
   it("routes npm.cmd through cmd.exe on win32 and keeps cwd", () => {

--- a/src/shell/androidSdkHome.ts
+++ b/src/shell/androidSdkHome.ts
@@ -1,0 +1,4 @@
+/** Android SDK root. `ANDROID_HOME` wins over the older `ANDROID_SDK_ROOT`. */
+export function androidSdkHome(): string | undefined {
+  return process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"];
+}

--- a/src/shell/appium/adb.ts
+++ b/src/shell/appium/adb.ts
@@ -2,13 +2,16 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { adbBin } from "~/core/androidBins.js";
+import { androidSdkHome } from "~/shell/androidSdkHome.js";
 
 const execFileAsync = promisify(execFile);
 
 export type AdbFn = (args: string[]) => Promise<{ stdout: string }>;
 
 export const defaultAdb: AdbFn = async (args) => {
-  const home = process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"];
-  const { stdout } = await execFileAsync(adbBin(home, process.platform), args);
+  const { stdout } = await execFileAsync(
+    adbBin(androidSdkHome(), process.platform),
+    args,
+  );
   return { stdout };
 };

--- a/src/shell/appium/createAndroidEmulator.ts
+++ b/src/shell/appium/createAndroidEmulator.ts
@@ -1,14 +1,11 @@
 import { spawn } from "node:child_process";
 
 import { emulatorBin } from "~/core/androidBins.js";
+import { androidSdkHome } from "~/shell/androidSdkHome.js";
 import { defaultAdb, type AdbFn } from "./adb.js";
 
 const defaultBootTimeoutMs = 120_000;
 const pollIntervalMs = 2_000;
-
-function androidHome(): string | undefined {
-  return process.env["ANDROID_HOME"] ?? process.env["ANDROID_SDK_ROOT"];
-}
 
 export type SpawnEmulatorFn = (
   bin: string,
@@ -85,7 +82,7 @@ export async function createAndroidEmulator(params: {
   const timeoutMs = params.options?.bootTimeoutMs ?? defaultBootTimeoutMs;
   const serial = `emulator-${port}`;
 
-  const proc = spawnFn(emulatorBin(androidHome(), process.platform), [
+  const proc = spawnFn(emulatorBin(androidSdkHome(), process.platform), [
     "-avd",
     avdName,
     "-no-audio",

--- a/src/shell/appium/createAppiumServer.ts
+++ b/src/shell/appium/createAppiumServer.ts
@@ -1,11 +1,8 @@
-import { join } from "node:path";
-
-import envPaths from "env-paths";
-
 import { existsSync } from "node:fs";
 
 import { appiumCliCandidates } from "~/core/nodeModulesBins.js";
 import { installMessages } from "~/core/messages/index.js";
+import { getAppiumHome } from "~/core/paths.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { defaultSpawnAppium, findFreePort } from "./spawnAppium.js";
 
@@ -95,8 +92,7 @@ export async function createAppiumServer(
   const spawnFn = params?.deps?.spawn ?? defaultSpawnAppium;
   const findFreePortFn = params?.deps?.findFreePort ?? findFreePort;
   const checkExists = params?.deps?.checkExists ?? existsSync;
-  const appiumHome =
-    params?.options?.appiumHome ?? join(envPaths("qawolf").data, "appium");
+  const appiumHome = params?.options?.appiumHome ?? getAppiumHome();
   const timeoutMs = params?.options?.startTimeoutMs ?? defaultStartTimeoutMs;
   const platform = params?.options?.platform ?? process.platform;
   const candidates = appiumCliCandidates(envDir, platform);

--- a/src/shell/appium/spawnAppium.test.ts
+++ b/src/shell/appium/spawnAppium.test.ts
@@ -1,13 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
+import { restoreComSpecAfterEach } from "~/shell/spawn.testUtils.js";
 import { buildAppiumSpawn } from "./spawnAppium.js";
 
-const originalComSpec = process.env["ComSpec"];
-
-afterEach(() => {
-  if (originalComSpec === undefined) delete process.env["ComSpec"];
-  else process.env["ComSpec"] = originalComSpec;
-});
+restoreComSpecAfterEach();
 
 describe("buildAppiumSpawn", () => {
   const env = { APPIUM_HOME: "/data/appium" };

--- a/src/shell/spawn.test.ts
+++ b/src/shell/spawn.test.ts
@@ -1,13 +1,9 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 import { buildSpawnCommand, defaultSpawn } from "./spawn.js";
+import { restoreComSpecAfterEach } from "./spawn.testUtils.js";
 
-const originalComSpec = process.env["ComSpec"];
-
-afterEach(() => {
-  if (originalComSpec === undefined) delete process.env["ComSpec"];
-  else process.env["ComSpec"] = originalComSpec;
-});
+restoreComSpecAfterEach();
 
 describe("buildSpawnCommand", () => {
   it("passes the command through untouched on linux/darwin", () => {

--- a/src/shell/spawn.testUtils.ts
+++ b/src/shell/spawn.testUtils.ts
@@ -1,0 +1,13 @@
+import { afterEach } from "bun:test";
+
+/**
+ * Restores `ComSpec` after each test. Tests set it to fake a win32 shell, and
+ * a leaked value changes how later tests build command lines.
+ */
+export function restoreComSpecAfterEach(): void {
+  const original = process.env["ComSpec"];
+  afterEach(() => {
+    if (original === undefined) delete process.env["ComSpec"];
+    else process.env["ComSpec"] = original;
+  });
+}


### PR DESCRIPTION
Resolves WIZ-11297

# Overview of Changes

Structural only, no behavior change. Five call sites restated the `ANDROID_HOME ?? ANDROID_SDK_ROOT` precedence, which is a contract `core/messages/doctor.ts` documents to users; they now share `androidSdkHome()`. Three sites computed the Appium home independently and were coupled only by comments telling each other to stay in sync; they now share `getAppiumHome()`, which composes the memoized `getDataDir()` that `core/paths.ts` already exported.

Both Appium consumers resolve the path inside their function bodies rather than at module level. A module-level call would populate the shared `envPaths` memo at import time and move the freeze point for `getConfigDir` — no caller can trigger that today, but this PR claims behavior preservation.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
```

1241 tests pass. Coverage is unchanged: existing callers' tests exercise both extracted functions, and the three `ComSpec` teardowns are byte-identical to what they replace.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable) — n/a, pure extraction
- [x] No breaking changes (or described below)