### PR TITLE
fix(runner): stage flow files that sit outside projectDir

### DIFF
--- a/src/domains/flows/ensureDeps.test.ts
+++ b/src/domains/flows/ensureDeps.test.ts
@@ -69,6 +69,15 @@ describe("resolveUniqueEnvDir", () => {
     expect(resolveUniqueEnvDir(files, defaultFs)).toBeUndefined();
   });
 
+  it("should return the one package dir even when a file sits outside it", async () => {
+    const root = await tracker.makeTmpDir();
+    const pkg = join(root, "pkg");
+    await mkdir(pkg, { recursive: true });
+    await writeFile(join(pkg, "package.json"), "{}");
+    const files = [join(pkg, "a.flow.ts"), join(root, "b.flow.ts")];
+    expect(resolveUniqueEnvDir(files, defaultFs)).toBe(pkg);
+  });
+
   it("should return undefined for an empty file list", async () => {
     expect(resolveUniqueEnvDir([], defaultFs)).toBeUndefined();
   });

--- a/src/domains/flows/expand.ts
+++ b/src/domains/flows/expand.ts
@@ -46,7 +46,7 @@ export async function expandPatterns(
     });
     for (const match of matches) {
       // tinyglobby emits forward slashes even on win32; the rest of the CLI
-      // builds paths with node:path. prepareRunDir's remapPath compares the
+      // builds paths with node:path. stageFlowFiles' remapPath compares the
       // two forms, so canonicalize here.
       const file = resolve(match);
       seen.add(file);

--- a/src/domains/runtimeEnv/prepareRunDir.stageOutside.test.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.stageOutside.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, sep } from "node:path";
+
+import { makeTmpDirTracker } from "~/shell/tmpDir.testUtils.js";
+import { prepareRunDir } from "./prepareRunDir.js";
+
+const tracker = makeTmpDirTracker("qawolf-stage-outside-test-");
+
+afterEach(() => tracker.cleanup());
+
+describe("stageFlowFiles — file outside projectDir", () => {
+  it("stages it into exec/ instead of returning the source path", async () => {
+    const [runRoot, depsRoot, outerDir] = await Promise.all([
+      tracker.makeTmpDir(),
+      tracker.makeTmpDir(),
+      tracker.makeTmpDir(),
+    ]);
+    await mkdir(join(depsRoot, "node_modules"), { recursive: true });
+    const projectDir = join(outerDir, "pkg");
+    await mkdir(projectDir, { recursive: true });
+    const insideFlow = join(projectDir, "inside.ts");
+    const outsideFlow = join(outerDir, "outside.ts");
+    await Promise.all([
+      writeFile(insideFlow, "// inside"),
+      writeFile(outsideFlow, "// outside"),
+    ]);
+
+    const result = await prepareRunDir({
+      files: [insideFlow, outsideFlow],
+      projectDir,
+      depsRoot,
+      runRoot,
+    });
+    tracker.track(result.runDir);
+
+    const execDir = join(result.runDir, "exec");
+    const [stagedInside, stagedOutside] = result.files;
+    if (stagedInside === undefined || stagedOutside === undefined) {
+      throw new Error("expected 2 staged file paths");
+    }
+    expect(stagedInside).toBe(join(execDir, "inside.ts"));
+    expect(stagedOutside.startsWith(execDir + sep)).toBe(true);
+    expect(await readFile(stagedOutside, "utf-8")).toBe("// outside");
+  });
+});

--- a/src/domains/runtimeEnv/prepareRunDir.ts
+++ b/src/domains/runtimeEnv/prepareRunDir.ts
@@ -1,14 +1,12 @@
 import { createHash } from "node:crypto";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { join, resolve } from "node:path";
 
-import { copyDirExcluding } from "~/shell/copyDir.js";
 import { type Fs, makeDefaultFs } from "~/shell/fs.js";
 
 import { writeExecSubpathImports } from "./execSubpathImports.js";
 import { populateInnerHop } from "./innerHop.js";
 import { type OuterHopResult, populateOuterHop } from "./outerHop.js";
-
-const excludedDirs = new Set(["node_modules", ".git", ".qawolf"]);
+import { stageFlowFiles } from "./stageFlowFiles.js";
 
 export type PrepareRunDirArgs = {
   files: string[];
@@ -92,53 +90,4 @@ function buildRunId(projectDir: string | undefined, files: string[]): string {
   // The pid suffix scopes the runDir to this process invocation; each command
   // calls prepareRunDir once, so same-seedPath reuse within a process is intentional.
   return `${hash}-${process.pid}`;
-}
-
-type StageFlowFilesArgs = {
-  files: string[];
-  projectDir: string | undefined;
-  execDir: string;
-  fs: Fs;
-};
-
-async function stageFlowFiles(args: StageFlowFilesArgs): Promise<string[]> {
-  const { files, projectDir, execDir, fs } = args;
-
-  if (projectDir !== undefined) {
-    await copyDirExcluding(projectDir, execDir, excludedDirs);
-    return files.map((f) => remapPath(f, projectDir, execDir));
-  }
-
-  if (files.length > 1) {
-    // Multiple files: place each under a subdir keyed by a hash of its source
-    // dirname so files with identical basenames from different directories do
-    // not overwrite each other.
-    return Promise.all(
-      files.map(async (f) => {
-        const dirHash = createHash("sha256")
-          .update(dirname(f))
-          .digest("hex")
-          .slice(0, 8);
-        const subDir = join(execDir, dirHash);
-        await fs.mkdir(subDir, { recursive: true });
-        const dest = join(subDir, basename(f));
-        await fs.copyFile(f, dest);
-        return dest;
-      }),
-    );
-  }
-
-  // Single file (or empty — validated upstream by buildRunId): flat staging.
-  await Promise.all(
-    files.map((f) => fs.copyFile(f, join(execDir, basename(f)))),
-  );
-  return files.map((f) => join(execDir, basename(f)));
-}
-
-function remapPath(file: string, projectDir: string, execDir: string): string {
-  if (file === projectDir) return execDir;
-  if (file.startsWith(projectDir + sep)) {
-    return join(execDir, file.slice(projectDir.length + 1));
-  }
-  return file;
 }

--- a/src/domains/runtimeEnv/stageFlowFiles.ts
+++ b/src/domains/runtimeEnv/stageFlowFiles.ts
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+import { basename, dirname, join, sep } from "node:path";
+
+import { copyDirExcluding } from "~/shell/copyDir.js";
+import type { Fs } from "~/shell/fs.js";
+
+const excludedDirs = new Set(["node_modules", ".git", ".qawolf"]);
+
+export type StageFlowFilesArgs = {
+  files: string[];
+  projectDir: string | undefined;
+  execDir: string;
+  fs: Fs;
+};
+
+export async function stageFlowFiles(
+  args: StageFlowFilesArgs,
+): Promise<string[]> {
+  const { files, projectDir, execDir, fs } = args;
+
+  if (projectDir !== undefined) {
+    await copyDirExcluding(projectDir, execDir, excludedDirs);
+    return files.map((f) => remapPath(f, projectDir, execDir));
+  }
+
+  if (files.length > 1) {
+    // Multiple files: place each under a subdir keyed by a hash of its source
+    // dirname so files with identical basenames from different directories do
+    // not overwrite each other.
+    return Promise.all(
+      files.map(async (f) => {
+        const dirHash = createHash("sha256")
+          .update(dirname(f))
+          .digest("hex")
+          .slice(0, 8);
+        const subDir = join(execDir, dirHash);
+        await fs.mkdir(subDir, { recursive: true });
+        const dest = join(subDir, basename(f));
+        await fs.copyFile(f, dest);
+        return dest;
+      }),
+    );
+  }
+
+  // Single file (or empty — validated upstream by buildRunId): flat staging.
+  await Promise.all(
+    files.map((f) => fs.copyFile(f, join(execDir, basename(f)))),
+  );
+  return files.map((f) => join(execDir, basename(f)));
+}
+
+function remapPath(file: string, projectDir: string, execDir: string): string {
+  if (file === projectDir) return execDir;
+  if (file.startsWith(projectDir + sep)) {
+    return join(execDir, file.slice(projectDir.length + 1));
+  }
+  return file;
+}

--- a/src/domains/runtimeEnv/stageFlowFiles.ts
+++ b/src/domains/runtimeEnv/stageFlowFiles.ts
@@ -6,7 +6,7 @@ import type { Fs } from "~/shell/fs.js";
 
 const excludedDirs = new Set(["node_modules", ".git", ".qawolf"]);
 
-export type StageFlowFilesArgs = {
+type StageFlowFilesArgs = {
   files: string[];
   projectDir: string | undefined;
   execDir: string;
@@ -20,26 +20,19 @@ export async function stageFlowFiles(
 
   if (projectDir !== undefined) {
     await copyDirExcluding(projectDir, execDir, excludedDirs);
-    return files.map((f) => remapPath(f, projectDir, execDir));
+    // A file set can span the project and files with no package.json ancestor:
+    // resolveProjectDirSafe keeps only the one project dir, so the stragglers
+    // are copied in one at a time.
+    return Promise.all(
+      files.map(
+        async (f) =>
+          remapPath(f, projectDir, execDir) ?? stageOneFile(f, execDir, fs),
+      ),
+    );
   }
 
   if (files.length > 1) {
-    // Multiple files: place each under a subdir keyed by a hash of its source
-    // dirname so files with identical basenames from different directories do
-    // not overwrite each other.
-    return Promise.all(
-      files.map(async (f) => {
-        const dirHash = createHash("sha256")
-          .update(dirname(f))
-          .digest("hex")
-          .slice(0, 8);
-        const subDir = join(execDir, dirHash);
-        await fs.mkdir(subDir, { recursive: true });
-        const dest = join(subDir, basename(f));
-        await fs.copyFile(f, dest);
-        return dest;
-      }),
-    );
+    return Promise.all(files.map((f) => stageOneFile(f, execDir, fs)));
   }
 
   // Single file (or empty — validated upstream by buildRunId): flat staging.
@@ -49,10 +42,34 @@ export async function stageFlowFiles(
   return files.map((f) => join(execDir, basename(f)));
 }
 
-function remapPath(file: string, projectDir: string, execDir: string): string {
+// Places one file under a subdir keyed by a hash of its source dirname so files
+// with identical basenames from different directories do not overwrite each other.
+async function stageOneFile(
+  file: string,
+  execDir: string,
+  fs: Fs,
+): Promise<string> {
+  const dirHash = createHash("sha256")
+    .update(dirname(file))
+    .digest("hex")
+    .slice(0, 8);
+  const subDir = join(execDir, dirHash);
+  await fs.mkdir(subDir, { recursive: true });
+  const dest = join(subDir, basename(file));
+  await fs.copyFile(file, dest);
+  return dest;
+}
+
+// Undefined means the file is not inside projectDir, so the projectDir copy did
+// not stage it — returning the source path would run the flow unstaged.
+function remapPath(
+  file: string,
+  projectDir: string,
+  execDir: string,
+): string | undefined {
   if (file === projectDir) return execDir;
   if (file.startsWith(projectDir + sep)) {
     return join(execDir, file.slice(projectDir.length + 1));
   }
-  return file;
+  return undefined;
 }


### PR DESCRIPTION
`resolveUniqueEnvDir` drops files with no `package.json` ancestor before its multi-package check, so a mixed file set yields a `projectDir` that does not contain every file. `remapPath` then returned the source path and that flow ran outside the run dir, without the pinned executor or the `#playwright` alias, and nothing logged it. Reachable on POSIX today — no win32 separator involved. Files outside `projectDir` now stage into `exec/<dirHash>/`, the scheme the standalone path already uses.

Trade-off: a staged straggler loses its sibling files, so a relative import inside it now fails loudly instead of resolving. Its package imports were already broken, so this replaces a silent wrong run with a visible one.

First commit is a behavior-preserving move — `prepareRunDir.ts` sat one line under the 150-line cap.

Closes WIZ-11292