### PR TITLE
feat(cli): print urls as clickable terminal hyperlinks

### DIFF
--- a/.changeset/clickable-urls.md
+++ b/.changeset/clickable-urls.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": minor
+---
+
+Print URLs as clickable terminal hyperlinks in human output

--- a/src/commands/context.ts
+++ b/src/commands/context.ts
@@ -20,6 +20,7 @@ import {
   detectOutputMode,
   isInteractive,
 } from "~/shell/ui/env.js";
+import { supportsHyperlinks } from "~/shell/ui/hyperlinks.js";
 import { createUI } from "~/shell/ui/index.js";
 import { createVerboseContext } from "~/shell/ui/createVerboseContext.js";
 import type {
@@ -71,6 +72,10 @@ export function buildBaseContext(
   const fs = makeDefaultFs();
   const ui = createUI(outputMode, {
     clack,
+    hyperlinks: supportsHyperlinks({
+      env,
+      stdoutIsTTY: Boolean(process.stdout.isTTY),
+    }),
     ...(verboseTarget ? { verboseTarget } : {}),
   });
   const updateNotifier = startUpdateCheck({

--- a/src/shell/ui/createUi.ts
+++ b/src/shell/ui/createUi.ts
@@ -12,6 +12,7 @@ export function createUI(
   mode: OutputMode,
   opts: {
     clack?: StyledClack;
+    hyperlinks?: boolean;
     verboseTarget?: { write: ((msg: string) => void) | undefined };
   } = {},
 ): UI {
@@ -19,7 +20,12 @@ export function createUI(
 
   return {
     mode,
-    ...pickRenderers(mode, clack, opts.verboseTarget),
+    ...pickRenderers({
+      mode,
+      clack,
+      verboseTarget: opts.verboseTarget,
+      hyperlinks: opts.hyperlinks ?? false,
+    }),
     confirm: createConfirm({ mode, clack }),
     password: createPassword({ mode, clack }),
     select: createSelect({ mode, clack }),

--- a/src/shell/ui/hyperlinks.test.ts
+++ b/src/shell/ui/hyperlinks.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+
+import { linkifyUrls, supportsHyperlinks } from "./hyperlinks.js";
+
+const osc8 = "\x1b]8;;";
+const bel = "\x07";
+const link = (url: string, label = url): string =>
+  `${osc8}${url}${bel}${label}${osc8}${bel}`;
+
+describe("linkifyUrls", () => {
+  it("wraps a url in an OSC 8 hyperlink", () => {
+    const url = "https://app.qawolf.com/team/runs/run-id";
+    expect(linkifyUrls(`url: ${url}`)).toBe(`url: ${link(url)}`);
+  });
+
+  it("leaves text without a url untouched", () => {
+    expect(linkifyUrls("runId: rnzy3jlwsod9opaf")).toBe(
+      "runId: rnzy3jlwsod9opaf",
+    );
+  });
+
+  it("wraps every url on a multi-line message", () => {
+    const first = "https://app.qawolf.com/a";
+    const second = "http://localhost:3000/b";
+    expect(linkifyUrls(`${first}\nthen ${second}`)).toBe(
+      `${link(first)}\nthen ${link(second)}`,
+    );
+  });
+
+  it("keeps trailing sentence punctuation outside the link", () => {
+    const url = "https://docs.qawolf.com/cli";
+    expect(linkifyUrls(`See ${url}.`)).toBe(`See ${link(url)}.`);
+  });
+
+  it("keeps query strings inside the link", () => {
+    const url = "https://app.qawolf.com/runs?filter=failed&page=2";
+    expect(linkifyUrls(url)).toBe(link(url));
+  });
+});
+
+describe("supportsHyperlinks", () => {
+  it("is false when stdout is not a tty", () => {
+    expect(
+      supportsHyperlinks({
+        env: { TERM_PROGRAM: "iTerm.app", TERM_PROGRAM_VERSION: "3.5.0" },
+        stdoutIsTTY: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for iTerm2 3.1 and newer", () => {
+    expect(
+      supportsHyperlinks({
+        env: { TERM_PROGRAM: "iTerm.app", TERM_PROGRAM_VERSION: "3.1" },
+        stdoutIsTTY: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for iTerm2 older than 3.1", () => {
+    expect(
+      supportsHyperlinks({
+        env: { TERM_PROGRAM: "iTerm.app", TERM_PROGRAM_VERSION: "3.0.15" },
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for VS Code 1.72 and newer", () => {
+    expect(
+      supportsHyperlinks({
+        env: { TERM_PROGRAM: "vscode", TERM_PROGRAM_VERSION: "1.108.0" },
+        stdoutIsTTY: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for macOS Terminal", () => {
+    expect(
+      supportsHyperlinks({
+        env: { TERM_PROGRAM: "Apple_Terminal", TERM_PROGRAM_VERSION: "455" },
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for an unknown terminal", () => {
+    expect(supportsHyperlinks({ env: {}, stdoutIsTTY: true })).toBe(false);
+  });
+
+  it("is false for TERM=dumb", () => {
+    expect(
+      supportsHyperlinks({
+        env: { TERM: "dumb", TERM_PROGRAM: "WezTerm" },
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("is true for kitty", () => {
+    expect(
+      supportsHyperlinks({ env: { TERM: "xterm-kitty" }, stdoutIsTTY: true }),
+    ).toBe(true);
+  });
+
+  it("is true for Windows Terminal", () => {
+    expect(
+      supportsHyperlinks({ env: { WT_SESSION: "abc" }, stdoutIsTTY: true }),
+    ).toBe(true);
+  });
+
+  it("is true for VTE 0.50 and newer", () => {
+    expect(
+      supportsHyperlinks({ env: { VTE_VERSION: "5202" }, stdoutIsTTY: true }),
+    ).toBe(true);
+  });
+
+  it("is false for VTE older than 0.50", () => {
+    expect(
+      supportsHyperlinks({ env: { VTE_VERSION: "4600" }, stdoutIsTTY: true }),
+    ).toBe(false);
+  });
+
+  it("honors FORCE_HYPERLINK even without a tty", () => {
+    expect(
+      supportsHyperlinks({ env: { FORCE_HYPERLINK: "1" }, stdoutIsTTY: false }),
+    ).toBe(true);
+  });
+
+  it("honors FORCE_HYPERLINK=0 on a supported terminal", () => {
+    expect(
+      supportsHyperlinks({
+        env: { FORCE_HYPERLINK: "0", TERM: "xterm-kitty" },
+        stdoutIsTTY: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/shell/ui/hyperlinks.ts
+++ b/src/shell/ui/hyperlinks.ts
@@ -1,0 +1,69 @@
+type TerminalEnv = Record<string, string | undefined>;
+
+const osc8 = "\x1b]8;;";
+const bel = "\x07";
+
+const urlPattern = /https?:\/\/\S+/g;
+const trailingPunctuation = /[.,;:!?)\]}'"]+$/;
+
+export function linkifyUrls(text: string): string {
+  return text.replace(urlPattern, (match) => {
+    const url = match.replace(trailingPunctuation, "");
+    const trailing = match.slice(url.length);
+    return `${osc8}${url}${bel}${url}${osc8}${bel}${trailing}`;
+  });
+}
+
+function isAtLeast(
+  version: string | undefined,
+  minimum: { major: number; minor: number },
+): boolean {
+  const [rawMajor, rawMinor] = (version ?? "").split(".");
+  const major = Number(rawMajor);
+  const minor = Number(rawMinor);
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) return false;
+  return (
+    major > minimum.major || (major === minimum.major && minor >= minimum.minor)
+  );
+}
+
+function termProgramSupportsHyperlinks(
+  name: string,
+  version: string | undefined,
+): boolean {
+  switch (name) {
+    case "iTerm.app":
+      return isAtLeast(version, { major: 3, minor: 1 });
+    case "vscode":
+      return isAtLeast(version, { major: 1, minor: 72 });
+    case "ghostty":
+    case "Hyper":
+    case "rio":
+    case "Tabby":
+    case "WarpTerminal":
+    case "WezTerm":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function supportsHyperlinks({
+  env,
+  stdoutIsTTY,
+}: {
+  env: TerminalEnv;
+  stdoutIsTTY: boolean;
+}): boolean {
+  const forced = env["FORCE_HYPERLINK"];
+  if (forced !== undefined && forced !== "") return forced !== "0";
+  if (!stdoutIsTTY) return false;
+  if (env["TERM"] === "dumb") return false;
+  if (env["WT_SESSION"] || env["KONSOLE_VERSION"]) return true;
+  if (env["TERM"] === "xterm-kitty") return true;
+  if (Number(env["VTE_VERSION"] ?? "") >= 5000) return true;
+  return termProgramSupportsHyperlinks(
+    env["TERM_PROGRAM"] ?? "",
+    env["TERM_PROGRAM_VERSION"],
+  );
+}

--- a/src/shell/ui/renderers/modes/human.test.ts
+++ b/src/shell/ui/renderers/modes/human.test.ts
@@ -115,6 +115,28 @@ describe("human renderers", () => {
       createHumanRenderers(clack).output({ id: 1 }, "Operation succeeded");
       expect(clack.log.info).toHaveBeenCalledWith("Operation succeeded");
     });
+
+    it("leaves urls plain when hyperlinks are unsupported", () => {
+      const clack = makeClack();
+      createHumanRenderers(clack, undefined, { hyperlinks: false }).output(
+        { url: "https://app.qawolf.com/runs/rn1" },
+        "url: https://app.qawolf.com/runs/rn1",
+      );
+      expect(clack.log.info).toHaveBeenCalledWith(
+        "url: https://app.qawolf.com/runs/rn1",
+      );
+    });
+
+    it("wraps urls in OSC 8 hyperlinks when supported", () => {
+      const clack = makeClack();
+      createHumanRenderers(clack, undefined, { hyperlinks: true }).output(
+        { url: "https://app.qawolf.com/runs/rn1" },
+        "url: https://app.qawolf.com/runs/rn1",
+      );
+      expect(clack.log.info).toHaveBeenCalledWith(
+        "url: \x1b]8;;https://app.qawolf.com/runs/rn1\x07https://app.qawolf.com/runs/rn1\x1b]8;;\x07",
+      );
+    });
   });
 
   describe("gap", () => {

--- a/src/shell/ui/renderers/modes/human.ts
+++ b/src/shell/ui/renderers/modes/human.ts
@@ -1,4 +1,5 @@
 import type { StyledClack } from "~/shell/ui/clack/index.js";
+import { linkifyUrls } from "~/shell/ui/hyperlinks.js";
 import { writeStdoutRaw } from "~/shell/ui/renderers/write.js";
 import { finalizeResults } from "./progress.js";
 import type { RendererSet } from "./types.js";
@@ -6,7 +7,11 @@ import type { RendererSet } from "./types.js";
 export function createHumanRenderers(
   clack: StyledClack,
   verboseTarget?: { write: ((msg: string) => void) | undefined },
+  options: { hyperlinks: boolean } = { hyperlinks: false },
 ): RendererSet {
+  const linkify = (text: string): string =>
+    options.hyperlinks ? linkifyUrls(text) : text;
+
   return {
     intro: (title) => clack.intro(title),
     note: (message, title) => clack.note(message, title),
@@ -14,18 +19,20 @@ export function createHumanRenderers(
     cancel: (message) => clack.cancel(message),
     step: (message, progress) => {
       clack.log.step(
-        progress
-          ? `[${String(progress.current)}/${String(progress.total)}] ${message}`
-          : message,
+        linkify(
+          progress
+            ? `[${String(progress.current)}/${String(progress.total)}] ${message}`
+            : message,
+        ),
       );
     },
-    success: (message) => clack.log.success(message),
-    warn: (message) => clack.log.warn(message),
-    info: (message) => clack.log.info(message),
+    success: (message) => clack.log.success(linkify(message)),
+    warn: (message) => clack.log.warn(linkify(message)),
+    info: (message) => clack.log.info(linkify(message)),
     error: (title, body) => {
-      clack.log.error(title + (body ? `\n${body}` : ""));
+      clack.log.error(linkify(title + (body ? `\n${body}` : "")));
     },
-    output: (_data, humanMessage) => clack.log.info(humanMessage),
+    output: (_data, humanMessage) => clack.log.info(linkify(humanMessage)),
     gap: () => process.stderr.write("\n"),
     write: (text) => writeStdoutRaw(text),
     withProgress: async (steps, done) => {

--- a/src/shell/ui/renderers/modes/index.ts
+++ b/src/shell/ui/renderers/modes/index.ts
@@ -7,14 +7,20 @@ import type { RendererSet } from "./types.js";
 
 export type { RendererSet } from "./types.js";
 
-export function pickRenderers(
-  mode: OutputMode,
-  clack: StyledClack,
-  verboseTarget?: { write: ((msg: string) => void) | undefined },
-): RendererSet {
+export function pickRenderers({
+  mode,
+  clack,
+  verboseTarget,
+  hyperlinks,
+}: {
+  mode: OutputMode;
+  clack: StyledClack;
+  verboseTarget: { write: ((msg: string) => void) | undefined } | undefined;
+  hyperlinks: boolean;
+}): RendererSet {
   switch (mode) {
     case "human":
-      return createHumanRenderers(clack, verboseTarget);
+      return createHumanRenderers(clack, verboseTarget, { hyperlinks });
     case "agent":
       return createAgentRenderers();
     case "json":


### PR DESCRIPTION
# Overview of Changes

Make the url from `qawolf run create` clickable:

<img width="1760" height="120" alt="CleanShot 2026-08-05 at 12 27 12" src="https://github.com/user-attachments/assets/ab2abecd-6ee2-49c9-b3a6-e1efa6d6a940" />

