### PR TITLE
fix(flows): resolve --env aliases to environment ids

### DIFF
--- a/.changeset/resolve-env-aliases.md
+++ b/.changeset/resolve-env-aliases.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Resolve environment aliases before flows commands use them. `flows pull --env <alias>` and `flows run --env <alias>` failed with an HTTP 400 because the CLI sent the alias to an endpoint that requires an environment id. The CLI now resolves an explicit `--env` value, and a `QAWOLF_ENVIRONMENT` value, through the `environment.get` public API. That endpoint accepts an id or an alias and returns the canonical id. Only the id goes to later requests, so `--env <alias>` and `--env <id>` now write to the same `.qawolf/<id>/` cache directory. When the resolution fails, the error names the environment value and tells you that aliases require a team API key.

--- a/src/commands/flows/run.register.ts
+++ b/src/commands/flows/run.register.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander";
 
-import { withAuthContext, withContext } from "~/commands/context.js";
+import { withContext } from "~/commands/context.js";
 import { declareCommandKind } from "~/commands/commandKind.js";
+import { flowsMessages } from "~/core/messages/index.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import type {
   HarContent,
@@ -15,6 +16,7 @@ import type { FlowsRunFlags } from "~/domains/runner/runInternals.js";
 
 import { handleFlowsRun } from "./runDefaults.js";
 import { handleHybridFlowsRun } from "./hybridRunDefaults.js";
+import { withResolvedEnv } from "./withResolvedEnv.js";
 
 const videoModes = ["on", "off", "retain-on-failure"] as const;
 const traceModes = ["on", "off", "retain-on-failure"] as const;
@@ -115,9 +117,16 @@ export function registerFlowsRunCommand(
         command: Command,
       ) => {
         if (opts.env !== undefined) {
-          const hybridFlags = { ...opts, env: opts.env };
-          return withAuthContext(signals, (ctx) =>
-            handleHybridFlowsRun(ctx, pattern, hybridFlags),
+          // Resolution turns an alias into the canonical id before the
+          // .qawolf/<env>/ cache lookup, so --env <alias> and --env <id>
+          // share one cache directory.
+          return withResolvedEnv(
+            signals,
+            {
+              explicit: opts.env,
+              requiredMessage: flowsMessages.run.requiresEnv,
+            },
+            (ctx, env) => handleHybridFlowsRun(ctx, pattern, { ...opts, env }),
           )(opts, command);
         }
         return withContext(signals, (ctx) =>

--- a/src/core/messages/environments.ts
+++ b/src/core/messages/environments.ts
@@ -12,6 +12,10 @@ export const environmentsMessages = {
     static: "Static environments",
     preview: "Preview (PR) environments",
   },
+  resolvedAlias: (ref: string, id: string) =>
+    `Environment ${ref} resolved to ${id}.`,
+  couldNotResolve: (ref: string, detail: string) =>
+    `Could not resolve environment ${ref}: ${detail} If ${ref} is an alias, note that aliases require a team API key.`,
   aborted: "Aborted; no environment selected.",
   tooManyPages: (pages: number) =>
     `Stopped listing environments after ${pages} pages. Pass --env explicitly.`,

--- a/src/core/messages/flows.ts
+++ b/src/core/messages/flows.ts
@@ -19,6 +19,10 @@ export const flowsMessages = {
       "--remote requires an environment. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
     flagsRequireRemote: "--env and --include-drafts require --remote",
   },
+  run: {
+    requiresEnv:
+      "An environment is required. Pass --env <env> or set QAWOLF_ENVIRONMENT.",
+  },
   pull: {
     requiresEnv:
       "An environment is required. Pass --env <env> or set QAWOLF_ENVIRONMENT.",

--- a/src/domains/environments/pickEnvironment.ts
+++ b/src/domains/environments/pickEnvironment.ts
@@ -1,0 +1,114 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
+import type { z } from "zod";
+
+import { environmentsMessages } from "~/core/messages/index.js";
+import { pluralize } from "~/core/pluralize.js";
+import type {
+  ResolveEnvironmentDeps,
+  ResolveEnvironmentOutcome,
+} from "./resolveEnvironment.js";
+
+const findContract = publicContractsV1.environment.find;
+
+type FindOutput = z.output<typeof findContract.output>;
+type Environment = FindOutput["environments"][number];
+
+// The interactive tail of environment resolution: list the team's
+// environments and auto-pick or prompt. Only reached in human mode when
+// neither --env nor QAWOLF_ENVIRONMENT is set.
+export async function pickEnvironment(
+  deps: ResolveEnvironmentDeps,
+): Promise<ResolveEnvironmentOutcome> {
+  const fetched = await fetchAllEnvironments(deps.platformClient);
+  if (!fetched.ok) return { kind: "error", error: fetched.error };
+
+  const environments = fetched.environments;
+  if (environments.length === 0) {
+    return { kind: "error", error: environmentsMessages.noEnvironments };
+  }
+  const sole = environments.length === 1 ? environments[0] : undefined;
+  if (sole) {
+    deps.ui.info(environmentsMessages.usingEnvironment(sole.name));
+    return { kind: "resolved", env: sole.id };
+  }
+
+  const narrowed = await narrowByKind(deps.ui, environments);
+  if (narrowed === "cancelled") return { kind: "cancelled" };
+
+  const soleOfKind = narrowed.length === 1 ? narrowed[0] : undefined;
+  if (soleOfKind) {
+    deps.ui.info(environmentsMessages.usingEnvironment(soleOfKind.name));
+    return { kind: "resolved", env: soleOfKind.id };
+  }
+
+  const picked = await deps.ui.select(
+    environmentsMessages.whichEnvironment,
+    narrowed.map((e) => ({
+      value: e.id,
+      label: e.name,
+      hint: `${e.kind} · ${e.status}`,
+    })),
+  );
+  if (!picked.ok) return { kind: "cancelled" };
+  // Only after a real prompt: teach the way to skip it next time. Auto-picks
+  // and env-var resolutions had no friction worth a tip.
+  deps.ui.info(environmentsMessages.exportHint(picked.value));
+  return { kind: "resolved", env: picked.value };
+}
+
+// Large teams accumulate many ephemeral preview (PR) environments that
+// drown out the handful of static ones, so when both kinds exist the user
+// picks a kind before scrolling a list. Single-kind teams skip this step.
+async function narrowByKind(
+  ui: ResolveEnvironmentDeps["ui"],
+  environments: Environment[],
+): Promise<Environment[] | "cancelled"> {
+  const byKind = (kind: Environment["kind"]) =>
+    environments.filter((e) => e.kind === kind);
+  const statics = byKind("static");
+  const previews = byKind("preview");
+  if (statics.length === 0 || previews.length === 0) return environments;
+
+  const countHint = (list: Environment[]) =>
+    pluralize(list.length, "environment");
+  const picked = await ui.select(environmentsMessages.whichKind, [
+    {
+      value: "static",
+      label: environmentsMessages.kindLabels.static,
+      hint: countHint(statics),
+    },
+    {
+      value: "preview",
+      label: environmentsMessages.kindLabels.preview,
+      hint: countHint(previews),
+    },
+  ]);
+  if (!picked.ok) return "cancelled";
+  return picked.value === "static" ? statics : previews;
+}
+
+// Termination depends on a server-controlled cursor, so the loop is
+// bounded: a pagination bug must produce an error, not a hung CLI. Ten
+// pages (1,000 environments) is an order of magnitude above any observed
+// team while keeping the pathological case to seconds, not minutes.
+const maxPages = 10;
+
+async function fetchAllEnvironments(
+  platformClient: ResolveEnvironmentDeps["platformClient"],
+): Promise<
+  { ok: true; environments: Environment[] } | { ok: false; error: string }
+> {
+  const environments: Environment[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < maxPages; page += 1) {
+    const result = await platformClient.callPublicApi(findContract, {
+      limit: 100,
+      cursor,
+    });
+    if (!result.ok) return result;
+    environments.push(...result.value.environments);
+    cursor = result.value.nextCursor;
+    if (cursor === undefined) return { ok: true, environments };
+  }
+  return { ok: false, error: environmentsMessages.tooManyPages(maxPages) };
+}

--- a/src/domains/environments/resolveEnvironment.test.ts
+++ b/src/domains/environments/resolveEnvironment.test.ts
@@ -4,27 +4,72 @@ import { resolveEnvironment } from "./resolveEnvironment.js";
 import { env, makeDeps } from "./resolveEnvironment.testUtils.js";
 
 describe("resolveEnvironment", () => {
-  it("returns the trimmed --env flag without any lookup", async () => {
-    const { deps, callPublicApi } = makeDeps({});
+  it("resolves the trimmed --env flag through environment.get", async () => {
+    const { deps, getEnvironment, findEnvironments } = makeDeps({
+      getEnv: env("env-1", "Staging"),
+    });
 
     const outcome = await resolveEnvironment(deps, {
       explicit: "  staging  ",
       requiredMessage: "req",
     });
 
-    expect(outcome).toEqual({ kind: "resolved", env: "staging" });
-    expect(callPublicApi).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ kind: "resolved", env: "env-1" });
+    expect(getEnvironment).toHaveBeenCalledWith({ environmentId: "staging" });
+    expect(findEnvironments).not.toHaveBeenCalled();
   });
 
-  it("falls back to QAWOLF_ENVIRONMENT and notes the source", async () => {
-    const { deps, info } = makeDeps({ envVar: " prod " });
+  it("notes the id an alias resolved to", async () => {
+    const { deps, info } = makeDeps({ getEnv: env("env-1", "Staging") });
+
+    await resolveEnvironment(deps, {
+      explicit: "staging",
+      requiredMessage: "req",
+    });
+
+    expect(info).toHaveBeenCalledWith("Environment staging resolved to env-1.");
+  });
+
+  it("stays quiet when --env is already the canonical id", async () => {
+    const { deps, info } = makeDeps({ getEnv: env("env-1", "Staging") });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: "env-1",
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({ kind: "resolved", env: "env-1" });
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an environment.get failure with the alias caveat", async () => {
+    const { deps } = makeDeps({ getError: "HTTP 400" });
+
+    const outcome = await resolveEnvironment(deps, {
+      explicit: "staging",
+      requiredMessage: "req",
+    });
+
+    expect(outcome).toEqual({
+      kind: "error",
+      error:
+        "Could not resolve environment staging: HTTP 400 If staging is an alias, note that aliases require a team API key.",
+    });
+  });
+
+  it("falls back to QAWOLF_ENVIRONMENT, notes the source, and resolves it", async () => {
+    const { deps, info, getEnvironment } = makeDeps({
+      envVar: " prod ",
+      getEnv: env("env-2", "Prod"),
+    });
 
     const outcome = await resolveEnvironment(deps, {
       explicit: undefined,
       requiredMessage: "req",
     });
 
-    expect(outcome).toEqual({ kind: "resolved", env: "prod" });
+    expect(outcome).toEqual({ kind: "resolved", env: "env-2" });
+    expect(getEnvironment).toHaveBeenCalledWith({ environmentId: "prod" });
     expect(info).toHaveBeenCalledWith(
       "Using environment from QAWOLF_ENVIRONMENT (prod)",
     );
@@ -43,7 +88,7 @@ describe("resolveEnvironment", () => {
 
   it("errors with the required message in non-human modes", async () => {
     for (const mode of ["json", "agent"] as const) {
-      const { deps, callPublicApi } = makeDeps({ mode });
+      const { deps, findEnvironments, getEnvironment } = makeDeps({ mode });
 
       const outcome = await resolveEnvironment(deps, {
         explicit: undefined,
@@ -51,7 +96,8 @@ describe("resolveEnvironment", () => {
       });
 
       expect(outcome).toEqual({ kind: "error", error: "req" });
-      expect(callPublicApi).not.toHaveBeenCalled();
+      expect(findEnvironments).not.toHaveBeenCalled();
+      expect(getEnvironment).not.toHaveBeenCalled();
     }
   });
 
@@ -112,7 +158,7 @@ describe("resolveEnvironment", () => {
   });
 
   it("pages through nextCursor before prompting", async () => {
-    const { deps, callPublicApi, select } = makeDeps({
+    const { deps, findEnvironments, select } = makeDeps({
       pages: [
         { environments: [env("env-1", "A")], nextCursor: "c2" },
         { environments: [env("env-2", "B")] },
@@ -126,7 +172,7 @@ describe("resolveEnvironment", () => {
     });
 
     expect(outcome).toEqual({ kind: "resolved", env: "env-1" });
-    expect(callPublicApi).toHaveBeenCalledTimes(2);
+    expect(findEnvironments).toHaveBeenCalledTimes(2);
     expect(select).toHaveBeenCalledTimes(1);
   });
 
@@ -145,7 +191,7 @@ describe("resolveEnvironment", () => {
   });
 
   it("stops with an error when pagination never terminates", async () => {
-    const { deps, callPublicApi } = makeDeps({ endlessCursor: true });
+    const { deps, findEnvironments } = makeDeps({ endlessCursor: true });
 
     const outcome = await resolveEnvironment(deps, {
       explicit: undefined,
@@ -157,7 +203,7 @@ describe("resolveEnvironment", () => {
       error:
         "Stopped listing environments after 10 pages. Pass --env explicitly.",
     });
-    expect(callPublicApi).toHaveBeenCalledTimes(10);
+    expect(findEnvironments).toHaveBeenCalledTimes(10);
   });
 
   it("surfaces a platform error", async () => {

--- a/src/domains/environments/resolveEnvironment.testUtils.ts
+++ b/src/domains/environments/resolveEnvironment.testUtils.ts
@@ -1,6 +1,15 @@
+import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 import { mock } from "bun:test";
+import type { z } from "zod";
 
+import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
 import type { ResolveEnvironmentDeps } from "./resolveEnvironment.js";
+
+const findContract = publicContractsV1.environment.find;
+const getContract = publicContractsV1.environment.get;
+
+type FindOutput = z.output<typeof findContract.output>;
+type GetOutput = z.output<typeof getContract.output>;
 
 export type Page = {
   environments: {
@@ -21,26 +30,54 @@ export function makeDeps(args: {
   // Every fetch returns a page with a nextCursor, so pagination never
   // terminates on its own — for testing the page cap.
   endlessCursor?: boolean;
+  // environment.get result for an explicit/env-var ref. Tests that never
+  // trigger ref resolution omit both getEnv and getError.
+  getEnv?: Page["environments"][number];
+  getError?: string;
   selectAnswers?: string[];
   selectCancelled?: boolean;
 }) {
   const pages = args.pages ?? [];
   let call = 0;
-  const callPublicApi = mock(async () => {
-    if (args.findError !== undefined) {
-      return { ok: false as const, error: args.findError };
-    }
-    if (args.endlessCursor) {
-      return {
-        ok: true as const,
-        value: { environments: [], nextCursor: "again" },
-      };
-    }
-    const page = pages[call];
-    call += 1;
-    if (page === undefined) throw new Error("unexpected extra page fetch");
-    return { ok: true as const, value: page };
-  });
+  const findEnvironments = mock(
+    async (): Promise<PlatformResult<FindOutput>> => {
+      if (args.findError !== undefined) {
+        return { ok: false, error: args.findError };
+      }
+      if (args.endlessCursor) {
+        return { ok: true, value: { environments: [], nextCursor: "again" } };
+      }
+      const page = pages[call];
+      call += 1;
+      if (page === undefined) throw new Error("unexpected extra page fetch");
+      return { ok: true, value: page };
+    },
+  );
+  const getEnvironment = mock(
+    async (_input: unknown): Promise<PlatformResult<GetOutput>> => {
+      if (args.getError !== undefined) {
+        return { ok: false, error: args.getError };
+      }
+      const value = args.getEnv;
+      if (value === undefined)
+        throw new Error("unexpected environment.get call");
+      return { ok: true, value };
+    },
+  );
+
+  function callPublicApi(
+    contract: typeof findContract,
+    input: z.input<typeof findContract.input>,
+  ): Promise<PlatformResult<FindOutput>>;
+  function callPublicApi(
+    contract: typeof getContract,
+    input: z.input<typeof getContract.input>,
+  ): Promise<PlatformResult<GetOutput>>;
+  function callPublicApi(contract: { name: string }, input: unknown) {
+    if (contract.name === getContract.name) return getEnvironment(input);
+    return findEnvironments();
+  }
+
   // One queued answer per expected prompt, in order (kind pick, then env
   // pick). A test that expects a single prompt queues a single answer.
   const answers = [...(args.selectAnswers ?? [])];
@@ -56,7 +93,7 @@ export function makeDeps(args: {
     ui: { mode: args.mode ?? "human", info, select },
     env: { QAWOLF_ENVIRONMENT: args.envVar },
   };
-  return { deps, callPublicApi, select, info };
+  return { deps, findEnvironments, getEnvironment, select, info };
 }
 
 export function env(

--- a/src/domains/environments/resolveEnvironment.ts
+++ b/src/domains/environments/resolveEnvironment.ts
@@ -2,30 +2,37 @@ import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 import type { z } from "zod";
 
 import { environmentsMessages } from "~/core/messages/index.js";
-import { pluralize } from "~/core/pluralize.js";
 import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
 import type { UI } from "~/shell/ui/index.js";
+import { pickEnvironment } from "./pickEnvironment.js";
 
 const findContract = publicContractsV1.environment.find;
+const getContract = publicContractsV1.environment.get;
 
 type FindOutput = z.output<typeof findContract.output>;
-type Environment = FindOutput["environments"][number];
+type GetOutput = z.output<typeof getContract.output>;
 
 export type ResolveEnvironmentOutcome =
   | { kind: "resolved"; env: string }
   | { kind: "cancelled" }
   | { kind: "error"; error: string };
 
-// The concrete instantiation of PlatformClient["callPublicApi"] this domain
-// needs. The real generic method is assignable to it, and test fakes can
-// satisfy it without casts.
-type FindEnvironmentsApi = (
-  contract: typeof findContract,
-  input: z.input<typeof findContract.input>,
-) => Promise<PlatformResult<FindOutput>>;
+// The concrete instantiations of PlatformClient["callPublicApi"] this domain
+// needs. The real generic method is assignable to the overload set, and test
+// fakes can satisfy it without casts.
+type EnvironmentsApi = {
+  (
+    contract: typeof findContract,
+    input: z.input<typeof findContract.input>,
+  ): Promise<PlatformResult<FindOutput>>;
+  (
+    contract: typeof getContract,
+    input: z.input<typeof getContract.input>,
+  ): Promise<PlatformResult<GetOutput>>;
+};
 
 export type ResolveEnvironmentDeps = {
-  platformClient: { callPublicApi: FindEnvironmentsApi };
+  platformClient: { callPublicApi: EnvironmentsApi };
   ui: Pick<UI, "mode" | "info" | "select">;
   env: Record<string, string | undefined>;
 };
@@ -42,108 +49,42 @@ export async function resolveEnvironment(
   opts: ResolveEnvironmentOpts,
 ): Promise<ResolveEnvironmentOutcome> {
   const explicit = opts.explicit?.trim();
-  if (explicit) return { kind: "resolved", env: explicit };
+  if (explicit) return resolveRef(deps, explicit);
 
   const fromEnvVar = deps.env["QAWOLF_ENVIRONMENT"]?.trim();
   if (fromEnvVar) {
     deps.ui.info(environmentsMessages.usingFromEnvVar(fromEnvVar));
-    return { kind: "resolved", env: fromEnvVar };
+    return resolveRef(deps, fromEnvVar);
   }
 
   if (deps.ui.mode !== "human") {
     return { kind: "error", error: opts.requiredMessage };
   }
 
-  const fetched = await fetchAllEnvironments(deps.platformClient);
-  if (!fetched.ok) return { kind: "error", error: fetched.error };
-
-  const environments = fetched.environments;
-  if (environments.length === 0) {
-    return { kind: "error", error: environmentsMessages.noEnvironments };
-  }
-  const sole = environments.length === 1 ? environments[0] : undefined;
-  if (sole) {
-    deps.ui.info(environmentsMessages.usingEnvironment(sole.name));
-    return { kind: "resolved", env: sole.id };
-  }
-
-  const narrowed = await narrowByKind(deps.ui, environments);
-  if (narrowed === "cancelled") return { kind: "cancelled" };
-
-  const soleOfKind = narrowed.length === 1 ? narrowed[0] : undefined;
-  if (soleOfKind) {
-    deps.ui.info(environmentsMessages.usingEnvironment(soleOfKind.name));
-    return { kind: "resolved", env: soleOfKind.id };
-  }
-
-  const picked = await deps.ui.select(
-    environmentsMessages.whichEnvironment,
-    narrowed.map((e) => ({
-      value: e.id,
-      label: e.name,
-      hint: `${e.kind} · ${e.status}`,
-    })),
-  );
-  if (!picked.ok) return { kind: "cancelled" };
-  // Only after a real prompt: teach the way to skip it next time. Auto-picks
-  // and env-var resolutions had no friction worth a tip.
-  deps.ui.info(environmentsMessages.exportHint(picked.value));
-  return { kind: "resolved", env: picked.value };
+  return pickEnvironment(deps);
 }
 
-// Large teams accumulate many ephemeral preview (PR) environments that
-// drown out the handful of static ones, so when both kinds exist the user
-// picks a kind before scrolling a list. Single-kind teams skip this step.
-async function narrowByKind(
-  ui: ResolveEnvironmentDeps["ui"],
-  environments: Environment[],
-): Promise<Environment[] | "cancelled"> {
-  const byKind = (kind: Environment["kind"]) =>
-    environments.filter((e) => e.kind === kind);
-  const statics = byKind("static");
-  const previews = byKind("preview");
-  if (statics.length === 0 || previews.length === 0) return environments;
-
-  const countHint = (list: Environment[]) =>
-    pluralize(list.length, "environment");
-  const picked = await ui.select(environmentsMessages.whichKind, [
-    {
-      value: "static",
-      label: environmentsMessages.kindLabels.static,
-      hint: countHint(statics),
-    },
-    {
-      value: "preview",
-      label: environmentsMessages.kindLabels.preview,
-      hint: countHint(previews),
-    },
-  ]);
-  if (!picked.ok) return "cancelled";
-  return picked.value === "static" ? statics : previews;
-}
-
-// Termination depends on a server-controlled cursor, so the loop is
-// bounded: a pagination bug must produce an error, not a hung CLI. Ten
-// pages (1,000 environments) is an order of magnitude above any observed
-// team while keeping the pathological case to seconds, not minutes.
-const maxPages = 10;
-
-async function fetchAllEnvironments(platformClient: {
-  callPublicApi: FindEnvironmentsApi;
-}): Promise<
-  { ok: true; environments: Environment[] } | { ok: false; error: string }
-> {
-  const environments: Environment[] = [];
-  let cursor: string | undefined;
-  for (let page = 0; page < maxPages; page += 1) {
-    const result = await platformClient.callPublicApi(findContract, {
-      limit: 100,
-      cursor,
-    });
-    if (!result.ok) return result;
-    environments.push(...result.value.environments);
-    cursor = result.value.nextCursor;
-    if (cursor === undefined) return { ok: true, environments };
+// A user-supplied value (--env flag or QAWOLF_ENVIRONMENT) may be an alias.
+// environment.get accepts an id or an alias and returns the canonical id, so
+// every ref goes through it — pattern-detecting aliases is not possible
+// because real ids also match the kebab-case slug pattern. Passing only the
+// canonical id downstream keeps cache identity stable: --env <alias> and
+// --env <id> land in the same .qawolf/<id>/ directory.
+async function resolveRef(
+  deps: ResolveEnvironmentDeps,
+  ref: string,
+): Promise<ResolveEnvironmentOutcome> {
+  const result = await deps.platformClient.callPublicApi(getContract, {
+    environmentId: ref,
+  });
+  if (!result.ok) {
+    return {
+      kind: "error",
+      error: environmentsMessages.couldNotResolve(ref, result.error),
+    };
   }
-  return { ok: false, error: environmentsMessages.tooManyPages(maxPages) };
+  if (result.value.id !== ref) {
+    deps.ui.info(environmentsMessages.resolvedAlias(ref, result.value.id));
+  }
+  return { kind: "resolved", env: result.value.id };
 }


### PR DESCRIPTION
Relates to WIZ-11372

# Overview of Changes

`flows pull --env <alias>` and `flows run --env <alias>` failed with a bare `HTTP 400` because the CLI forwarded the raw `--env` value to the flows-bundle endpoint, which requires an environment id, while `flows list --remote` happened to work because the public `flow.list` endpoint resolves aliases server-side. `resolveEnvironment` now resolves any user-supplied value (`--env` flag or `QAWOLF_ENVIRONMENT`) through the public `environment.get` endpoint, which accepts an id or an alias and returns the canonical id, and only the id is passed downstream. `flows run --env` previously bypassed resolution entirely and derived its `.qawolf/<env>/` cache directory from the raw flag, so it now routes through `withResolvedEnv` — `--env <alias>` and `--env <id>` share one id-named cache directory. No pattern-based alias detection: real ids also match the kebab-case slug pattern.

Alias resolution is surfaced to the user (`Environment <alias> resolved to <id>.`), and a resolution failure names the value and notes that aliases require a team API key. The interactive picker moved to `pickEnvironment.ts` to stay under the file-size lint.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

Verified live against a real team: `flows pull --env <alias>` pulls into `.qawolf/<id>/`, `flows list --remote --env <alias>` lists and prints the resolution notice, and `--env <id>` behaves as before.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)