### PR TITLE
feat(flows): pick an environment interactively when --env is omitted

### DIFF
--- a/.changeset/interactive-environment-picker.md
+++ b/.changeset/interactive-environment-picker.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": minor
+---
+
+`flows pull` and `flows list --remote` no longer require `--env`. When the flag is omitted, the CLI reads `QAWOLF_ENVIRONMENT`, and in an interactive terminal it otherwise lists the team's environments and prompts for a pick — auto-selecting when only one exists. Teams with both static and preview (PR) environments first pick a kind, so ephemeral PR environments don't drown out the static ones. Non-interactive runs without a flag or env var still fail with a clear error, so CI and agent behavior stays deterministic.
+
+The `@qawolf/api-contracts` bump to 0.14.0 also adds three generated commands: `environment find`, `environment setVariable`, and `flow addTag`.

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@napi-rs/keyring": "1.3.0",
         "@oxc-node/core": "0.1.0",
         "@playwright/test": "1.60.0",
-        "@qawolf/api-contracts": "0.11.0",
+        "@qawolf/api-contracts": "0.14.0",
         "@qawolf/emails": "1.1.1",
         "@qawolf/flow-targets": "1.0.0",
         "@qawolf/flows": "0.1.4",
@@ -462,7 +462,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@2.13.2", "", { "dependencies": { "debug": "^4.4.3", "extract-zip": "^2.0.1", "progress": "^2.0.3", "proxy-agent": "^6.5.0", "semver": "^7.7.4", "tar-fs": "^3.1.1", "yargs": "^17.7.2" }, "bin": { "browsers": "lib/cjs/main-cli.js" } }, "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw=="],
 
-    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.11.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-yO9bImex06ph3No4iixqZLMFflSuzFciw4bHjitkeNaIs44IdTXlAih1yE1wiQMknEsjBxKZEO6YfdZxomFIEg=="],
+    "@qawolf/api-contracts": ["@qawolf/api-contracts@0.14.0", "", { "dependencies": { "tslib": "^2.5.3" }, "peerDependencies": { "zod": "^4.1.11" } }, "sha512-CEHYzyAtsGRsTdhEKZIXjcRi9Q7bFdWwUjvQxFhmJMrLUcJa12t2qTv6wAFRFxp7dqiCiZZqJbjCoBCZBN5b1w=="],
 
     "@qawolf/emailer-types": ["@qawolf/emailer-types@1.1.0", "", { "dependencies": { "email-addresses": "^5.0.0", "tslib": "^2.5.3", "zod": "^4.1.11", "zod-form-data": "^3.0.1" } }, "sha512-7cX+e31L9dpO8fntQ2cfSMt/1Lla/yUjaLUr/KLpXuscBSajy7CgNzjAGURa1KsCcxz7n+9PGQw6cM3RlC1bSg=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@napi-rs/keyring": "1.3.0",
     "@oxc-node/core": "0.1.0",
     "@playwright/test": "1.60.0",
-    "@qawolf/api-contracts": "0.11.0",
+    "@qawolf/api-contracts": "0.14.0",
     "@qawolf/emails": "1.1.1",
     "@qawolf/flow-targets": "1.0.0",
     "@qawolf/flows": "0.1.4",

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -48,8 +48,11 @@ write on timeout: it may have reached the server the first time.
 | `qawolf automate`                      | write                      | Request an automation that builds the selected draft flows in an environment.                                              |
 | `qawolf doctor`                        | local                      | Diagnose problems running flows locally                                                                                    |
 | `qawolf environment create`            | write                      | Create an environment on the caller's team and return it in the environment.get shape.                                     |
+| `qawolf environment find`              | read                       | List the team's environments, newest first.                                                                                |
 | `qawolf environment get`               | read                       | Read a single environment's name, kind, health status, and termination state.                                              |
 | `qawolf environment listVariableNames` | read                       | List the names of an environment's variables, sorted. Names only — values never leave the server.                          |
+| `qawolf environment setVariable`       | write                      | Create or replace one environment variable by name and return its stored name. The value is never returned.                |
+| `qawolf flow addTag`                   | write                      | Assign an existing tag to the selected flows. Create tags with tag.create.                                                 |
 | `qawolf flows list`                    | local (read with --remote) | List flows matching [pattern] from the local project, or from a QA Wolf environment with --remote                          |
 | `qawolf flows pull`                    | read                       | Download an environment's flows into the local .qawolf/<env>/ cache                                                        |
 | `qawolf flows run`                     | local (read with --env)    | Run flows matching [pattern], or every flow when omitted; with --env, pull missing flows from that QA Wolf environment     |

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -213,7 +213,8 @@ environment with --remote
 Options:
   --remote          List flows from the QA Wolf platform instead of the local
                     project (default: false)
-  --env <env>       Environment to list flows from (required with --remote)
+  --env <env>       Environment to list flows from (with --remote; defaults to
+                    QAWOLF_ENVIRONMENT, or an interactive picker)
   --include-drafts  Include draft flows in the listing (requires --remote)
                     (default: false)
   -h, --help        display help for command
@@ -232,7 +233,8 @@ exports[`--help output qawolf flows pull 1`] = `
 Download an environment's flows into the local .qawolf/<env>/ cache
 
 Options:
-  --env <env>   Environment to pull from (UUID or kebab-case slug)
+  --env <env>   Environment to pull from (UUID or kebab-case slug); defaults to
+                QAWOLF_ENVIRONMENT, or an interactive picker
   --out <path>  Destination directory (defaults to .qawolf/<env>/)
   --yes         Overwrite locally-modified files without prompting (default:
                 false)

--- a/src/commands/__snapshots__/help.test.ts.snap
+++ b/src/commands/__snapshots__/help.test.ts.snap
@@ -23,6 +23,7 @@ Commands:
   automate [options]           Request an automation that builds the selected
                                draft flows in an environment.
   environment                  QA Wolf public API environment commands
+  flow                         QA Wolf public API flow commands
   issue                        QA Wolf public API issue commands
   run                          Trigger and manage QA Wolf runs on the platform
   tag                          QA Wolf public API tag commands

--- a/src/commands/flows/index.ts
+++ b/src/commands/flows/index.ts
@@ -1,18 +1,16 @@
 import type { Command } from "commander";
 
 import { declareCommandKind } from "~/commands/commandKind.js";
-import { withAuthContext, withContext } from "~/commands/context.js";
+import { withContext } from "~/commands/context.js";
 import { flowsMessages } from "~/core/messages/index.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 
 import { handleFlowsList } from "~/domains/flows/list.js";
 import { flowsListRemote } from "~/domains/flows/listRemote.js";
-import {
-  type FlowsPullOptions,
-  handleFlowsPull,
-} from "~/domains/flows/pull/handler.js";
+import { registerFlowsPullCommand } from "./pull.register.js";
 import { registerFlowsRunCommand } from "./run.register.js";
 import { registerRunWorkerCommand } from "./runWorker.register.js";
+import { withResolvedEnv } from "./withResolvedEnv.js";
 
 const listExamples = `
 Examples:
@@ -26,12 +24,6 @@ type FlowsListOptions = {
   readonly env: string | undefined;
   readonly includeDrafts: boolean;
 };
-
-const pullExamples = `
-Examples:
-  $ qawolf flows pull --env staging
-  $ qawolf flows pull --env 4e9c... --out ./snapshot
-  $ qawolf flows pull --env staging --yes`;
 
 export function registerFlowsCommand(
   program: Command,
@@ -57,7 +49,7 @@ export function registerFlowsCommand(
     )
     .option(
       "--env <env>",
-      "Environment to list flows from (required with --remote)",
+      "Environment to list flows from (with --remote; defaults to QAWOLF_ENVIRONMENT, or an interactive picker)",
     )
     .option(
       "--include-drafts",
@@ -72,17 +64,17 @@ export function registerFlowsCommand(
         command: Command,
       ) => {
         if (opts.remote) {
-          const env = opts.env;
-          if (env === undefined) {
-            return withContext(signals, async () => ({
-              error: flowsMessages.list.remoteRequiresEnv,
-            }))(opts, command);
-          }
-          return withAuthContext(signals, (ctx) =>
-            flowsListRemote(ctx, pattern, {
-              env,
-              includeDrafts: opts.includeDrafts,
-            }),
+          return withResolvedEnv(
+            signals,
+            {
+              explicit: opts.env,
+              requiredMessage: flowsMessages.list.remoteRequiresEnv,
+            },
+            (ctx, env) =>
+              flowsListRemote(ctx, pattern, {
+                env,
+                includeDrafts: opts.includeDrafts,
+              }),
           )(opts, command);
         }
         if (opts.env !== undefined || opts.includeDrafts) {
@@ -97,28 +89,5 @@ export function registerFlowsCommand(
       },
     );
 
-  declareCommandKind(flows.command("pull"), "read")
-    .description(
-      "Download an environment's flows into the local .qawolf/<env>/ cache",
-    )
-    .requiredOption(
-      "--env <env>",
-      "Environment to pull from (UUID or kebab-case slug)",
-    )
-    .option(
-      "--out <path>",
-      "Destination directory (defaults to .qawolf/<env>/)",
-    )
-    .option(
-      "--yes",
-      "Overwrite locally-modified files without prompting",
-      false,
-    )
-    .addHelpText("after", pullExamples)
-    .action((opts: FlowsPullOptions, command: Command) => {
-      return withAuthContext(signals, (ctx) => handleFlowsPull(ctx, opts))(
-        opts,
-        command,
-      );
-    });
+  registerFlowsPullCommand(flows, signals);
 }

--- a/src/commands/flows/pull.register.ts
+++ b/src/commands/flows/pull.register.ts
@@ -1,0 +1,51 @@
+import type { Command } from "commander";
+
+import { declareCommandKind } from "~/commands/commandKind.js";
+import { flowsMessages } from "~/core/messages/index.js";
+import {
+  type FlowsPullOptions,
+  handleFlowsPull,
+} from "~/domains/flows/pull/handler.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+import { withResolvedEnv } from "./withResolvedEnv.js";
+
+const pullExamples = `
+Examples:
+  $ qawolf flows pull --env staging
+  $ qawolf flows pull --env 4e9c... --out ./snapshot
+  $ qawolf flows pull --env staging --yes`;
+
+type FlowsPullCliOptions = Omit<FlowsPullOptions, "env"> & {
+  readonly env: string | undefined;
+};
+
+export function registerFlowsPullCommand(
+  flows: Command,
+  signals: SignalRegistry,
+): void {
+  declareCommandKind(flows.command("pull"), "read")
+    .description(
+      "Download an environment's flows into the local .qawolf/<env>/ cache",
+    )
+    .option(
+      "--env <env>",
+      "Environment to pull from (UUID or kebab-case slug); defaults to QAWOLF_ENVIRONMENT, or an interactive picker",
+    )
+    .option(
+      "--out <path>",
+      "Destination directory (defaults to .qawolf/<env>/)",
+    )
+    .option(
+      "--yes",
+      "Overwrite locally-modified files without prompting",
+      false,
+    )
+    .addHelpText("after", pullExamples)
+    .action((opts: FlowsPullCliOptions, command: Command) => {
+      return withResolvedEnv(
+        signals,
+        { explicit: opts.env, requiredMessage: flowsMessages.pull.requiresEnv },
+        (ctx, env) => handleFlowsPull(ctx, { ...opts, env }),
+      )(opts, command);
+    });
+}

--- a/src/commands/flows/withResolvedEnv.ts
+++ b/src/commands/flows/withResolvedEnv.ts
@@ -13,7 +13,7 @@ import { detectOutputMode, type OutputFlags } from "~/shell/ui/env.js";
 type Args = {
   // The --env flag value for this invocation.
   explicit: string | undefined;
-  // Command-specific "--env is required" text.
+  // Command-specific "an environment is required" text.
   requiredMessage: string;
 };
 

--- a/src/commands/flows/withResolvedEnv.ts
+++ b/src/commands/flows/withResolvedEnv.ts
@@ -1,0 +1,64 @@
+import type { Command } from "commander";
+
+import { withAuthContext, withContext } from "~/commands/context.js";
+import { environmentsMessages } from "~/core/messages/index.js";
+import { resolveEnvironment } from "~/domains/environments/resolveEnvironment.js";
+import type {
+  AuthCommandContext,
+  CommandResult,
+} from "~/shell/commandContext.js";
+import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+import { detectOutputMode, type OutputFlags } from "~/shell/ui/env.js";
+
+type Args = {
+  // The --env flag value for this invocation.
+  explicit: string | undefined;
+  // Command-specific "--env is required" text.
+  requiredMessage: string;
+};
+
+/**
+ * Wraps a platform command action with environment resolution: --env flag,
+ * then QAWOLF_ENVIRONMENT, then the interactive picker.
+ */
+export function withResolvedEnv(
+  signals: SignalRegistry,
+  args: Args,
+  fn: (ctx: AuthCommandContext, env: string) => Promise<CommandResult>,
+): (opts: unknown, command: Command) => Promise<void> {
+  return (opts, command) => {
+    // The picker is the only resolution path that needs the platform. A
+    // missing env in a non-interactive mode is a usage error and must not
+    // require auth (or a slow keyring read) to report, so it short-circuits
+    // before withAuthContext. Mode detection mirrors buildBaseContext.
+    const pickerNeeded =
+      !args.explicit?.trim() &&
+      !(process.env["QAWOLF_ENVIRONMENT"] ?? "").trim();
+    if (pickerNeeded) {
+      const mode = detectOutputMode({
+        flags: command.optsWithGlobals<OutputFlags>(),
+        env: process.env,
+        stdoutIsTTY: Boolean(process.stdout.isTTY),
+      });
+      if (mode !== "human") {
+        return withContext(signals, async () => ({
+          error: args.requiredMessage,
+        }))(opts, command);
+      }
+    }
+    return withAuthContext(signals, async (ctx) => {
+      const outcome = await resolveEnvironment(
+        { platformClient: ctx.platformClient, ui: ctx.ui, env: process.env },
+        { explicit: args.explicit, requiredMessage: args.requiredMessage },
+      );
+      if (outcome.kind === "cancelled") {
+        ctx.ui.info(environmentsMessages.aborted);
+        return;
+      }
+      if (outcome.kind === "error") {
+        return { error: outcome.error };
+      }
+      return fn(ctx, outcome.env);
+    })(opts, command);
+  };
+}

--- a/src/core/messages/environments.ts
+++ b/src/core/messages/environments.ts
@@ -1,0 +1,16 @@
+export const environmentsMessages = {
+  noEnvironments:
+    'No environments found on your team. Create one with "qawolf environment create".',
+  usingEnvironment: (name: string) => `Using environment ${name}`,
+  usingFromEnvVar: (env: string) =>
+    `Using environment from QAWOLF_ENVIRONMENT (${env})`,
+  exportHint: (env: string) =>
+    `Tip: export QAWOLF_ENVIRONMENT=${env} to make this your default environment.`,
+  whichEnvironment: "Which environment?",
+  whichKind: "Which kind of environment?",
+  kindLabels: {
+    static: "Static environments",
+    preview: "Preview (PR) environments",
+  },
+  aborted: "Aborted; no environment selected.",
+};

--- a/src/core/messages/environments.ts
+++ b/src/core/messages/environments.ts
@@ -13,4 +13,6 @@ export const environmentsMessages = {
     preview: "Preview (PR) environments",
   },
   aborted: "Aborted; no environment selected.",
+  tooManyPages: (pages: number) =>
+    `Stopped listing environments after ${pages} pages. Pass --env explicitly.`,
 };

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -16,12 +16,12 @@ export const flowsMessages = {
   flowCount: (count: number) => pluralize(count, "flow"),
   list: {
     remoteRequiresEnv:
-      "--remote requires --env <env> to pick the environment to list",
+      "--remote requires an environment. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
     flagsRequireRemote: "--env and --include-drafts require --remote",
   },
   pull: {
     requiresEnv:
-      "--env is required. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
+      "An environment is required. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
     downloadingBundle: "Downloading flows bundle",
     fetchingEnvVars: "Fetching environment variables",
     downloadComplete: "Downloaded flows bundle and environment variables",

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -20,6 +20,8 @@ export const flowsMessages = {
     flagsRequireRemote: "--env and --include-drafts require --remote",
   },
   pull: {
+    requiresEnv:
+      "--env is required. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
     downloadingBundle: "Downloading flows bundle",
     fetchingEnvVars: "Fetching environment variables",
     downloadComplete: "Downloaded flows bundle and environment variables",

--- a/src/core/messages/index.ts
+++ b/src/core/messages/index.ts
@@ -1,5 +1,6 @@
 export { authMessages } from "./auth.js";
 export { doctorMessages } from "./doctor.js";
+export { environmentsMessages } from "./environments.js";
 export { flowsMessages } from "./flows.js";
 export { initMessages } from "./init.js";
 export { installMessages } from "./install.js";

--- a/src/core/publicApi/flagSpecs.union.test.ts
+++ b/src/core/publicApi/flagSpecs.union.test.ts
@@ -19,6 +19,7 @@ describe("buildFlagSpecs union inputs", () => {
       { flag: "--description <value>", required: false },
       { flag: "--name <value>", required: true },
       { flag: "--priority <value>", required: false },
+      { flag: "--workspace-id <value>", required: false },
       { flag: "--type <value>", required: true },
       { flag: "--estimated-due-date <value>", required: false },
     ]);

--- a/src/domains/environments/resolveEnvironment.kinds.test.ts
+++ b/src/domains/environments/resolveEnvironment.kinds.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveEnvironment } from "./resolveEnvironment.js";
+import { env, makeDeps } from "./resolveEnvironment.testUtils.js";
+
+describe("resolveEnvironment kind pre-selector", () => {
+  it("skips the kind pre-selector when only previews exist", async () => {
+    const { deps, select } = makeDeps({
+      pages: [
+        {
+          environments: [
+            env("env-1", "PR 1", "preview"),
+            env("env-2", "PR 2", "preview"),
+          ],
+        },
+      ],
+      selectAnswers: ["env-1"],
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-1" });
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it("pre-selects a kind when both kinds exist, then lists only that kind", async () => {
+    const { deps, select } = makeDeps({
+      pages: [
+        {
+          environments: [
+            env("env-1", "PR 1", "preview"),
+            env("env-2", "PR 2", "preview"),
+            env("env-3", "Staging", "static"),
+            env("env-4", "Prod", "static"),
+          ],
+        },
+      ],
+      selectAnswers: ["preview", "env-2"],
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-2" });
+    expect(select).toHaveBeenNthCalledWith(1, "Which kind of environment?", [
+      { value: "static", label: "Static environments", hint: "2 environments" },
+      {
+        value: "preview",
+        label: "Preview (PR) environments",
+        hint: "2 environments",
+      },
+    ]);
+    expect(select).toHaveBeenNthCalledWith(2, "Which environment?", [
+      { value: "env-1", label: "PR 1", hint: "preview · ready" },
+      { value: "env-2", label: "PR 2", hint: "preview · ready" },
+    ]);
+  });
+
+  it("auto-picks when the chosen kind has exactly one environment", async () => {
+    const { deps, select, info } = makeDeps({
+      pages: [
+        {
+          environments: [
+            env("env-1", "PR 1", "preview"),
+            env("env-2", "PR 2", "preview"),
+            env("env-3", "Staging", "static"),
+          ],
+        },
+      ],
+      selectAnswers: ["static"],
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-3" });
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith("Using environment Staging");
+  });
+
+  it("returns cancelled when the kind prompt is dismissed", async () => {
+    const { deps } = makeDeps({
+      pages: [
+        {
+          environments: [
+            env("env-1", "PR 1", "preview"),
+            env("env-2", "Staging", "static"),
+          ],
+        },
+      ],
+      selectCancelled: true,
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "cancelled" });
+  });
+});

--- a/src/domains/environments/resolveEnvironment.test.ts
+++ b/src/domains/environments/resolveEnvironment.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveEnvironment } from "./resolveEnvironment.js";
+import { env, makeDeps } from "./resolveEnvironment.testUtils.js";
+
+describe("resolveEnvironment", () => {
+  it("returns the trimmed --env flag without any lookup", async () => {
+    const { deps, callPublicApi } = makeDeps({});
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: "  staging  ",
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "staging" });
+    expect(callPublicApi).not.toHaveBeenCalled();
+  });
+
+  it("falls back to QAWOLF_ENVIRONMENT and notes the source", async () => {
+    const { deps, info } = makeDeps({ envVar: " prod " });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "prod" });
+    expect(info).toHaveBeenCalledWith(
+      "Using environment from QAWOLF_ENVIRONMENT (prod)",
+    );
+  });
+
+  it("ignores a blank QAWOLF_ENVIRONMENT", async () => {
+    const { deps } = makeDeps({ envVar: "   ", mode: "json" });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "error", error: "req" });
+  });
+
+  it("errors with the required message in non-human modes", async () => {
+    for (const mode of ["json", "agent"] as const) {
+      const { deps, callPublicApi } = makeDeps({ mode });
+
+      const outcome = await resolveEnvironment(deps, {
+        explicit: undefined,
+        requiredMessage: "req",
+      });
+
+      expect(outcome).toEqual({ kind: "error", error: "req" });
+      expect(callPublicApi).not.toHaveBeenCalled();
+    }
+  });
+
+  it("errors when the team has no environments", async () => {
+    const { deps } = makeDeps({ pages: [{ environments: [] }] });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({
+      kind: "error",
+      error:
+        'No environments found on your team. Create one with "qawolf environment create".',
+    });
+  });
+
+  it("auto-picks a sole environment and says so", async () => {
+    const { deps, select, info } = makeDeps({
+      pages: [{ environments: [env("env-1", "Staging")] }],
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-1" });
+    expect(select).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalledWith("Using environment Staging");
+    // Auto-picks are frictionless; the export tip only follows a real prompt.
+    expect(info).toHaveBeenCalledTimes(1);
+  });
+
+  it("prompts with name labels and kind/status hints when several exist", async () => {
+    const { deps, select, info } = makeDeps({
+      pages: [
+        { environments: [env("env-1", "Staging"), env("env-2", "Prod")] },
+      ],
+      selectAnswers: ["env-2"],
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-2" });
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(select).toHaveBeenCalledWith("Which environment?", [
+      { value: "env-1", label: "Staging", hint: "static · ready" },
+      { value: "env-2", label: "Prod", hint: "static · ready" },
+    ]);
+    expect(info).toHaveBeenCalledWith(
+      "Tip: export QAWOLF_ENVIRONMENT=env-2 to make this your default environment.",
+    );
+  });
+
+  it("pages through nextCursor before prompting", async () => {
+    const { deps, callPublicApi, select } = makeDeps({
+      pages: [
+        { environments: [env("env-1", "A")], nextCursor: "c2" },
+        { environments: [env("env-2", "B")] },
+      ],
+      selectAnswers: ["env-1"],
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-1" });
+    expect(callPublicApi).toHaveBeenCalledTimes(2);
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns cancelled when the prompt is dismissed", async () => {
+    const { deps } = makeDeps({
+      pages: [{ environments: [env("env-1", "A"), env("env-2", "B")] }],
+      selectCancelled: true,
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "cancelled" });
+  });
+
+  it("surfaces a platform error", async () => {
+    const { deps } = makeDeps({ findError: "HTTP 500" });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "error", error: "HTTP 500" });
+  });
+});

--- a/src/domains/environments/resolveEnvironment.test.ts
+++ b/src/domains/environments/resolveEnvironment.test.ts
@@ -144,6 +144,22 @@ describe("resolveEnvironment", () => {
     expect(outcome).toEqual({ kind: "cancelled" });
   });
 
+  it("stops with an error when pagination never terminates", async () => {
+    const { deps, callPublicApi } = makeDeps({ endlessCursor: true });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: undefined,
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({
+      kind: "error",
+      error:
+        "Stopped listing environments after 10 pages. Pass --env explicitly.",
+    });
+    expect(callPublicApi).toHaveBeenCalledTimes(10);
+  });
+
   it("surfaces a platform error", async () => {
     const { deps } = makeDeps({ findError: "HTTP 500" });
 

--- a/src/domains/environments/resolveEnvironment.testUtils.ts
+++ b/src/domains/environments/resolveEnvironment.testUtils.ts
@@ -1,0 +1,59 @@
+import { mock } from "bun:test";
+
+import type { ResolveEnvironmentDeps } from "./resolveEnvironment.js";
+
+export type Page = {
+  environments: {
+    id: string;
+    name: string;
+    kind: "static" | "preview";
+    status: "blocked" | "needs-investigation" | "ready" | "running";
+    url: string;
+  }[];
+  nextCursor?: string;
+};
+
+export function makeDeps(args: {
+  mode?: "human" | "json" | "agent";
+  envVar?: string;
+  pages?: Page[];
+  findError?: string;
+  selectAnswers?: string[];
+  selectCancelled?: boolean;
+}) {
+  const pages = args.pages ?? [];
+  let call = 0;
+  const callPublicApi = mock(async () => {
+    if (args.findError !== undefined) {
+      return { ok: false as const, error: args.findError };
+    }
+    const page = pages[call];
+    call += 1;
+    if (page === undefined) throw new Error("unexpected extra page fetch");
+    return { ok: true as const, value: page };
+  });
+  // One queued answer per expected prompt, in order (kind pick, then env
+  // pick). A test that expects a single prompt queues a single answer.
+  const answers = [...(args.selectAnswers ?? [])];
+  const select = mock(async () => {
+    if (args.selectCancelled) return { ok: false as const };
+    const next = answers.shift();
+    if (next === undefined) throw new Error("unexpected extra select prompt");
+    return { ok: true as const, value: next };
+  });
+  const info = mock();
+  const deps: ResolveEnvironmentDeps = {
+    platformClient: { callPublicApi },
+    ui: { mode: args.mode ?? "human", info, select },
+    env: { QAWOLF_ENVIRONMENT: args.envVar },
+  };
+  return { deps, callPublicApi, select, info };
+}
+
+export function env(
+  id: string,
+  name: string,
+  kind: "static" | "preview" = "static",
+): Page["environments"][number] {
+  return { id, name, kind, status: "ready", url: "https://x" };
+}

--- a/src/domains/environments/resolveEnvironment.testUtils.ts
+++ b/src/domains/environments/resolveEnvironment.testUtils.ts
@@ -18,6 +18,9 @@ export function makeDeps(args: {
   envVar?: string;
   pages?: Page[];
   findError?: string;
+  // Every fetch returns a page with a nextCursor, so pagination never
+  // terminates on its own — for testing the page cap.
+  endlessCursor?: boolean;
   selectAnswers?: string[];
   selectCancelled?: boolean;
 }) {
@@ -26,6 +29,12 @@ export function makeDeps(args: {
   const callPublicApi = mock(async () => {
     if (args.findError !== undefined) {
       return { ok: false as const, error: args.findError };
+    }
+    if (args.endlessCursor) {
+      return {
+        ok: true as const,
+        value: { environments: [], nextCursor: "again" },
+      };
     }
     const page = pages[call];
     call += 1;

--- a/src/domains/environments/resolveEnvironment.ts
+++ b/src/domains/environments/resolveEnvironment.ts
@@ -1,0 +1,142 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import type { z } from "zod";
+
+import { environmentsMessages } from "~/core/messages/index.js";
+import { pluralize } from "~/core/pluralize.js";
+import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
+import type { UI } from "~/shell/ui/index.js";
+
+const findContract = publicContractsV1.environment.find;
+
+type FindOutput = z.output<typeof findContract.output>;
+type Environment = FindOutput["environments"][number];
+
+export type ResolveEnvironmentOutcome =
+  | { kind: "resolved"; env: string }
+  | { kind: "cancelled" }
+  | { kind: "error"; error: string };
+
+// The concrete instantiation of PlatformClient["callPublicApi"] this domain
+// needs. The real generic method is assignable to it, and test fakes can
+// satisfy it without casts.
+type FindEnvironmentsApi = (
+  contract: typeof findContract,
+  input: z.input<typeof findContract.input>,
+) => Promise<PlatformResult<FindOutput>>;
+
+export type ResolveEnvironmentDeps = {
+  platformClient: { callPublicApi: FindEnvironmentsApi };
+  ui: Pick<UI, "mode" | "info" | "select">;
+  env: Record<string, string | undefined>;
+};
+
+type ResolveEnvironmentOpts = {
+  explicit: string | undefined;
+  // Command-specific "--env is required" text, shown when resolution is
+  // impossible without a prompt (JSON/agent mode).
+  requiredMessage: string;
+};
+
+export async function resolveEnvironment(
+  deps: ResolveEnvironmentDeps,
+  opts: ResolveEnvironmentOpts,
+): Promise<ResolveEnvironmentOutcome> {
+  const explicit = opts.explicit?.trim();
+  if (explicit) return { kind: "resolved", env: explicit };
+
+  const fromEnvVar = deps.env["QAWOLF_ENVIRONMENT"]?.trim();
+  if (fromEnvVar) {
+    deps.ui.info(environmentsMessages.usingFromEnvVar(fromEnvVar));
+    return { kind: "resolved", env: fromEnvVar };
+  }
+
+  if (deps.ui.mode !== "human") {
+    return { kind: "error", error: opts.requiredMessage };
+  }
+
+  const fetched = await fetchAllEnvironments(deps.platformClient);
+  if (!fetched.ok) return { kind: "error", error: fetched.error };
+
+  const environments = fetched.environments;
+  if (environments.length === 0) {
+    return { kind: "error", error: environmentsMessages.noEnvironments };
+  }
+  const sole = environments.length === 1 ? environments[0] : undefined;
+  if (sole) {
+    deps.ui.info(environmentsMessages.usingEnvironment(sole.name));
+    return { kind: "resolved", env: sole.id };
+  }
+
+  const narrowed = await narrowByKind(deps.ui, environments);
+  if (narrowed === "cancelled") return { kind: "cancelled" };
+
+  const soleOfKind = narrowed.length === 1 ? narrowed[0] : undefined;
+  if (soleOfKind) {
+    deps.ui.info(environmentsMessages.usingEnvironment(soleOfKind.name));
+    return { kind: "resolved", env: soleOfKind.id };
+  }
+
+  const picked = await deps.ui.select(
+    environmentsMessages.whichEnvironment,
+    narrowed.map((e) => ({
+      value: e.id,
+      label: e.name,
+      hint: `${e.kind} · ${e.status}`,
+    })),
+  );
+  if (!picked.ok) return { kind: "cancelled" };
+  // Only after a real prompt: teach the way to skip it next time. Auto-picks
+  // and env-var resolutions had no friction worth a tip.
+  deps.ui.info(environmentsMessages.exportHint(picked.value));
+  return { kind: "resolved", env: picked.value };
+}
+
+// Large teams accumulate many ephemeral preview (PR) environments that
+// drown out the handful of static ones, so when both kinds exist the user
+// picks a kind before scrolling a list. Single-kind teams skip this step.
+async function narrowByKind(
+  ui: ResolveEnvironmentDeps["ui"],
+  environments: Environment[],
+): Promise<Environment[] | "cancelled"> {
+  const byKind = (kind: Environment["kind"]) =>
+    environments.filter((e) => e.kind === kind);
+  const statics = byKind("static");
+  const previews = byKind("preview");
+  if (statics.length === 0 || previews.length === 0) return environments;
+
+  const countHint = (list: Environment[]) =>
+    pluralize(list.length, "environment");
+  const picked = await ui.select(environmentsMessages.whichKind, [
+    {
+      value: "static",
+      label: environmentsMessages.kindLabels.static,
+      hint: countHint(statics),
+    },
+    {
+      value: "preview",
+      label: environmentsMessages.kindLabels.preview,
+      hint: countHint(previews),
+    },
+  ]);
+  if (!picked.ok) return "cancelled";
+  return picked.value === "static" ? statics : previews;
+}
+
+async function fetchAllEnvironments(platformClient: {
+  callPublicApi: FindEnvironmentsApi;
+}): Promise<
+  { ok: true; environments: Environment[] } | { ok: false; error: string }
+> {
+  const environments: Environment[] = [];
+  let cursor: string | undefined;
+  do {
+    const result = await platformClient.callPublicApi(findContract, {
+      limit: 100,
+      cursor,
+    });
+    if (!result.ok) return result;
+    environments.push(...result.value.environments);
+    cursor = result.value.nextCursor;
+  } while (cursor !== undefined);
+  return { ok: true, environments };
+}

--- a/src/domains/environments/resolveEnvironment.ts
+++ b/src/domains/environments/resolveEnvironment.ts
@@ -32,8 +32,8 @@ export type ResolveEnvironmentDeps = {
 
 type ResolveEnvironmentOpts = {
   explicit: string | undefined;
-  // Command-specific "--env is required" text, shown when resolution is
-  // impossible without a prompt (JSON/agent mode).
+  // Command-specific "an environment is required" text, shown when
+  // resolution is impossible without a prompt (JSON/agent mode).
   requiredMessage: string;
 };
 
@@ -122,6 +122,12 @@ async function narrowByKind(
   return picked.value === "static" ? statics : previews;
 }
 
+// Termination depends on a server-controlled cursor, so the loop is
+// bounded: a pagination bug must produce an error, not a hung CLI. Ten
+// pages (1,000 environments) is an order of magnitude above any observed
+// team while keeping the pathological case to seconds, not minutes.
+const maxPages = 10;
+
 async function fetchAllEnvironments(platformClient: {
   callPublicApi: FindEnvironmentsApi;
 }): Promise<
@@ -129,7 +135,7 @@ async function fetchAllEnvironments(platformClient: {
 > {
   const environments: Environment[] = [];
   let cursor: string | undefined;
-  do {
+  for (let page = 0; page < maxPages; page += 1) {
     const result = await platformClient.callPublicApi(findContract, {
       limit: 100,
       cursor,
@@ -137,6 +143,7 @@ async function fetchAllEnvironments(platformClient: {
     if (!result.ok) return result;
     environments.push(...result.value.environments);
     cursor = result.value.nextCursor;
-  } while (cursor !== undefined);
-  return { ok: true, environments };
+    if (cursor === undefined) return { ok: true, environments };
+  }
+  return { ok: false, error: environmentsMessages.tooManyPages(maxPages) };
 }

--- a/src/shell/commandContext.testUtils.ts
+++ b/src/shell/commandContext.testUtils.ts
@@ -18,6 +18,7 @@ export function makeFakeUI(mode: OutputMode = "human"): UI {
     outro: mock(() => {}),
     confirm: mock(() => Promise.resolve({ ok: false } as const)),
     password: mock(() => Promise.resolve({ ok: false } as const)),
+    select: mock(() => Promise.resolve({ ok: false } as const)),
     withProgress: mock(
       async (steps: { message: string; task: () => Promise<unknown> }[]) => {
         const results: unknown[] = [];

--- a/src/shell/ui/clack/styledClack.mock.ts
+++ b/src/shell/ui/clack/styledClack.mock.ts
@@ -33,6 +33,7 @@ export function makeClack() {
     cancel: mock(),
     confirm: mock(),
     password: mock(),
+    select: mock(),
     isCancel: isCancel as typeof isCancel & StyledClack["isCancel"],
     spinner: mock((): MockSpinner => {
       const s: MockSpinner = {

--- a/src/shell/ui/clack/styledClack.ts
+++ b/src/shell/ui/clack/styledClack.ts
@@ -7,6 +7,7 @@ import {
   note,
   outro,
   password,
+  select,
   spinner,
   taskLog,
 } from "@clack/prompts";
@@ -30,6 +31,11 @@ export type StyledClack = {
     initialValue?: boolean;
   }): Promise<boolean | symbol>;
   password(opts: { message: string }): Promise<string | symbol>;
+  select(opts: {
+    message: string;
+    options: { value: string; label: string; hint?: string }[];
+    initialValue?: string;
+  }): Promise<string | symbol>;
   isCancel(value: unknown): value is symbol;
   spinner(): {
     start(message: string): void;
@@ -52,6 +58,7 @@ export function createStyledClack(): StyledClack {
     cancel,
     confirm,
     password,
+    select,
     isCancel,
     spinner,
     taskLog,

--- a/src/shell/ui/createUi.ts
+++ b/src/shell/ui/createUi.ts
@@ -5,6 +5,7 @@ import { createConfirm } from "./renderers/confirm.js";
 import { createJson } from "./renderers/json.js";
 import { pickRenderers } from "./renderers/modes/index.js";
 import { createPassword } from "./renderers/password.js";
+import { createSelect } from "./renderers/select.js";
 import type { UI } from "./types.js";
 
 export function createUI(
@@ -21,6 +22,7 @@ export function createUI(
     ...pickRenderers(mode, clack, opts.verboseTarget),
     confirm: createConfirm({ mode, clack }),
     password: createPassword({ mode, clack }),
+    select: createSelect({ mode, clack }),
     json: createJson(),
   };
 }

--- a/src/shell/ui/renderers/select.test.ts
+++ b/src/shell/ui/renderers/select.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { makeClack } from "~/shell/ui/clack/styledClack.mock.js";
+import { createSelect } from "./select.js";
+
+const options = [
+  { value: "env-1", label: "Staging", hint: "static · ready" },
+  { value: "env-2", label: "Production", hint: "static · running" },
+];
+
+describe("createSelect", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("returns ok with the picked value in human mode", async () => {
+    const clack = makeClack();
+    clack.select.mockResolvedValue("env-2");
+    clack.isCancel.mockReturnValue(false);
+    const select = createSelect({ mode: "human", clack });
+
+    const result = await select("Which environment?", options);
+
+    expect(clack.select).toHaveBeenCalledWith({
+      message: "Which environment?",
+      options,
+    });
+    expect(result).toEqual({ ok: true, value: "env-2" });
+  });
+
+  it("returns not ok when the user cancels", async () => {
+    const clack = makeClack();
+    clack.select.mockResolvedValue(Symbol("cancel"));
+    clack.isCancel.mockReturnValue(true);
+    const select = createSelect({ mode: "human", clack });
+
+    const result = await select("Which environment?", options);
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("throws in json mode", () => {
+    const clack = makeClack();
+    const select = createSelect({ mode: "json", clack });
+
+    expect(select("Which environment?", options)).rejects.toThrow(
+      "This command requires an interactive terminal. select",
+    );
+  });
+
+  it("throws in agent mode", () => {
+    const clack = makeClack();
+    const select = createSelect({ mode: "agent", clack });
+
+    expect(select("Which environment?", options)).rejects.toThrow(
+      "This command requires an interactive terminal. select",
+    );
+  });
+});

--- a/src/shell/ui/renderers/select.ts
+++ b/src/shell/ui/renderers/select.ts
@@ -1,0 +1,31 @@
+import type { StyledClack } from "~/shell/ui/clack/index.js";
+import type { OutputMode } from "~/shell/ui/env.js";
+import { assertHumanMode } from "./assertHumanMode.js";
+import type { PromptResult } from "./types.js";
+
+type SelectDeps = { mode: OutputMode; clack: StyledClack };
+
+// Values are plain strings: clack's Option<Value> is a conditional type
+// that only resolves for concrete Value, so a generic passthrough cannot
+// typecheck. hint omits `| undefined` because exactOptionalPropertyTypes
+// makes clack reject an explicitly-undefined hint; omit the key instead.
+type SelectOption = {
+  value: string;
+  label: string;
+  hint?: string;
+};
+
+export type SelectFn = (
+  message: string,
+  options: readonly SelectOption[],
+) => Promise<PromptResult<string>>;
+
+export function createSelect({ mode, clack }: SelectDeps): SelectFn {
+  return async (message, options) => {
+    assertHumanMode(mode, "select");
+
+    const value = await clack.select({ message, options: [...options] });
+    if (clack.isCancel(value)) return { ok: false };
+    return { ok: true, value };
+  };
+}

--- a/src/shell/ui/types.ts
+++ b/src/shell/ui/types.ts
@@ -1,5 +1,6 @@
 import type { OutputMode } from "./env.js";
 import type { PromptResult } from "./renderers/types.js";
+import type { SelectFn } from "./renderers/select.js";
 import type { WithProgressFn } from "./renderers/modes/progress.js";
 
 export type UI = {
@@ -22,6 +23,7 @@ export type UI = {
     },
   ): Promise<PromptResult<boolean>>;
   password(message: string, hint?: string): Promise<PromptResult<string>>;
+  select: SelectFn;
   withProgress: WithProgressFn;
   step(message: string, progress?: { current: number; total: number }): void;
   success(message: string): void;


### PR DESCRIPTION
## Problem

The commands `flows pull` and `flows list --remote` do not operate without the `--env` flag. The CLI cannot show the available environments. The user must copy an environment ID from the web application. The user must supply the flag each time.

## Fix

If the user does not supply the `--env` flag, the CLI does these steps in sequence:

1. The CLI reads the `QAWOLF_ENVIRONMENT` variable. If the variable is set, the CLI shows the source and uses the value.
2. If the terminal is interactive, the CLI shows a list of environments. The user selects one environment.
3. If the terminal is not interactive, the CLI shows the same error as before. The exit code is 1.

The CLI gets the environments from the `environment.find` contract. The contract is new in `@qawolf/api-contracts` 0.14.0. This change includes the version increase. The generator also makes three new commands: `environment find`, `environment setVariable`, and `flow addTag`.

If only one environment is available, the CLI selects it automatically. If static environments and preview (PR) environments are both available, the CLI first asks for the environment kind. This prevents a long list of PR environments. After a manual selection, the CLI shows a tip: `export QAWOLF_ENVIRONMENT=<id>`. The command `flows run` is not changed. Without `--env`, the command `flows run` operates only on local flows.

This change adds three parts:

- A `select()` prompt in `src/shell/ui/`. Its structure is equivalent to `confirm()`.
- The resolver domain in `src/domains/environments/`.
- The wrapper `withResolvedEnv` in `src/commands/flows/`. The wrapper shows the usage error before authentication. A flag error does not cause a keyring read. A flag error does not show an incorrect authentication error.

## Testing

- The change includes 18 new unit tests. The tests examine precedence, environment counts, kind selection, pagination, cancellation, and platform errors.
- The full test suite (1277 tests), lint, format, typecheck, and knip pass.
- We did live tests against production. The command `environment find` returns pages of environments. The two commands show the correct errors in pipe mode.
- We did a manual test of the prompts in the node build under a TTY.
