### PR TITLE
docs(skill): document cross-harness installation

### DIFF
--- a/.changeset/portable-agent-skill.md
+++ b/.changeset/portable-agent-skill.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Document cross-harness Agent Skill installation and declare the CLI runtime requirement in the portable skill metadata.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,29 @@ Run any command with `--help` for its flags and options.
 
 ## Agent integration
 
-The npm package ships [`skills/qawolf-cli/SKILL.md`](skills/qawolf-cli/SKILL.md), a Claude Code agent skill that describes the CLI's command surface for AI agents. It is generated from its [source template](src/commands/qawolfCliSkill.template.md) and the command tree (`bun run generate`), and kept in sync by the test suite.
+This repository ships a [`qawolf-cli` Agent Skill](skills/qawolf-cli/SKILL.md) that follows the open [Agent Skills specification](https://agentskills.io/specification). It works with compatible harnesses such as Claude Code, Codex, Cursor, Gemini CLI, GitHub Copilot, and OpenCode.
+
+Install the CLI first, then use the cross-harness [`skills`](https://github.com/vercel-labs/skills) installer to install the skill globally:
+
+```bash
+npm install -g @qawolf/cli
+npx skills add qawolf/cli --skill qawolf-cli --global
+```
+
+The installer detects supported harnesses and prompts you to select where to install the skill. To target specific harnesses non-interactively:
+
+```bash
+npx skills add qawolf/cli \
+  --skill qawolf-cli \
+  --global \
+  --agent claude-code \
+  --agent codex \
+  --yes
+```
+
+Omit `--global` to install the skill only for the current project. The skill also ships in the npm package for consumers that manage skill files directly.
+
+The skill is generated from its [source template](src/commands/qawolfCliSkill.template.md) and the command tree (`bun run generate`), and kept in sync by the test suite.
 
 ## Reference
 

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: qawolf-cli
 description: Manage QA Wolf through the qawolf CLI. Use when asked which QA Wolf environment variables are available or to list, set, or delete them; manage environments, flows, runs, tags, or issues; authenticate; install; or perform other QA Wolf operations from a shell.
+license: Apache-2.0
+compatibility: Requires the qawolf CLI on PATH. Install it from @qawolf/cli or use a standalone binary from GitHub Releases.
 ---
 
 # QA Wolf CLI

--- a/src/commands/qawolfCliSkill.template.md
+++ b/src/commands/qawolfCliSkill.template.md
@@ -1,6 +1,8 @@
 ---
 name: qawolf-cli
 description: Manage QA Wolf through the qawolf CLI. Use when asked which QA Wolf environment variables are available or to list, set, or delete them; manage environments, flows, runs, tags, or issues; authenticate; install; or perform other QA Wolf operations from a shell.
+license: Apache-2.0
+compatibility: Requires the qawolf CLI on PATH. Install it from @qawolf/cli or use a standalone binary from GitHub Releases.
 ---
 
 # QA Wolf CLI


### PR DESCRIPTION
# Overview of Changes

The bundled Agent Skill was documented as Claude Code-specific even though its `skills/qawolf-cli/SKILL.md` layout follows the open Agent Skills specification. Document cross-harness installation with `npx skills add`, add standard license and runtime compatibility metadata to the generated skill, and include a patch changeset.

# Testing

```bash
bun run test
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run build
npx --yes skills add . --list
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (not applicable; existing generation test covers the skill)
- [x] No breaking changes
