### PR TITLE
fix(runner): name the packages missing from a --deps directory

### DIFF
--- a/src/core/messages/runner.ts
+++ b/src/core/messages/runner.ts
@@ -37,6 +37,12 @@ export const runnerMessages = {
     `Using managed runtime — override with --deps <dir> or QAWOLF_RUNTIME_DIR:\n${dir}`,
   installingProjectDeps: (count: number) =>
     `Installing ${pluralize(count, "project dependency", "project dependencies")}…`,
+  depsDirIncomplete: (dir: string, failures: string[]) =>
+    [
+      `--deps directory ${dir} is missing required pinned dependencies:`,
+      ...failures.map((failure) => `  - ${failure}`),
+      `Run 'npm install' in that directory or point to a valid managed env directory.`,
+    ].join("\n"),
   outerHopCandidateRejected: (dir: string, missing: string[]) =>
     `outer-hop candidate rejected: ${dir} missing ${missing.join(", ")}`,
   moduleNotFoundHint: (pkg: string, projectDir: string | undefined) =>

--- a/src/domains/runtimeEnv/ensureRuntimeEnv.test.ts
+++ b/src/domains/runtimeEnv/ensureRuntimeEnv.test.ts
@@ -66,6 +66,54 @@ describe("ensureRuntimeEnv", () => {
     expect((caughtError as Error).message).toContain(overrideDir);
   });
 
+  it("names the failing package and shim in the rejection", async () => {
+    const fs = makeMemoryFs();
+    const overrideDir = "/override/stale";
+    seedFullEnv(fs, overrideDir);
+    const flowsPkg = join(overrideDir, "node_modules", "@qawolf", "flows");
+    fs.writeFileSync(
+      join(flowsPkg, "package.json"),
+      JSON.stringify({ version: "0.0.0" }),
+    );
+    const { install } = makeNoopInstall();
+
+    let caughtError: unknown;
+    try {
+      await ensureRuntimeEnv(
+        { overrideDir, platform: "linux" },
+        { fs, install, resolveManagedDir: () => managedDir },
+      );
+    } catch (e) {
+      caughtError = e;
+    }
+
+    const pinned = pinnedPackages.find((p) => p.name === "@qawolf/flows");
+    expect((caughtError as Error).message).toContain(
+      `@qawolf/flows 0.0.0 (pinned ${pinned?.version})`,
+    );
+  });
+
+  it("names a missing package as missing", async () => {
+    const fs = makeMemoryFs();
+    const overrideDir = "/override/partial";
+    const { install } = makeNoopInstall();
+
+    let caughtError: unknown;
+    try {
+      await ensureRuntimeEnv(
+        { overrideDir, platform: "linux" },
+        { fs, install, resolveManagedDir: () => managedDir },
+      );
+    } catch (e) {
+      caughtError = e;
+    }
+
+    const message = (caughtError as Error).message;
+    const pinned = pinnedPackages.find((p) => p.name === "appium");
+    expect(message).toContain(`appium (missing, pinned ${pinned?.version})`);
+    expect(message).toContain("node_modules/.bin/appium (missing)");
+  });
+
   it("returns project source when projectDir has all pinned deps", async () => {
     const fs = makeMemoryFs();
     const projectDir = "/user/project";

--- a/src/domains/runtimeEnv/ensureRuntimeEnv.ts
+++ b/src/domains/runtimeEnv/ensureRuntimeEnv.ts
@@ -1,8 +1,13 @@
+import { runnerMessages } from "~/core/messages/runner.js";
 import { type Fs, makeDefaultFs } from "~/shell/fs.js";
 
 import { managedEnvDir as defaultManagedEnvDir } from "./managedEnvDir.js";
 import { installPinned, defaultSpawnInstall } from "./installPinned.js";
-import { allPinnedResolved } from "./resolvePinned.js";
+import {
+  allPinnedResolved,
+  describePinnedFailure,
+  pinnedResolutionFailures,
+} from "./resolvePinned.js";
 
 type RuntimeEnvSource = "override" | "project" | "managed";
 
@@ -45,7 +50,12 @@ export async function ensureRuntimeEnv(
       }));
 
   if (args.overrideDir !== undefined) {
-    if (allPinnedResolved(args.overrideDir, fs, args.platform)) {
+    const failures = pinnedResolutionFailures(
+      args.overrideDir,
+      fs,
+      args.platform,
+    );
+    if (failures.length === 0) {
       return {
         depsRoot: args.overrideDir,
         source: "override",
@@ -53,8 +63,10 @@ export async function ensureRuntimeEnv(
       };
     }
     throw new Error(
-      `--deps directory ${args.overrideDir} is missing required pinned dependencies. ` +
-        `Run 'npm install' in that directory or point to a valid managed env directory.`,
+      runnerMessages.depsDirIncomplete(
+        args.overrideDir,
+        failures.map(describePinnedFailure),
+      ),
     );
   }
 

--- a/src/domains/runtimeEnv/resolvePinned.test.ts
+++ b/src/domains/runtimeEnv/resolvePinned.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
 
 import { pinnedPackages } from "./pinnedPackages.js";
-import { allPinnedResolved, readInstalledVersion } from "./resolvePinned.js";
+import {
+  allPinnedResolved,
+  pinnedResolutionFailures,
+  readInstalledVersion,
+} from "./resolvePinned.js";
 
 const dir = "/project";
 
@@ -75,6 +79,68 @@ function seedShim(
   fs.mkdirSync(join(dir, "node_modules", ".bin"), { recursive: true });
   fs.writeFileSync(join(dir, "node_modules", ".bin", name), contents);
 }
+
+describe("pinnedResolutionFailures", () => {
+  it("reports the installed version alongside the pinned one", () => {
+    const fs = makeMemoryFs();
+    seedAllPackages(fs);
+    seedPackage(fs, "@qawolf/flows", "0.0.0");
+
+    const pinned = pinnedPackages.find((p) => p.name === "@qawolf/flows");
+
+    expect(pinnedResolutionFailures(dir, fs, "linux")).toEqual([
+      {
+        kind: "package",
+        name: "@qawolf/flows",
+        pinned: pinned?.version ?? "",
+        installed: "0.0.0",
+      },
+    ]);
+  });
+
+  it("reports an absent package with no installed version", () => {
+    const fs = makeMemoryFs();
+    for (const { name, version } of pinnedPackages) {
+      if (name !== "appium") {
+        seedPackage(fs, name, version);
+      }
+    }
+    seedShim(fs, "playwright", "#!/bin/sh");
+    seedShim(fs, "appium", "#!/bin/sh");
+
+    const pinned = pinnedPackages.find((p) => p.name === "appium");
+
+    expect(pinnedResolutionFailures(dir, fs, "linux")).toEqual([
+      {
+        kind: "package",
+        name: "appium",
+        pinned: pinned?.version ?? "",
+        installed: undefined,
+      },
+    ]);
+  });
+
+  it("returns no failures when every package matches", () => {
+    const fs = makeMemoryFs();
+    seedAllPackages(fs);
+
+    expect(pinnedResolutionFailures(dir, fs, "linux")).toEqual([]);
+  });
+
+  // The state WIZ-11284 made rejectable: every package matches, but the
+  // directory has no runnable appium.
+  it("reports a missing shim even when every package matches", () => {
+    const fs = makeMemoryFs();
+    for (const { name, version } of pinnedPackages) {
+      seedPackage(fs, name, version);
+    }
+    seedShim(fs, "playwright", "#!/bin/sh");
+
+    expect(pinnedResolutionFailures(dir, fs, "linux")).toEqual([
+      { kind: "shim", name: "appium" },
+    ]);
+  });
+});
 
 describe("allPinnedResolved", () => {
   it("returns true when all packages match and both shims exist", () => {

--- a/src/domains/runtimeEnv/resolvePinned.ts
+++ b/src/domains/runtimeEnv/resolvePinned.ts
@@ -33,26 +33,53 @@ export function readInstalledVersion(
   }
 }
 
+export type PinnedFailure =
+  | {
+      kind: "package";
+      name: string;
+      pinned: string;
+      installed: string | undefined;
+    }
+  | { kind: "shim"; name: string };
+
+// The same candidate lists installBrowserList and createAppiumServer resolve
+// from, so this check and those two cannot disagree.
+const shims = [
+  { name: "playwright", candidates: playwrightCliCandidates },
+  { name: "appium", candidates: appiumCliCandidates },
+];
+
 /**
- * Returns true when every pinned package is installed at its exact pinned
- * version AND both CLI shims exist. A matching package version does not imply
- * a runnable shim, so checking versions alone can resolve a root that later
- * fails to spawn the binary.
+ * Returns one entry per pinned package that is absent or installed at a
+ * version other than the pinned one, plus one per missing CLI shim. An empty
+ * array means the directory resolves. A matching package version does not
+ * imply a runnable shim, so checking versions alone can resolve a root that
+ * later fails to spawn the binary.
  */
+export function pinnedResolutionFailures(
+  dir: string,
+  fs: Fs,
+  platform: NodeJS.Platform,
+): PinnedFailure[] {
+  const failures: PinnedFailure[] = [];
+  for (const { name, version } of pinnedPackages) {
+    const installed = readInstalledVersion(dir, name, fs);
+    if (installed !== version) {
+      failures.push({ kind: "package", name, pinned: version, installed });
+    }
+  }
+  for (const { name, candidates } of shims) {
+    if (!candidates(dir, platform).some((p) => fs.existsSync(p))) {
+      failures.push({ kind: "shim", name });
+    }
+  }
+  return failures;
+}
+
 export function allPinnedResolved(
   dir: string,
   fs: Fs,
   platform: NodeJS.Platform,
 ): boolean {
-  // The same candidate lists installBrowserList and createAppiumServer resolve
-  // from, so this check and those two cannot disagree.
-  const shimsPresent = [playwrightCliCandidates, appiumCliCandidates].every(
-    (candidates) => candidates(dir, platform).some((p) => fs.existsSync(p)),
-  );
-  if (!shimsPresent) {
-    return false;
-  }
-  return pinnedPackages.every(
-    ({ name, version }) => readInstalledVersion(dir, name, fs) === version,
-  );
+  return pinnedResolutionFailures(dir, fs, platform).length === 0;
 }

--- a/src/domains/runtimeEnv/resolvePinned.ts
+++ b/src/domains/runtimeEnv/resolvePinned.ts
@@ -76,6 +76,15 @@ export function pinnedResolutionFailures(
   return failures;
 }
 
+export function describePinnedFailure(failure: PinnedFailure): string {
+  if (failure.kind === "shim") {
+    return `node_modules/.bin/${failure.name} (missing)`;
+  }
+  return failure.installed === undefined
+    ? `${failure.name} (missing, pinned ${failure.pinned})`
+    : `${failure.name} ${failure.installed} (pinned ${failure.pinned})`;
+}
+
 export function allPinnedResolved(
   dir: string,
   fs: Fs,


### PR DESCRIPTION
`--deps` rejection listed no package names, so a plain `npm install` produced the same rejection with no new information. `allPinnedResolved` already computed which packages and shims failed and discarded the detail; the first commit splits that out structurally, the second wires it into the message. Whether `qawolf install --deps <dir>` should exist — the ticket's open question — is deferred, since no CLI command populates a prepared directory today.

Closes WIZ-11293