### PR TITLE
fix(runner): import resolved packages via file:// URLs on win32

### DIFF
--- a/.changeset/windows-import-file-urls.md
+++ b/.changeset/windows-import-file-urls.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Fix Windows runs failing with "Could not load @qawolf/testkit ... Received protocol 'c:'". The Node ESM loader requires file:// URLs for absolute paths on win32, so the testkit, Playwright, and emails loaders now convert resolved paths before dynamic import.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,13 @@ jobs:
       - name: Smoke — cmd.exe argument escaping round-trips
         shell: bash
         run: node test/spawn/cmdEscapeSmoke.mjs
+      # Only Node-on-win32 rejects raw absolute paths in import() ("protocol
+      # 'c:'"), so only this job catches a regression in the file:// URL
+      # conversion. WIZ-11313 shipped through that gap.
+      - name: Bundle testkit loader for smoke
+        shell: bash
+        run: |
+          bun build src/shell/testkit.ts --target=node --format=esm --outfile test/testkit/testkit.generated.mjs
+      - name: Smoke — testkit loads from an absolute win32 path
+        shell: bash
+        run: node test/testkit/loadSmoke.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/generated/
 # Generated smoke-test bundles (built in CI)
 test/node20/loader.generated.mjs
 test/spawn/*.generated.mjs
+test/testkit/*.generated.mjs
 
 # Environment
 .env

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -107,7 +107,8 @@
     "node_modules/",
     "knip.config.ts",
     "test/node20/",
-    "test/spawn/"
+    "test/spawn/",
+    "test/testkit/"
   ],
   "overrides": [
     {

--- a/src/domains/emails/configureEmails.ts
+++ b/src/domains/emails/configureEmails.ts
@@ -4,6 +4,7 @@ import type {
   createEmailsClient,
 } from "@qawolf/emails";
 
+import { importFromPath } from "~/shell/importFromPath.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
 import { packageLoadFailed } from "~/core/messages/index.js";
 import { errorMessage } from "~/core/errors.js";
@@ -26,7 +27,7 @@ export type EmailsConfig =
 async function loadSdkDeps(cwd: string): Promise<EmailsModule> {
   try {
     const emailsPath = resolveFromEnvDir(cwd, "@qawolf/emails");
-    return (await import(emailsPath)) as EmailsModule;
+    return (await importFromPath(emailsPath)) as EmailsModule;
   } catch (err) {
     throw new Error(
       packageLoadFailed("@qawolf/emails", cwd, errorMessage(err)),

--- a/src/domains/runner/runWebFlowDeps.ts
+++ b/src/domains/runner/runWebFlowDeps.ts
@@ -1,6 +1,7 @@
 import { createRunnerDeps } from "./runnerDeps.js";
 import type { RunWebFlowDeps } from "./runWebFlow.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+import { importFromPath } from "~/shell/importFromPath.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
 import { runnerMessages } from "~/core/messages/index.js";
 import { errorMessage } from "~/core/errors.js";
@@ -21,7 +22,7 @@ export async function defaultRunWebFlowDeps(
   let playwright: Pick<RunWebFlowDeps, "chromium" | "firefox" | "webkit">;
   try {
     const playwrightPath = resolveFromEnvDir(envDir, "playwright");
-    playwright = (await import(playwrightPath)) as Pick<
+    playwright = (await importFromPath(playwrightPath)) as Pick<
       RunWebFlowDeps,
       "chromium" | "firefox" | "webkit"
     >;

--- a/src/shell/importFromPath.test.ts
+++ b/src/shell/importFromPath.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { importFromPath } from "./importFromPath.js";
+import { makeTmpDirTracker } from "./tmpDir.testUtils.js";
+
+const tmp = makeTmpDirTracker("qawolf-import-from-path-");
+
+afterEach(() => tmp.cleanup());
+
+describe("importFromPath", () => {
+  it("imports a module addressed by absolute filesystem path", async () => {
+    const dir = await tmp.makeTmpDir();
+    const modPath = join(dir, "fixture.mjs");
+    await writeFile(modPath, 'export const loaded = "esm-ok";\n');
+
+    const mod = (await importFromPath(modPath)) as { loaded?: string };
+
+    expect(mod.loaded).toBe("esm-ok");
+  });
+});

--- a/src/shell/importFromPath.ts
+++ b/src/shell/importFromPath.ts
@@ -1,0 +1,9 @@
+import { pathToFileURL } from "node:url";
+
+/** Dynamically imports the module at an absolute filesystem path. */
+export function importFromPath(absPath: string): Promise<unknown> {
+  // import() takes a URL, not a path. POSIX paths happen to parse as URL
+  // paths, but a Windows path ("C:\...") parses as URL protocol "c:", which
+  // the Node ESM loader rejects (WIZ-11313).
+  return import(pathToFileURL(absPath).href);
+}

--- a/src/shell/testkit.ts
+++ b/src/shell/testkit.ts
@@ -3,6 +3,7 @@ import type { createTestkitClient } from "@qawolf/testkit/client";
 import type { configureTestkitClient } from "@qawolf/testkit";
 
 import { runnerMessages } from "~/core/messages/index.js";
+import { importFromPath } from "~/shell/importFromPath.js";
 import { resolveFromEnvDir } from "~/shell/resolveExport.js";
 import { packageLoadFailed } from "~/core/messages/index.js";
 import { errorMessage } from "~/core/errors.js";
@@ -27,8 +28,8 @@ function notAvailableLocally(name: string): never {
 async function loadSdkDeps(cwd: string): Promise<TestkitModule> {
   const testkitDir = join(cwd, "node_modules", "@qawolf", "testkit");
   try {
-    const clientMod = (await import(
-      resolveFromEnvDir(cwd, "@qawolf/testkit/client")
+    const clientMod = (await importFromPath(
+      resolveFromEnvDir(cwd, "@qawolf/testkit/client"),
     )) as Pick<TestkitModule, "createTestkitClient">;
     if (typeof clientMod.createTestkitClient !== "function")
       throw new Error("createTestkitClient is not a function");
@@ -36,8 +37,8 @@ async function loadSdkDeps(cwd: string): Promise<TestkitModule> {
     // TODO WIZ-10612: route through resolveFromEnvDir once @qawolf/testkit
     // exposes a dedicated exports-map entry, or Bun fixes the scoped-package
     // traversal bug that prevents loading the main entry here.
-    const scopeMod = (await import(
-      join(testkitDir, "dist", "clientScope.js")
+    const scopeMod = (await importFromPath(
+      join(testkitDir, "dist", "clientScope.js"),
     )) as Pick<TestkitModule, "configureTestkitClient">;
     if (typeof scopeMod.configureTestkitClient !== "function")
       throw new Error("configureTestkitClient is not a function");

--- a/test/testkit/loadSmoke.mjs
+++ b/test/testkit/loadSmoke.mjs
@@ -1,0 +1,44 @@
+// End-to-end witness for WIZ-11313: loading @qawolf/testkit from its absolute
+// on-disk path must survive the Node ESM loader on win32, where a raw
+// "C:\..." import specifier parses as URL protocol "c:" and is rejected.
+// Drives the REAL shipped loader — testkit.generated.mjs is
+// `src/shell/testkit.ts` bundled by bun (see the windows-smoke CI job);
+// bundling resolves the `~/` path alias that Node cannot.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { configureTestkit } from "./testkit.generated.mjs";
+
+const envDir = await mkdtemp(join(tmpdir(), "qawolf-testkit-smoke-"));
+try {
+  const pkgDir = join(envDir, "node_modules", "@qawolf", "testkit");
+  await mkdir(join(pkgDir, "dist"), { recursive: true });
+  await writeFile(
+    join(pkgDir, "package.json"),
+    JSON.stringify({
+      name: "@qawolf/testkit",
+      version: "0.0.0-smoke",
+      exports: { "./client": "./dist/client.js" },
+    }),
+  );
+  await writeFile(
+    join(pkgDir, "dist", "client.js"),
+    "export function createTestkitClient(ports) { return { ports }; }\n",
+  );
+  await writeFile(
+    join(pkgDir, "dist", "clientScope.js"),
+    "export function configureTestkitClient(client) { globalThis.__qawolfSmokeClient = client; }\n",
+  );
+
+  await configureTestkit(envDir);
+
+  if (globalThis.__qawolfSmokeClient === undefined) {
+    console.error("testkit load smoke FAILED: client was not registered");
+    process.exit(1);
+  }
+} finally {
+  await rm(envDir, { recursive: true, force: true });
+}
+
+console.log(`testkit load smoke OK on ${process.platform}`);


### PR DESCRIPTION
Fixes WIZ-11313.

## Problem

`qawolf flows run` on Windows fails with:

`Could not load @qawolf/testkit ... Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`

The npm-installed CLI runs under Node, and `import()` treats its argument as a URL, not a filesystem path. POSIX paths happen to parse as URL paths, but a Windows path (`C:\...`) parses as URL protocol `c:`, which Node's ESM loader rejects. Four call sites passed raw `resolveFromEnvDir()`/`join()` paths to `import()`: the testkit loader (both imports — the reported failure), the Playwright loader, and the emails loader.

## Fix

New `src/shell/importFromPath.ts` converts an absolute path to a `file://` URL via `pathToFileURL` before importing; all four sites now use it. Same-module-instance semantics are unchanged on POSIX (Node keys its ESM cache by the resolved `file://` URL, which is identical for both forms), so the shared-AsyncLocalStorage invariant holds.

## Regression guard

The `windows-smoke` CI job gains a smoke that bundles the real `src/shell/testkit.ts` and drives `configureTestkit` under Node on win32 against a fixture `@qawolf/testkit` — red on the previous code (`Received protocol 'c:'`), green with the fix. Only Node-on-win32 rejects raw absolute-path specifiers, so only that job can catch a regression here.

## Testing

- Full suite (1260 tests), lint, format, typecheck, knip pass
- Smoke passes under Node 24 on darwin; mechanism repro confirmed (`import("C:\\temp\\x.js")` throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` on any platform)
- Verified working on a win 11 machine to launch and pass a web test