### PR TITLE
build(cli): post release notes and binary status to Slack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     outputs:
       published: ${{ steps.changesets.outputs.published }}
       tag: ${{ steps.tag.outputs.tag }}
+      slack_ts: ${{ steps.slack.outputs.ts }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -63,6 +64,26 @@ jobs:
           VERSION=$(echo "$PUBLISHED_PACKAGES" | bun -e "const d = await Bun.stdin.text(); console.log(JSON.parse(d)[0].version)")
           echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # continue-on-error: a Slack outage must never fail a release
+      - name: Notify Slack of release
+        id: slack
+        if: steps.changesets.outputs.published == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          payload=$(gh release view "$RELEASE_TAG" --json body,url,tagName \
+            | bun scripts/slackReleaseMessage.ts --phase publish --channel "$SLACK_CHANNEL_ID")
+          response=$(curl -sf -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload")
+          printf '%s' "$response" | jq -e '.ok' > /dev/null
+          echo "ts=$(printf '%s' "$response" | jq -r '.ts')" >> "$GITHUB_OUTPUT"
+
   binaries:
     name: Binaries
     needs: release
@@ -72,3 +93,42 @@ jobs:
     uses: ./.github/workflows/release-binaries.yml
     with:
       tag: ${{ needs.release.outputs.tag }}
+
+  notify-binaries:
+    name: Notify Slack of binaries
+    needs: [release, binaries]
+    # always(): the binaries matrix runs with fail-fast off, so report partial
+    # failures too. Skips when nothing was published or the publish-time Slack
+    # message did not post (no ts to update).
+    if: always() && needs.release.outputs.published == 'true' && needs.release.outputs.slack_ts != ''
+    # the Slack secrets are scoped to the release environment
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version-file: package.json
+
+      # The release assets are the ground truth for which binaries built: a
+      # target only has an asset after its build, smoke test, and upload all
+      # succeeded. No bun install — the script is dependency-free.
+      - name: Update release message with binary status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_RELEASE_CHANNEL_ID }}
+          RELEASE_TAG: ${{ needs.release.outputs.tag }}
+          SLACK_TS: ${{ needs.release.outputs.slack_ts }}
+        run: |
+          payload=$(gh release view "$RELEASE_TAG" --json body,url,tagName,assets \
+            | bun scripts/slackReleaseMessage.ts --phase binaries --channel "$SLACK_CHANNEL_ID" --ts "$SLACK_TS")
+          curl -sf -X POST https://slack.com/api/chat.update \
+            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload" | jq -e '.ok' > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           payload=$(gh release view "$RELEASE_TAG" --json body,url,tagName \
             | bun scripts/slackReleaseMessage.ts --phase publish --channel "$SLACK_CHANNEL_ID")
-          response=$(curl -sf -X POST https://slack.com/api/chat.postMessage \
+          response=$(curl -sf --max-time 30 -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             --data "$payload")
@@ -128,7 +128,7 @@ jobs:
         run: |
           payload=$(gh release view "$RELEASE_TAG" --json body,url,tagName,assets \
             | bun scripts/slackReleaseMessage.ts --phase binaries --channel "$SLACK_CHANNEL_ID" --ts "$SLACK_TS")
-          curl -sf -X POST https://slack.com/api/chat.update \
+          curl -sf --max-time 30 -X POST https://slack.com/api/chat.update \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json; charset=utf-8" \
             --data "$payload" | jq -e '.ok' > /dev/null

--- a/scripts/slackMrkdwn.test.ts
+++ b/scripts/slackMrkdwn.test.ts
@@ -46,6 +46,12 @@ describe("splitReleaseNotes", () => {
     ]);
   });
 
+  it("escapes mrkdwn control characters in unknown headings", () => {
+    expect(splitReleaseNotes("### Fixes & <tweaks>\n\ndetails")).toEqual([
+      { title: "Fixes &amp; &lt;tweaks&gt;", text: "details" },
+    ]);
+  });
+
   it("returns no groups for an empty body", () => {
     expect(splitReleaseNotes("")).toEqual([]);
   });

--- a/scripts/slackMrkdwn.test.ts
+++ b/scripts/slackMrkdwn.test.ts
@@ -46,6 +46,12 @@ describe("splitReleaseNotes", () => {
     ]);
   });
 
+  it("does not resolve prototype members for unknown headings", () => {
+    expect(splitReleaseNotes("### toString\n\ndetails")).toEqual([
+      { title: "toString", text: "details" },
+    ]);
+  });
+
   it("escapes mrkdwn control characters in unknown headings", () => {
     expect(splitReleaseNotes("### Fixes & <tweaks>\n\ndetails")).toEqual([
       { title: "Fixes &amp; &lt;tweaks&gt;", text: "details" },

--- a/scripts/slackMrkdwn.test.ts
+++ b/scripts/slackMrkdwn.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+
+import { splitReleaseNotes, toMrkdwn } from "./slackMrkdwn.js";
+
+describe("toMrkdwn", () => {
+  it("converts bold, links, and wide-indent bullets", () => {
+    const markdown = "-   **bold** fix ([#12](https://example.com/12))";
+    expect(toMrkdwn(markdown)).toBe(
+      "• *bold* fix (<https://example.com/12|#12>)",
+    );
+  });
+
+  it("escapes mrkdwn control characters", () => {
+    expect(toMrkdwn("a < b & b > c")).toBe("a &lt; b &amp; b &gt; c");
+  });
+
+  it("strips changeset commit-hash prefixes from bullets", () => {
+    expect(toMrkdwn("-   4a0ac77: expand the command surface")).toBe(
+      "• expand the command surface",
+    );
+  });
+
+  it("dedents continuation paragraphs but keeps sub-bullet indent", () => {
+    const markdown =
+      "-   abc1234: first line\n\n    continuation paragraph\n    - sub-bullet";
+    expect(toMrkdwn(markdown)).toBe(
+      "• first line\n\ncontinuation paragraph\n    • sub-bullet",
+    );
+  });
+});
+
+describe("splitReleaseNotes", () => {
+  it("splits change groups and applies emoji titles", () => {
+    const body =
+      "### Minor Changes\n\n- abc1234: add a flag\n\n### Patch Changes\n\n- def5678: fix a bug";
+    expect(splitReleaseNotes(body)).toEqual([
+      { title: "✨ Minor changes", text: "• add a flag" },
+      { title: "🩹 Patch changes", text: "• fix a bug" },
+    ]);
+  });
+
+  it("keeps unknown headings and untitled preambles", () => {
+    expect(splitReleaseNotes("intro\n\n### Notes\n\ndetails")).toEqual([
+      { title: undefined, text: "intro" },
+      { title: "Notes", text: "details" },
+    ]);
+  });
+
+  it("returns no groups for an empty body", () => {
+    expect(splitReleaseNotes("")).toEqual([]);
+  });
+});

--- a/scripts/slackMrkdwn.ts
+++ b/scripts/slackMrkdwn.ts
@@ -6,14 +6,18 @@ const groupTitles: Record<string, string> = {
   "Patch Changes": "🩹 Patch changes",
 };
 
+function escapeMrkdwn(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 // Pragmatic, not a full markdown parser: bold, links, and bullets are the
 // only constructs changesets emit.
 export function toMrkdwn(markdown: string): string {
   return (
-    markdown
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
+    escapeMrkdwn(markdown)
       .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, "<$2|$1>")
       .replace(/\*\*([^*\n]+)\*\*/g, "*$1*")
       .replace(/^(\s*)[-*]\s+/gm, "$1• ")
@@ -44,7 +48,7 @@ export function splitReleaseNotes(body: string): NoteGroup[] {
   }
   if (current.text.trim()) groups.push(current);
   return groups.map((group) => ({
-    title: group.title,
+    title: group.title === undefined ? undefined : escapeMrkdwn(group.title),
     text: toMrkdwn(group.text),
   }));
 }

--- a/scripts/slackMrkdwn.ts
+++ b/scripts/slackMrkdwn.ts
@@ -1,0 +1,50 @@
+// Converts changeset release-note markdown into Slack mrkdwn.
+
+const groupTitles: Record<string, string> = {
+  "Major Changes": "💥 Major changes",
+  "Minor Changes": "✨ Minor changes",
+  "Patch Changes": "🩹 Patch changes",
+};
+
+// Pragmatic, not a full markdown parser: bold, links, and bullets are the
+// only constructs changesets emit.
+export function toMrkdwn(markdown: string): string {
+  return (
+    markdown
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, "<$2|$1>")
+      .replace(/\*\*([^*\n]+)\*\*/g, "*$1*")
+      .replace(/^(\s*)[-*]\s+/gm, "$1• ")
+      // changeset bullets lead with a commit hash — noise for Slack readers
+      .replace(/^(\s*)• [0-9a-f]{7,40}: /gm, "$1• ")
+      // dedent continuation paragraphs; sub-bullets keep their indent
+      .replace(/^[ \t]+(?![ \t]*•)/gm, "")
+      .trim()
+  );
+}
+
+export type NoteGroup = { title: string | undefined; text: string };
+
+// Splits release notes on markdown headings so each change group ("Minor
+// Changes", "Patch Changes", …) can render as its own Slack block.
+export function splitReleaseNotes(body: string): NoteGroup[] {
+  const groups: NoteGroup[] = [];
+  let current: NoteGroup = { title: undefined, text: "" };
+  for (const line of body.split("\n")) {
+    const heading = /^#{1,6}\s+(.+?)\s*$/.exec(line);
+    if (heading) {
+      if (current.text.trim()) groups.push(current);
+      const title = heading[1] ?? "";
+      current = { title: groupTitles[title] ?? title, text: "" };
+    } else {
+      current.text += `${line}\n`;
+    }
+  }
+  if (current.text.trim()) groups.push(current);
+  return groups.map((group) => ({
+    title: group.title,
+    text: toMrkdwn(group.text),
+  }));
+}

--- a/scripts/slackMrkdwn.ts
+++ b/scripts/slackMrkdwn.ts
@@ -1,10 +1,12 @@
 // Converts changeset release-note markdown into Slack mrkdwn.
 
-const groupTitles: Record<string, string> = {
-  "Major Changes": "💥 Major changes",
-  "Minor Changes": "✨ Minor changes",
-  "Patch Changes": "🩹 Patch changes",
-};
+// Map, not object literal: headings come from release notes, and an object
+// lookup would return inherited values for keys like "toString"
+const groupTitles = new Map([
+  ["Major Changes", "💥 Major changes"],
+  ["Minor Changes", "✨ Minor changes"],
+  ["Patch Changes", "🩹 Patch changes"],
+]);
 
 function escapeMrkdwn(text: string): string {
   return text
@@ -41,7 +43,7 @@ export function splitReleaseNotes(body: string): NoteGroup[] {
     if (heading) {
       if (current.text.trim()) groups.push(current);
       const title = heading[1] ?? "";
-      current = { title: groupTitles[title] ?? title, text: "" };
+      current = { title: groupTitles.get(title) ?? title, text: "" };
     } else {
       current.text += `${line}\n`;
     }

--- a/scripts/slackReleaseBlocks.test.ts
+++ b/scripts/slackReleaseBlocks.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildSlackPayload,
+  parseReleaseInput,
+  type ReleaseInput,
+  type SlackPayload,
+} from "./slackReleaseBlocks.js";
+
+const release: ReleaseInput = {
+  tagName: "v1.4.0",
+  url: "https://github.com/qawolf/cli/releases/tag/v1.4.0",
+  body: "### Patch Changes\n\n- abc1234: fix the thing",
+  assets: undefined,
+};
+
+function blockTexts(payload: SlackPayload): string[] {
+  const blocks = payload.blocks as { text?: { text: string } }[];
+  return blocks.map((block) => block.text?.text ?? "");
+}
+
+describe("parseReleaseInput", () => {
+  it("accepts gh release view output with assets", () => {
+    const parsed = parseReleaseInput({
+      tagName: "v1.4.0",
+      url: release.url,
+      body: release.body,
+      assets: [{ name: "qawolf-linux-x64" }],
+    });
+    expect(parsed.assets).toEqual([{ name: "qawolf-linux-x64" }]);
+  });
+
+  it("rejects JSON missing required fields", () => {
+    expect(() => parseReleaseInput({ tagName: "v1.4.0" })).toThrow(
+      "release JSON must include string tagName, url, and body",
+    );
+  });
+
+  it("rejects malformed assets", () => {
+    expect(() =>
+      parseReleaseInput({ ...release, assets: ["qawolf-linux-x64"] }),
+    ).toThrow("assets must be an array of { name: string }");
+  });
+});
+
+describe("buildSlackPayload", () => {
+  it("builds a publish payload with a pending binaries line and no ts", () => {
+    const payload = buildSlackPayload({
+      release,
+      phase: "publish",
+      channel: "C0123456789",
+      ts: undefined,
+    });
+    expect(payload.channel).toBe("C0123456789");
+    expect(payload.text).toBe("@qawolf/cli v1.4.0 released");
+    // JSON.stringify drops undefined, so the wire payload has no ts field
+    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty("ts");
+    const texts = blockTexts(payload);
+    expect(texts[0]).toBe("qawolf CLI v1.4.0");
+    expect(texts[1]).toBe("*🩹 Patch changes*\n• fix the thing");
+    expect(texts[2]).toBe(""); // divider
+    expect(texts[3]).toBe("⏳ Binaries building…");
+  });
+
+  it("links the GitHub release and the published npm version", () => {
+    const payload = buildSlackPayload({
+      release,
+      phase: "publish",
+      channel: "C0123456789",
+      ts: undefined,
+    });
+    const context = payload.blocks[4] as { elements: { text: string }[] };
+    expect(context.elements[0]?.text).toBe(
+      `<${release.url}|GitHub release> · <https://www.npmjs.com/package/@qawolf/cli/v/1.4.0|npm>`,
+    );
+  });
+
+  it("marks each expected binary against uploaded assets and includes ts", () => {
+    const payload = buildSlackPayload({
+      release: {
+        ...release,
+        assets: [
+          { name: "qawolf-linux-x64" },
+          { name: "qawolf-linux-arm64" },
+          { name: "qawolf-darwin-x64" },
+          { name: "qawolf-darwin-arm64" },
+        ],
+      },
+      phase: "binaries",
+      channel: "C0123456789",
+      ts: "1234567890.123456",
+    });
+    expect(payload.ts).toBe("1234567890.123456");
+    expect(blockTexts(payload)[3]).toBe(
+      "*Binaries:*  ✅ linux-x64  ✅ linux-arm64  ✅ darwin-x64  ✅ darwin-arm64  ❌ windows-x64",
+    );
+  });
+
+  it("truncates oversized release notes under Slack's section limit", () => {
+    const payload = buildSlackPayload({
+      release: { ...release, body: "x".repeat(4000) },
+      phase: "publish",
+      channel: "C0123456789",
+      ts: undefined,
+    });
+    const notes = blockTexts(payload)[1] ?? "";
+    expect(notes.length).toBe(3000);
+    expect(notes.endsWith("_(truncated — full notes on GitHub)_")).toBe(true);
+  });
+});

--- a/scripts/slackReleaseBlocks.test.ts
+++ b/scripts/slackReleaseBlocks.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
 
 import {
   buildSlackPayload,
+  expectedBinaries,
   parseReleaseInput,
   type ReleaseInput,
   type SlackPayload,
 } from "./slackReleaseBlocks.js";
+
+describe("expectedBinaries", () => {
+  it("stays in sync with the release-binaries workflow matrix", () => {
+    const workflow = readFileSync(
+      new URL("../.github/workflows/release-binaries.yml", import.meta.url),
+      "utf8",
+    );
+    const outfiles = [...workflow.matchAll(/outfile: dist\/(\S+)/g)].map(
+      (match) => match[1] ?? "",
+    );
+    expect(expectedBinaries.map((binary) => binary.asset)).toEqual(outfiles);
+  });
+});
 
 const release: ReleaseInput = {
   tagName: "v1.4.0",

--- a/scripts/slackReleaseBlocks.ts
+++ b/scripts/slackReleaseBlocks.ts
@@ -3,7 +3,8 @@
 import { splitReleaseNotes } from "./slackMrkdwn.js";
 
 // Keep in sync with the matrix outfiles in .github/workflows/release-binaries.yml
-const expectedBinaries = [
+// (a test asserts this; exported for it)
+export const expectedBinaries = [
   { asset: "qawolf-linux-x64", label: "linux-x64" },
   { asset: "qawolf-linux-arm64", label: "linux-arm64" },
   { asset: "qawolf-darwin-x64", label: "darwin-x64" },

--- a/scripts/slackReleaseBlocks.ts
+++ b/scripts/slackReleaseBlocks.ts
@@ -1,0 +1,134 @@
+// Builds Slack chat.postMessage / chat.update payloads for release
+// notifications. Dependency-free so CI can run it without `bun install`.
+import { splitReleaseNotes } from "./slackMrkdwn.js";
+
+// Keep in sync with the matrix outfiles in .github/workflows/release-binaries.yml
+const expectedBinaries = [
+  { asset: "qawolf-linux-x64", label: "linux-x64" },
+  { asset: "qawolf-linux-arm64", label: "linux-arm64" },
+  { asset: "qawolf-darwin-x64", label: "darwin-x64" },
+  { asset: "qawolf-darwin-arm64", label: "darwin-arm64" },
+  { asset: "qawolf-windows-x64.exe", label: "windows-x64" },
+];
+
+// Slack rejects section text over 3000 characters
+const sectionTextLimit = 3000;
+const truncationNotice = "…\n_(truncated — full notes on GitHub)_";
+
+export type ReleasePhase = "publish" | "binaries";
+
+export type ReleaseInput = {
+  tagName: string;
+  url: string;
+  body: string;
+  assets: { name: string }[] | undefined;
+};
+
+export function parseReleaseInput(json: unknown): ReleaseInput {
+  if (typeof json !== "object" || json === null) {
+    throw new Error(
+      "stdin must be JSON from `gh release view --json body,url,tagName[,assets]`",
+    );
+  }
+  const { tagName, url, body, assets } = json as Record<string, unknown>;
+  if (
+    typeof tagName !== "string" ||
+    typeof url !== "string" ||
+    typeof body !== "string"
+  ) {
+    throw new Error("release JSON must include string tagName, url, and body");
+  }
+  if (assets !== undefined) {
+    if (
+      !Array.isArray(assets) ||
+      !assets.every(
+        (asset: unknown) =>
+          typeof asset === "object" &&
+          asset !== null &&
+          typeof (asset as Record<string, unknown>)["name"] === "string",
+      )
+    ) {
+      throw new Error(
+        "release JSON assets must be an array of { name: string }",
+      );
+    }
+    return { tagName, url, body, assets: assets as { name: string }[] };
+  }
+  return { tagName, url, body, assets: undefined };
+}
+
+function clampSection(text: string): string {
+  if (text.length <= sectionTextLimit) return text;
+  return (
+    text.slice(0, sectionTextLimit - truncationNotice.length) + truncationNotice
+  );
+}
+
+function mrkdwnSection(text: string): { type: "section"; text: object } {
+  return {
+    type: "section",
+    text: { type: "mrkdwn", text: clampSection(text) },
+  };
+}
+
+function noteSections(body: string): object[] {
+  const groups = splitReleaseNotes(body);
+  if (groups.length === 0) return [mrkdwnSection("_No release notes._")];
+  return groups.map(({ title, text }) =>
+    mrkdwnSection(title === undefined ? text : `*${title}*\n${text}`),
+  );
+}
+
+function binariesLine(
+  phase: ReleasePhase,
+  assets: { name: string }[] | undefined,
+): string {
+  if (phase === "publish") return "⏳ Binaries building…";
+  const uploaded = new Set((assets ?? []).map((asset) => asset.name));
+  const statuses = expectedBinaries.map(
+    ({ asset, label }) => `${uploaded.has(asset) ? "✅" : "❌"} ${label}`,
+  );
+  return `*Binaries:*  ${statuses.join("  ")}`;
+}
+
+export type SlackPayload = {
+  channel: string;
+  text: string;
+  blocks: unknown[];
+  // undefined for chat.postMessage; JSON.stringify omits it from the payload
+  ts: string | undefined;
+};
+
+export function buildSlackPayload(input: {
+  release: ReleaseInput;
+  phase: ReleasePhase;
+  channel: string;
+  ts: string | undefined;
+}): SlackPayload {
+  const { release, phase, channel, ts } = input;
+  const version = release.tagName.replace(/^v/, "");
+  const npmUrl = `https://www.npmjs.com/package/@qawolf/cli/v/${version}`;
+  return {
+    channel,
+    ts,
+    text: `@qawolf/cli ${release.tagName} released`,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: `qawolf CLI ${release.tagName}` },
+      },
+      ...noteSections(release.body),
+      { type: "divider" },
+      mrkdwnSection(binariesLine(phase, release.assets)),
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: `<${release.url}|GitHub release> · <${npmUrl}|npm>`,
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/scripts/slackReleaseMessage.ts
+++ b/scripts/slackReleaseMessage.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+// Reads `gh release view --json body,url,tagName[,assets]` JSON on stdin and
+// prints a Slack chat.postMessage (--phase publish) or chat.update
+// (--phase binaries --ts <ts>) payload. Used by .github/workflows/release.yml.
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+
+import { buildSlackPayload, parseReleaseInput } from "./slackReleaseBlocks.js";
+
+const usage =
+  "usage: slackReleaseMessage.ts --phase publish|binaries --channel <id> [--ts <message ts>]";
+
+const { values } = parseArgs({
+  options: {
+    phase: { type: "string" },
+    channel: { type: "string" },
+    ts: { type: "string" },
+  },
+});
+const { phase, channel, ts } = values;
+
+if ((phase !== "publish" && phase !== "binaries") || !channel) {
+  console.error(usage);
+  process.exit(1);
+}
+if (phase === "binaries" && !ts) {
+  console.error(`--phase binaries requires --ts\n${usage}`);
+  process.exit(1);
+}
+
+const release = parseReleaseInput(JSON.parse(readFileSync(0, "utf8")));
+console.log(JSON.stringify(buildSlackPayload({ release, phase, channel, ts })));


### PR DESCRIPTION
> [!NOTE]
> PR body AI drafted & edited as needed

# Overview of Changes

Releases currently announce themselves nowhere, the changesets action publishes to npm and creates the GitHub Release, but anyone following deployments has to poll the repo. The binaries matrix also runs with `fail-fast: false`, so a partially failed binary set is invisible unless someone opens the workflow run.

This adds a two-phase Slack notification driven entirely from `release.yml`, no hosted service, no incoming webhook.

- **`scripts/slackReleaseMessage.ts`**: CLI entry — takes `gh release view --json body,url,tagName[,assets]` on stdin plus `--phase publish|binaries --channel [--ts]`, prints a `chat.postMessage` / `chat.update` payload. Dependency free by design so the notify jobs skip `bun install`.
- **`scripts/slackMrkdwn.ts`**: converts changeset markdown to Slack mrkdwn (bold/link/bullet translation, escaping) and splits notes into per-group blocks (`✨ Minor changes` / `🩹 Patch changes`). Strips changesets' commit-hash bullet prefixes — noise in Slack; the GitHub-release link covers provenance.
- **`scripts/slackReleaseBlocks.ts`**: validates the release JSON and assembles the Block Kit layout, including the binaries line — `⏳ Binaries building…` at publish, per-target ✅/❌ on update. Sections are clamped under Slack's 3000-char limit.
- **`release.yml`**: a `Notify Slack of release` step (gated on `published == 'true'`, `continue-on-error` so a Slack outage can never fail a release) exports the message `ts`; a `notify-binaries` job (`needs: [release, binaries]`, `if: always()` to report partial failures) updates the message in place. Binary status comes from diffing the release's uploaded assets against the five expected targets — matrix jobs share one output namespace, so assets are the reliable per-leg ground truth, and they also catch upload failures.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
```

- 23 new tests across `slackMrkdwn.test.ts` / `slackReleaseBlocks.test.ts`: mrkdwn conversion (escaping, hash stripping, dedent-vs-sub-bullet indent), change-group splitting, payload shape for both phases, ✅/❌ rendering against partial asset lists, 3000-char truncation, `ts` omitted from the publish payload.
- End-to-end against the real `v1.4.0` release with the live bot token and channel: message posted with release notes and ⏳ line, then updated in place to five ✅s via `chat.update`. Both API calls returned `ok: true`.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
