### PR TITLE
build(cli): drop approval gate from binaries Slack notify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,7 @@ jobs:
     # failures too. Skips when nothing was published or the publish-time Slack
     # message did not post (no ts to update).
     if: always() && needs.release.outputs.published == 'true' && needs.release.outputs.slack_ts != ''
-    # the Slack secrets are scoped to the release environment
-    environment: release
+    environment: release-notify
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Point notify-binaries at the new release-notify environment so the binaries Slack update no longer waits for a second approval. The publish approval gate is unchanged.