### PR TITLE
refactor(cli): rename the API-client context field to platformClient

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -48,7 +48,7 @@ export async function handleLogin(ctx: CommandContext): Promise<CommandResult> {
         message: authMessages.verifying,
         task: async () => {
           const v = await validateApiKey({
-            platform: createPlatformClient(result.value, {
+            platformClient: createPlatformClient(result.value, {
               baseUrl: ctx.apiBaseUrl,
               fetch: globalThis.fetch,
             }),

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -34,13 +34,16 @@ export async function handleWhoami(
     return { error: "not authenticated" };
   }
 
-  const platform = (deps.createPlatform ?? createPlatformClient)(resolved.key, {
-    baseUrl: ctx.apiBaseUrl,
-    fetch: globalThis.fetch,
-    logger: ctx.log("trpc"),
-  });
+  const platformClient = (deps.createPlatform ?? createPlatformClient)(
+    resolved.key,
+    {
+      baseUrl: ctx.apiBaseUrl,
+      fetch: globalThis.fetch,
+      logger: ctx.log("trpc"),
+    },
+  );
 
-  const identity = await platform.getIdentity();
+  const identity = await platformClient.getIdentity();
 
   if (!identity.ok) {
     if (ctx.ui.mode === "human") {

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -130,7 +130,7 @@ export function withAuthContext(
       return;
     }
 
-    const platform = (deps.createPlatform ?? createPlatformClient)(
+    const platformClient = (deps.createPlatform ?? createPlatformClient)(
       resolved.key,
       { baseUrl: apiBaseUrl, fetch: globalThis.fetch, logger: ctx.log("trpc") },
     );
@@ -138,7 +138,7 @@ export function withAuthContext(
     try {
       const result = await fn({
         ...ctx,
-        platform,
+        platformClient,
         apiKeySource: resolved.source,
       });
       if (result !== undefined) {

--- a/src/commands/flows/flowRuntimeDeps.ts
+++ b/src/commands/flows/flowRuntimeDeps.ts
@@ -13,7 +13,7 @@ type CreateFlowRuntimeDepsArgs = {
   readonly envDir: string;
   readonly ctx: Pick<CommandContext, "apiBaseUrl" | "configDir" | "fs"> &
     Partial<Pick<CommandContext, "log">>;
-  readonly platform?: PlatformClient;
+  readonly platformClient?: PlatformClient;
   readonly env?: Record<string, string | undefined>;
   readonly resolveApiKeyFn?: typeof resolveApiKey;
   readonly configureEmailsFn?: typeof configureEmails;
@@ -24,22 +24,22 @@ type GetInbox = NonNullable<FlowRuntimeDeps["getInbox"]>;
 
 type LazyGetInboxArgs = Omit<
   Required<CreateFlowRuntimeDepsArgs>,
-  "platform"
+  "platformClient"
 > & {
-  readonly platform: PlatformClient | undefined;
+  readonly platformClient: PlatformClient | undefined;
 };
 
 async function maybeGetIdentityTeamId(
-  platform: PlatformClient,
+  platformClient: PlatformClient,
 ): Promise<string | undefined> {
-  const identity = await platform.getIdentity();
+  const identity = await platformClient.getIdentity();
   return identity.ok ? identity.value.team.id : undefined;
 }
 
 function lazyGetInbox({
   envDir,
   ctx,
-  platform,
+  platformClient,
   env,
   resolveApiKeyFn,
   configureEmailsFn,
@@ -55,17 +55,17 @@ function lazyGetInbox({
         ? await resolveApiKeyFn(ctx.configDir, ctx.fs)
         : undefined;
 
-    if (teamId === undefined && platform !== undefined) {
-      teamId = await maybeGetIdentityTeamId(platform);
+    if (teamId === undefined && platformClient !== undefined) {
+      teamId = await maybeGetIdentityTeamId(platformClient);
     }
 
     if (teamId === undefined && apiKeyResult !== undefined) {
-      const identityPlatform = createPlatform(apiKeyResult.key, {
+      const identityClient = createPlatform(apiKeyResult.key, {
         baseUrl: ctx.apiBaseUrl,
         fetch: globalThis.fetch,
         ...(ctx.log ? { logger: ctx.log("trpc") } : {}),
       });
-      teamId = await maybeGetIdentityTeamId(identityPlatform);
+      teamId = await maybeGetIdentityTeamId(identityClient);
     }
 
     const teamIdPart = teamId !== undefined ? { teamId } : {};
@@ -100,7 +100,7 @@ function lazyGetInbox({
 export async function createFlowRuntimeDeps({
   envDir,
   ctx,
-  platform,
+  platformClient,
   env = process.env,
   resolveApiKeyFn = resolveApiKey,
   configureEmailsFn = configureEmails,
@@ -109,7 +109,7 @@ export async function createFlowRuntimeDeps({
   const getInbox = lazyGetInbox({
     envDir,
     ctx,
-    platform,
+    platformClient,
     env,
     resolveApiKeyFn,
     configureEmailsFn,

--- a/src/commands/flows/flowRuntimeDeps.ts
+++ b/src/commands/flows/flowRuntimeDeps.ts
@@ -13,7 +13,6 @@ type CreateFlowRuntimeDepsArgs = {
   readonly envDir: string;
   readonly ctx: Pick<CommandContext, "apiBaseUrl" | "configDir" | "fs"> &
     Partial<Pick<CommandContext, "log">>;
-  readonly platformClient?: PlatformClient;
   readonly env?: Record<string, string | undefined>;
   readonly resolveApiKeyFn?: typeof resolveApiKey;
   readonly configureEmailsFn?: typeof configureEmails;
@@ -22,12 +21,7 @@ type CreateFlowRuntimeDepsArgs = {
 
 type GetInbox = NonNullable<FlowRuntimeDeps["getInbox"]>;
 
-type LazyGetInboxArgs = Omit<
-  Required<CreateFlowRuntimeDepsArgs>,
-  "platformClient"
-> & {
-  readonly platformClient: PlatformClient | undefined;
-};
+type LazyGetInboxArgs = Required<CreateFlowRuntimeDepsArgs>;
 
 async function maybeGetIdentityTeamId(
   platformClient: PlatformClient,
@@ -39,7 +33,6 @@ async function maybeGetIdentityTeamId(
 function lazyGetInbox({
   envDir,
   ctx,
-  platformClient,
   env,
   resolveApiKeyFn,
   configureEmailsFn,
@@ -54,10 +47,6 @@ function lazyGetInbox({
       explicitEmailerUrl === undefined
         ? await resolveApiKeyFn(ctx.configDir, ctx.fs)
         : undefined;
-
-    if (teamId === undefined && platformClient !== undefined) {
-      teamId = await maybeGetIdentityTeamId(platformClient);
-    }
 
     if (teamId === undefined && apiKeyResult !== undefined) {
       const identityClient = createPlatform(apiKeyResult.key, {
@@ -100,7 +89,6 @@ function lazyGetInbox({
 export async function createFlowRuntimeDeps({
   envDir,
   ctx,
-  platformClient,
   env = process.env,
   resolveApiKeyFn = resolveApiKey,
   configureEmailsFn = configureEmails,
@@ -109,7 +97,6 @@ export async function createFlowRuntimeDeps({
   const getInbox = lazyGetInbox({
     envDir,
     ctx,
-    platformClient,
     env,
     resolveApiKeyFn,
     configureEmailsFn,

--- a/src/commands/flows/hybridRun.test.ts
+++ b/src/commands/flows/hybridRun.test.ts
@@ -7,6 +7,7 @@ import type { FlowRuntimeDeps } from "~/domains/runner/flowRuntimeDeps.js";
 import { makeNoopLogger } from "~/shell/logger.testUtils.js";
 import { makeNoopSignals } from "~/shell/signals/createSignalRegistry.fixtures.js";
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+import { makeMockPlatformClient } from "~/shell/platform/createPlatformClient.testUtils.js";
 import { runStagingRoot } from "~/domains/runtimeEnv/index.js";
 import {
   handleHybridFlowsRun,
@@ -68,12 +69,12 @@ function makeCtx(): AuthCommandContext {
     outputMode: "human",
     isInteractive: false,
     apiKeySource: "env",
-    platformClient: {} as unknown,
+    platformClient: makeMockPlatformClient(),
     fs: makeMemoryFs(),
     signals: makeNoopSignals(),
     ui: makeFakeUI("human"),
     log: () => makeNoopLogger(),
-  } as unknown as AuthCommandContext;
+  };
 }
 
 function defaultFlags(): FlowsRunFlags {

--- a/src/commands/flows/hybridRun.test.ts
+++ b/src/commands/flows/hybridRun.test.ts
@@ -68,7 +68,7 @@ function makeCtx(): AuthCommandContext {
     outputMode: "human",
     isInteractive: false,
     apiKeySource: "env",
-    platform: {} as unknown,
+    platformClient: {} as unknown,
     fs: makeMemoryFs(),
     signals: makeNoopSignals(),
     ui: makeFakeUI("human"),

--- a/src/domains/auth/validate.test.ts
+++ b/src/domains/auth/validate.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 function makeDeps(result: PlatformResult<IdentityResponse>) {
   return {
-    platform: makeMockPlatformClient({
+    platformClient: makeMockPlatformClient({
       getIdentity:
         mock<PlatformClient["getIdentity"]>().mockResolvedValue(result),
     }),
@@ -32,7 +32,7 @@ describe("validateApiKey", () => {
 
     const result = await validateApiKey(deps);
     expect(result).toEqual({ valid: true, team: teamData });
-    expect(deps.platform.getIdentity).toHaveBeenCalled();
+    expect(deps.platformClient.getIdentity).toHaveBeenCalled();
   });
 
   it("returns invalid when API responds with 401 (already formatted by platform client)", async () => {

--- a/src/domains/auth/validate.ts
+++ b/src/domains/auth/validate.ts
@@ -3,13 +3,13 @@ import type { PlatformClient } from "~/shell/platform/createPlatformClient.js";
 import type { ValidateApiKeyResult } from "./types.js";
 
 type Dependencies = {
-  platform: PlatformClient;
+  platformClient: PlatformClient;
 };
 
 export async function validateApiKey(
   deps: Dependencies,
 ): Promise<ValidateApiKeyResult> {
-  const result = await deps.platform.getIdentity();
+  const result = await deps.platformClient.getIdentity();
 
   if (!result.ok) {
     return { valid: false, error: result.error };

--- a/src/domains/flows/listRemote.test.ts
+++ b/src/domains/flows/listRemote.test.ts
@@ -62,23 +62,23 @@ async function run(opts: {
   flows?: SampleFlow[];
   pattern?: string;
   options?: FlowsListRemoteOptions;
-  platform?: PlatformClient;
-}): Promise<{ ui: UI; platform: PlatformClient; result: unknown }> {
+  platformClient?: PlatformClient;
+}): Promise<{ ui: UI; platformClient: PlatformClient; result: unknown }> {
   const ui = makeFakeUI();
-  const platform =
-    opts.platform ?? platformWithFlows(opts.flows ?? sampleFlows);
+  const platformClient =
+    opts.platformClient ?? platformWithFlows(opts.flows ?? sampleFlows);
   const ctx: AuthCommandContext = {
     ...makeBaseCtx(opts.mode),
     ui: { ...ui, mode: opts.mode },
     apiKeySource: "env",
-    platform,
+    platformClient,
   };
   const result = await flowsListRemote(
     ctx,
     opts.pattern,
     opts.options ?? defaultOptions,
   );
-  return { ui, platform, result };
+  return { ui, platformClient, result };
 }
 
 const stripAnsi = (s: string | undefined): string =>
@@ -87,12 +87,12 @@ const stripAnsi = (s: string | undefined): string =>
 
 describe("flowsListRemote wire call", () => {
   it("calls public.flow.list with the environment and drafts flag", async () => {
-    const { platform } = await run({
+    const { platformClient } = await run({
       mode: "json",
       options: { env: "env-1", includeDrafts: true },
     });
 
-    expect(platform.callPublicApi).toHaveBeenCalledWith(
+    expect(platformClient.callPublicApi).toHaveBeenCalledWith(
       publicContractsV1.flow.list,
       { environmentId: "env-1", includeDrafts: true },
     );
@@ -229,7 +229,7 @@ describe("flowsListRemote platform error", () => {
   it("returns a CommandResult with the platform error message", async () => {
     const { ui, result } = await run({
       mode: "human",
-      platform: makeMockPlatformClient({
+      platformClient: makeMockPlatformClient({
         callPublicApi: makeCallPublicApiMock().mockResolvedValue({
           ok: false,
           error: "QA Wolf API rejected the flow.list request (HTTP 401).",

--- a/src/domains/flows/listRemote.ts
+++ b/src/domains/flows/listRemote.ts
@@ -27,10 +27,13 @@ export async function flowsListRemote(
   pattern: string | undefined,
   options: FlowsListRemoteOptions,
 ): Promise<CommandResult> {
-  const result = await ctx.platform.callPublicApi(publicContractsV1.flow.list, {
-    environmentId: options.env,
-    includeDrafts: options.includeDrafts,
-  });
+  const result = await ctx.platformClient.callPublicApi(
+    publicContractsV1.flow.list,
+    {
+      environmentId: options.env,
+      includeDrafts: options.includeDrafts,
+    },
+  );
   if (!result.ok) {
     return { error: result.error };
   }

--- a/src/domains/flows/pull/fetchPhase.ts
+++ b/src/domains/flows/pull/fetchPhase.ts
@@ -12,7 +12,7 @@ export async function fetchBundleAndEnvVars(
   ctx: AuthCommandContext,
   envId: string,
 ): Promise<FetchedBundle> {
-  const { platform } = ctx;
+  const { platformClient } = ctx;
   let tmpArchive: string | undefined;
   let bundleFetchedAt: Date | undefined;
   let envVars: Record<string, string> | undefined;
@@ -23,7 +23,7 @@ export async function fetchBundleAndEnvVars(
       {
         message: flowsMessages.pull.downloadingBundle,
         task: async () => {
-          const result = await platform.downloadBundle(envId);
+          const result = await platformClient.downloadBundle(envId);
           if (!result.ok) throw new Error(result.error);
           tmpArchive = result.value.tmpArchive;
           bundleFetchedAt = new Date();
@@ -32,7 +32,7 @@ export async function fetchBundleAndEnvVars(
       {
         message: flowsMessages.pull.fetchingEnvVars,
         task: async () => {
-          const result = await platform.getEnvVars(envId);
+          const result = await platformClient.getEnvVars(envId);
           if (!result.ok) throw new Error(result.error);
           envVars = result.value;
           envVarsFetchedAt = new Date();

--- a/src/domains/flows/pull/handler.test.ts
+++ b/src/domains/flows/pull/handler.test.ts
@@ -68,7 +68,7 @@ function makeCtx(
     signals: noopSignals,
     log: () => makeNoopLogger(),
     fs: makeDefaultFs(),
-    platform: makeMockPlatformClient({
+    platformClient: makeMockPlatformClient({
       downloadBundle: mock().mockResolvedValue({
         ok: true,
         value: { tmpArchive: bundlePath },

--- a/src/domains/flows/pull/handler.ts
+++ b/src/domains/flows/pull/handler.ts
@@ -93,7 +93,8 @@ export async function handleFlowsPull(
         {
           message: flowsMessages.pull.downloadingTeamStorageAssets,
           task: async () => {
-            const result = await ctx.platform.syncTeamStorageAssets(assetsAbs);
+            const result =
+              await ctx.platformClient.syncTeamStorageAssets(assetsAbs);
             if (!result.ok) throw new Error(result.error);
             return result.value;
           },

--- a/src/domains/publicApi/handle.test.ts
+++ b/src/domains/publicApi/handle.test.ts
@@ -43,12 +43,12 @@ const countSpec = (): CommandSpec => {
   return spec;
 };
 
-function ctxWith(ui: UI, platform: PlatformClient): AuthCommandContext {
+function ctxWith(ui: UI, platformClient: PlatformClient): AuthCommandContext {
   return {
     ...makeCtx("human"),
     ui,
     apiKeySource: "env",
-    platform,
+    platformClient,
   };
 }
 

--- a/src/domains/publicApi/handle.ts
+++ b/src/domains/publicApi/handle.ts
@@ -94,7 +94,10 @@ export async function handlePublicApiCommand(
   const parsed = spec.contract.input.safeParse(assembled.input);
   if (!parsed.success) return { error: z.prettifyError(parsed.error) };
 
-  const result = await ctx.platform.callPublicApi(spec.contract, parsed.data);
+  const result = await ctx.platformClient.callPublicApi(
+    spec.contract,
+    parsed.data,
+  );
   if (!result.ok) return { error: result.error };
 
   ctx.ui.output(result.value, renderHuman(result.value));

--- a/src/shell/commandContext.ts
+++ b/src/shell/commandContext.ts
@@ -17,7 +17,7 @@ export type CommandContext = {
 };
 
 export type AuthCommandContext = CommandContext & {
-  readonly platform: PlatformClient;
+  readonly platformClient: PlatformClient;
   readonly apiKeySource: string;
 };
 


### PR DESCRIPTION
Resolves WIZ-11298

# Overview of Changes

`platform` named two unrelated things: the QA Wolf API client on `AuthCommandContext`, and the host OS in 39 `NodeJS.Platform` signatures. Two `deps.platform` reads meant different things at review time. The first commit renames the API-client field to `platformClient`, freeing the name for the host OS to move onto `CommandContext` later. `createPlatform` and `platformWithFlows` keep their names — both denote factories, not clients.

The second commit deletes the `platformClient` argument on `createFlowRuntimeDeps`, which no caller ever set, along with the `getIdentity` branch it guarded. It also drops the `as unknown as AuthCommandContext` cast in `hybridRun.test.ts` — that cast is why a stale `platform` key survived the rename. Both commits are structural, no behaviour change.

# Testing

All green on both commits.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test     # 1239 pass, 0 fail
bun run build
```

Verified the removed cast now bites: reintroducing `platform:` in place of `platformClient:` in `hybridRun.test.ts` fails typecheck with TS2353, where before it was silently swallowed.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable) — rename and dead-code removal; existing tests updated, no new tests
- [x] No breaking changes (or described below)