### PR TITLE
fix(runner): surface flow failure detail in json output

### DIFF
--- a/.changeset/json-failure-detail.md
+++ b/.changeset/json-failure-detail.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Show flow failure detail in json output. Before this change, a failed `flows run` printed only `{"type":"error","title":"N flow(s) failed"}` in json mode. The CLI also selects json mode in CI and when stdout is piped. The failure message and stack only reached disk through the `--junit` report. The final error event now includes a `body` field. The `body` field contains the message and the cause stack for each failed flow. Human and agent modes do not change. They already show the failure detail inline.

--- a/src/commands/context.test.ts
+++ b/src/commands/context.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 import { Command } from "commander";
 
 import {
@@ -117,5 +125,25 @@ describe("withContext exit code plumbing", () => {
     })({}, fakeCommand());
 
     expect(process.exitCode).toBe(1);
+  });
+
+  it("passes errorBody through to the error diagnostic", async () => {
+    const writes: string[] = [];
+    spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+
+    await withContext(noopSignals, async () => ({
+      error: "1 flow(s) failed",
+      errorBody: "Caused by: expected title to be 'Dashboard'",
+    }))({}, fakeCommand());
+
+    const errorLine = writes.find((line) => line.includes('"type":"error"'));
+    expect(errorLine).toBeDefined();
+    expect(errorLine).toContain('"title":"1 flow(s) failed"');
+    expect(errorLine).toContain(
+      '"body":"Caused by: expected title to be \'Dashboard\'"',
+    );
   });
 });

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -113,7 +113,7 @@ export function withContext(
     try {
       const result = await fn(ctx);
       if (result !== undefined) {
-        ctx.ui.error(result.error);
+        ctx.ui.error(result.error, result.errorBody);
         process.exitCode = result.exitCode ?? 1;
       }
     } catch (err: unknown) {
@@ -165,7 +165,7 @@ export function withAuthContext(
         apiKeySource: resolved.source,
       });
       if (result !== undefined) {
-        ctx.ui.error(result.error);
+        ctx.ui.error(result.error, result.errorBody);
         process.exitCode = result.exitCode ?? 1;
       }
     } catch (err: unknown) {

--- a/src/domains/runner/run.failureDetail.test.ts
+++ b/src/domains/runner/run.failureDetail.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { runnerMessages } from "~/core/messages/index.js";
+import {
+  defaultFlags,
+  failResult,
+  makeCtx,
+  makeDeps,
+  passResult,
+} from "./run.fixtures.js";
+import { flowsRun } from "./run.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+function expectFailure(result: Awaited<ReturnType<typeof flowsRun>>): {
+  error: string;
+  errorBody?: string;
+} {
+  if (result === undefined) throw new Error("expected a failing CommandResult");
+  return result;
+}
+
+describe("flowsRun failure detail", () => {
+  it("attaches the failure cause and stack as errorBody in json mode", async () => {
+    const ctx = makeCtx("json");
+    const deps = makeDeps({
+      metaByFile: { "/a.flow.ts": { target: "Web - Chrome" } },
+      runResults: [failResult(new Error("expected title to be 'Dashboard'"))],
+    });
+
+    const result = expectFailure(
+      await flowsRun(ctx, ["/a.flow.ts"], defaultFlags(), deps),
+    );
+
+    expect(result.error).toBe(runnerMessages.flowsFailed(1));
+    expect(result.errorBody).toContain("Flow failed on attempt 1");
+    expect(result.errorBody).toContain("Caused by:");
+    expect(result.errorBody).toContain("expected title to be 'Dashboard'");
+  });
+
+  it("joins the detail of every failed flow in json mode", async () => {
+    const ctx = makeCtx("json");
+    const deps = makeDeps({
+      metaByFile: {
+        "/a.flow.ts": { target: "Web - Chrome" },
+        "/b.flow.ts": { target: "Web - Chrome" },
+      },
+      runResults: [
+        failResult(new Error("first cause")),
+        failResult(new Error("second cause")),
+      ],
+    });
+
+    const result = expectFailure(
+      await flowsRun(ctx, ["/a.flow.ts", "/b.flow.ts"], defaultFlags(), deps),
+    );
+
+    expect(result.error).toBe(runnerMessages.flowsFailed(2));
+    expect(result.errorBody).toContain("first cause");
+    expect(result.errorBody).toContain("second cause");
+  });
+
+  it("attaches errorBody for pooled runs in json mode", async () => {
+    const ctx = makeCtx("json");
+    const dispatch = mock(() =>
+      Promise.resolve({
+        run: failResult(new Error("pooled cause")),
+        durationMs: 1,
+      }),
+    );
+    const deps = makeDeps({
+      metaByFile: { "/a.flow.ts": { target: "Web - Chrome" } },
+      createPooledDispatch: () => dispatch,
+    });
+    const flags = { ...defaultFlags(), workers: 2 };
+
+    const result = expectFailure(
+      await flowsRun(ctx, ["/a.flow.ts"], flags, deps),
+    );
+
+    expect(result.error).toBe(runnerMessages.flowsFailed(1));
+    expect(result.errorBody).toContain("pooled cause");
+  });
+
+  it("omits errorBody in human mode where the reporter already streamed it", async () => {
+    const ctx = makeCtx("human");
+    const deps = makeDeps({
+      metaByFile: { "/a.flow.ts": { target: "Web - Chrome" } },
+      runResults: [failResult(new Error("streamed already"))],
+    });
+
+    const result = expectFailure(
+      await flowsRun(ctx, ["/a.flow.ts"], defaultFlags(), deps),
+    );
+
+    expect(result).toEqual({ error: runnerMessages.flowsFailed(1) });
+  });
+
+  it("still delivers onFlowFail to the caller's reporter", async () => {
+    const ctx = makeCtx("json");
+    const deps = makeDeps({
+      metaByFile: {
+        "/a.flow.ts": { target: "Web - Chrome" },
+        "/b.flow.ts": { target: "Web - Chrome" },
+      },
+      runResults: [failResult(), passResult()],
+    });
+
+    await flowsRun(ctx, ["/a.flow.ts", "/b.flow.ts"], defaultFlags(), deps);
+
+    expect(deps.reporter.onFlowFail).toHaveBeenCalledTimes(1);
+    expect(deps.reporter.onFlowPass).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/domains/runner/run.ts
+++ b/src/domains/runner/run.ts
@@ -96,10 +96,16 @@ export async function flowsRun(
   // In json mode the reporter's streamed output is discarded (ui.write is a
   // no-op), so collect each failure's detail to attach to the final error.
   const failureDetails: string[] = [];
-  const reporter = createCompositeReporter([
-    deps.reporter,
-    { onFlowFail: ({ err }) => failureDetails.push(formatErrorWithCause(err)) },
-  ]);
+  const reporter =
+    ctx.outputMode === "json"
+      ? createCompositeReporter([
+          deps.reporter,
+          {
+            onFlowFail: ({ err }) =>
+              failureDetails.push(formatErrorWithCause(err)),
+          },
+        ])
+      : deps.reporter;
 
   const result = await executeFlows({
     ctx,

--- a/src/domains/runner/run.ts
+++ b/src/domains/runner/run.ts
@@ -1,6 +1,8 @@
 import { classifyTarget, flowBasename } from "~/core/flowMeta.js";
 import { batchMap, flowBatchSize } from "~/core/batchMap.js";
 import type { CommandContext, CommandResult } from "~/shell/commandContext.js";
+import { createCompositeReporter } from "~/shell/reporter/createCompositeReporter.js";
+import { formatErrorWithCause } from "~/shell/reporter/formatErrorWithCause.js";
 import type { RunSummary } from "~/shell/reporter/types.js";
 import type { BrowserName } from "~/core/types.js";
 import { runnerMessages } from "~/core/messages/index.js";
@@ -91,9 +93,17 @@ export async function flowsRun(
 
   const { webOptions, androidOptions } = buildRunOptions(flags);
 
+  // In json mode the reporter's streamed output is discarded (ui.write is a
+  // no-op), so collect each failure's detail to attach to the final error.
+  const failureDetails: string[] = [];
+  const reporter = createCompositeReporter([
+    deps.reporter,
+    { onFlowFail: ({ err }) => failureDetails.push(formatErrorWithCause(err)) },
+  ]);
+
   const result = await executeFlows({
     ctx,
-    deps,
+    deps: { ...deps, reporter },
     flags,
     flows,
     webFlows,
@@ -123,6 +133,12 @@ export async function flowsRun(
   ctx.ui.gap();
 
   if (counts.flowsFailed > 0) {
-    return { error: runnerMessages.flowsFailed(counts.flowsFailed) };
+    const error = runnerMessages.flowsFailed(counts.flowsFailed);
+    // Human and agent modes already streamed the detail via the reporter;
+    // attaching it here too would print every failure twice.
+    if (ctx.outputMode === "json" && failureDetails.length > 0) {
+      return { error, errorBody: failureDetails.join("\n\n") };
+    }
+    return { error };
   }
 }

--- a/src/shell/commandContext.ts
+++ b/src/shell/commandContext.ts
@@ -23,5 +23,7 @@ export type AuthCommandContext = CommandContext & {
 
 export type CommandResult = {
   readonly error: string;
+  /** Multi-line detail rendered under the error (json mode emits it as `body`). */
+  readonly errorBody?: string;
   readonly exitCode?: number;
 } | void;


### PR DESCRIPTION
## Problem

A failed `flows run` in json mode prints only:

```json
{"type":"error","title":"1 flow(s) failed"}
```

No message, no stack. Json mode is auto-selected for `--json`, CI, and any piped stdout, so the detail is lost exactly where it matters most. The console reporter formats the full error and cause chain, but both its sinks route through `ctx.ui.write`, which is a no-op in json mode — the only surviving copy was the JUnit XML behind `--junit`. `--verbose` cannot help: no code path logs the error object.

## Fix

- `flowsRun` wraps the reporter in a composite that collects `formatErrorWithCause(err)` for every `onFlowFail` (covers both the serial and pooled worker paths).
- `CommandResult` gains an optional `errorBody`, which `withContext`/`withAuthContext` pass through to `ctx.ui.error(title, body)`. The json renderer already serialized `body`; it was just never populated.
- The detail is attached only in json mode. Human and agent modes already stream it inline via the reporter, so attaching it there would print every failure twice.

Same failing flow after the fix:

```json
{"type":"error","title":"1 flow(s) failed","body":"FlowRunError: Flow \"Broken example\" failed on attempt 1\nCaused by: Error: expect(page).toHaveTitle(expected) failed\n\nExpected pattern: /Dashboard/\nReceived string:  \"Example Domain\"\n..."}
```

## Testing

- `run.failureDetail.test.ts`: json single/multiple failures, pooled path, human-mode omission, reporter passthrough
- `context.test.ts`: end-to-end assertion that the emitted error diagnostic carries `body`
- Verified live against a real failing flow in json, agent, and (unpatched-baseline) comparison runs

Fixes WIZ-11358
