### PR TITLE
fix(init): set type module and add flows dep on existing package.json

### DIFF
--- a/.changeset/init-existing-package-esm.md
+++ b/.changeset/init-existing-package-esm.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Make `init` repair an existing package.json so the scaffolded flow can load. The scaffolded flow and config are ES modules. Node reads their module format from the nearest package.json `type` field. Before this change, `init` only added the `test:e2e` script to an existing package.json. It did not set `"type": "module"` and did not add the `@qawolf/flows` dependency, so the example flow failed to load. Current npm writes `"type": "commonjs"` into every `npm init -y` package.json, so an explicit value does not signal author intent. `init` now offers three changes in one prompt: add the `test:e2e` script, set `"type": "module"`, and add the `@qawolf/flows` dependency. It applies the missing ones and skips the rest. It prints a warning after it changes an explicit `type` value, because that changes how every `.js` file in the package loads. Run `init` again on a half-configured project to repair it; the old code stopped at the first existing script.

--- a/src/core/messages/init.ts
+++ b/src/core/messages/init.ts
@@ -8,6 +8,10 @@ export const initMessages = {
   createdPackageJson: "Created package.json",
   packageJsonInvalidJson:
     "package.json is not valid JSON — skipped updating it",
+  packageJsonNotAnObject:
+    "package.json is not a JSON object — skipped updating it",
+  packageJsonMalformedSection: (field: string) =>
+    `package.json has a non-object "${field}" — skipped changes to it`,
   packageJsonHasTestE2e:
     "package.json already has `test:e2e` — leaving it as is",
   packageJsonUpToDate: "package.json already configured — nothing to update",

--- a/src/core/messages/init.ts
+++ b/src/core/messages/init.ts
@@ -7,11 +7,11 @@ export const initMessages = {
   skippedUpdatingPackageJson: "Skipped updating package.json",
   createdPackageJson: "Created package.json",
   packageJsonInvalidJson:
-    "package.json is not valid JSON — skipped updating it",
+    "`package.json` contains invalid JSON. Correct the JSON syntax, then run `qawolf init` again.",
   packageJsonNotAnObject:
-    "package.json is not a JSON object — skipped updating it",
+    "`package.json` must contain a JSON object. Update it, then run `qawolf init` again.",
   packageJsonMalformedSection: (field: string) =>
-    `package.json has a non-object "${field}" — skipped changes to it`,
+    `The \`${field}\` field in \`package.json\` must be a JSON object. Update it, then run \`qawolf init\` again.`,
   packageJsonHasTestE2e:
     "package.json already has `test:e2e` — leaving it as is",
   packageJsonUpToDate: "package.json already configured — nothing to update",

--- a/src/core/messages/init.ts
+++ b/src/core/messages/init.ts
@@ -4,12 +4,22 @@ export const initMessages = {
     "Run `qawolf auth login`, then `qawolf flows pull`, then `qawolf flows run`.",
   createPackageJsonPrompt: "Create package.json (required to run flows)?",
   skippedCreatingPackageJson: "Skipped package.json",
-  skippedAddingTestE2e: "Skipped adding test:e2e to package.json",
+  skippedUpdatingPackageJson: "Skipped updating package.json",
   createdPackageJson: "Created package.json",
   packageJsonInvalidJson:
-    "package.json is not valid JSON — skipped adding `test:e2e`",
-  packageJsonHasTestE2e: "package.json already has `test:e2e` — skipped",
-  addTestE2ePrompt: "Add `test:e2e: qawolf flows run` to package.json?",
+    "package.json is not valid JSON — skipped updating it",
+  packageJsonHasTestE2e:
+    "package.json already has `test:e2e` — leaving it as is",
+  packageJsonUpToDate: "package.json already configured — nothing to update",
+  typeChanged: (from: string) =>
+    `Changed "type" from "${from}" to "module" — .js files in this package now load as ES modules.`,
+  pkgChanges: {
+    script: "add `test:e2e` script",
+    type: 'set "type": "module"',
+    flowsDep: "add @qawolf/flows dependency",
+  },
+  updatePackageJsonPrompt: (changes: readonly string[]) =>
+    `Update package.json (${changes.join(", ")})?`,
   updatedPackageJson: "Updated package.json",
   overwritePrompt: (relPath: string) => `Overwrite ${relPath}?`,
   skippedFile: (relPath: string) => `Skipped ${relPath}`,

--- a/src/domains/init/ensurePackageJson.ts
+++ b/src/domains/init/ensurePackageJson.ts
@@ -34,22 +34,28 @@ export async function ensurePackageJson(
 
   const raw = await deps.fs.readFile(pkgPath);
 
-  let pkg: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    pkg = JSON.parse(raw) as Record<string, unknown>;
+    parsed = JSON.parse(raw);
   } catch {
     ctx.ui.warn(initMessages.packageJsonInvalidJson);
     return;
   }
+  // JSON.parse also accepts null, arrays, and primitives — none of which can
+  // safely take property assignments (or keep them through stringify).
+  if (!isRecord(parsed)) {
+    ctx.ui.warn(initMessages.packageJsonNotAnObject);
+    return;
+  }
+  const pkg = parsed;
 
-  const scripts = (pkg["scripts"] ?? {}) as Record<string, string>;
-  const dependencies = (pkg["dependencies"] ?? {}) as Record<string, string>;
-  const devDependencies = (pkg["devDependencies"] ?? {}) as Record<
-    string,
-    string
-  >;
+  // A section that exists but is not an object cannot be repaired without
+  // destroying whatever the user put there; skip only that repair.
+  const scripts = readSection(ctx, pkg, "scripts");
+  const dependencies = readSection(ctx, pkg, "dependencies");
+  const devDependencies = readSection(ctx, pkg, "devDependencies");
 
-  const needScript = !scripts["test:e2e"];
+  const needScript = scripts !== undefined && !scripts["test:e2e"];
   // The scaffolded flow and config are ES modules; Node picks their module
   // format from this package.json's "type". `npm init -y` writes an explicit
   // "type": "commonjs" on current npm, so an explicit value does not signal
@@ -59,7 +65,9 @@ export async function ensurePackageJson(
   const priorType = pkg["type"];
   const needType = priorType !== "module";
   const needFlowsDep =
-    !dependencies["@qawolf/flows"] && !devDependencies["@qawolf/flows"];
+    dependencies !== undefined &&
+    !dependencies["@qawolf/flows"] &&
+    !devDependencies?.["@qawolf/flows"];
 
   const changes: string[] = [];
   if (needScript) changes.push(initMessages.pkgChanges.script);
@@ -70,7 +78,7 @@ export async function ensurePackageJson(
     ctx.ui.info(initMessages.packageJsonUpToDate);
     return;
   }
-  if (!needScript) {
+  if (scripts !== undefined && scripts["test:e2e"]) {
     ctx.ui.warn(initMessages.packageJsonHasTestE2e);
   }
 
@@ -83,12 +91,12 @@ export async function ensurePackageJson(
     return;
   }
 
-  if (needScript) {
+  if (needScript && scripts !== undefined) {
     scripts["test:e2e"] = "qawolf flows run";
     pkg["scripts"] = scripts;
   }
   if (needType) pkg["type"] = "module";
-  if (needFlowsDep) {
+  if (needFlowsDep && dependencies !== undefined) {
     dependencies["@qawolf/flows"] = flowsVersion;
     pkg["dependencies"] = dependencies;
   }
@@ -104,4 +112,25 @@ export async function ensurePackageJson(
       typeof priorType === "string" ? priorType : JSON.stringify(priorType);
     ctx.ui.warn(initMessages.typeChanged(label));
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reads a package.json section as a mutable record. Absent sections come back
+ * as an empty record (repairable); malformed ones come back undefined after a
+ * warning, so their repairs are skipped rather than destroying user data.
+ */
+function readSection(
+  ctx: CommandContext,
+  pkg: Record<string, unknown>,
+  key: "scripts" | "dependencies" | "devDependencies",
+): Record<string, unknown> | undefined {
+  const value = pkg[key];
+  if (value === undefined) return {};
+  if (isRecord(value)) return value;
+  ctx.ui.warn(initMessages.packageJsonMalformedSection(key));
+  return undefined;
 }

--- a/src/domains/init/ensurePackageJson.ts
+++ b/src/domains/init/ensurePackageJson.ts
@@ -1,0 +1,107 @@
+import { join } from "node:path";
+import type { CommandContext } from "~/shell/commandContext.js";
+import { flowsVersion } from "~/generated/dependencyVersions.js";
+import { initMessages } from "~/core/messages/index.js";
+
+import type { InitDeps } from "./init.js";
+
+export async function ensurePackageJson(
+  ctx: CommandContext,
+  yes: boolean,
+  deps: InitDeps,
+): Promise<void> {
+  const pkgPath = join(deps.cwd, "package.json");
+
+  if (!(await deps.fs.pathExists(pkgPath))) {
+    const confirmed = await ctx.ui.confirm(
+      initMessages.createPackageJsonPrompt,
+      { yes },
+    );
+    if (!confirmed.ok || !confirmed.value) {
+      ctx.ui.info(initMessages.skippedCreatingPackageJson);
+      return;
+    }
+    const pkg = {
+      private: true,
+      type: "module",
+      dependencies: { "@qawolf/flows": flowsVersion },
+      scripts: { "test:e2e": "qawolf flows run" },
+    };
+    await deps.fs.writeFile(pkgPath, JSON.stringify(pkg, undefined, 2) + "\n");
+    ctx.ui.step(initMessages.createdPackageJson);
+    return;
+  }
+
+  const raw = await deps.fs.readFile(pkgPath);
+
+  let pkg: Record<string, unknown>;
+  try {
+    pkg = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    ctx.ui.warn(initMessages.packageJsonInvalidJson);
+    return;
+  }
+
+  const scripts = (pkg["scripts"] ?? {}) as Record<string, string>;
+  const dependencies = (pkg["dependencies"] ?? {}) as Record<string, string>;
+  const devDependencies = (pkg["devDependencies"] ?? {}) as Record<
+    string,
+    string
+  >;
+
+  const needScript = !scripts["test:e2e"];
+  // The scaffolded flow and config are ES modules; Node picks their module
+  // format from this package.json's "type". `npm init -y` writes an explicit
+  // "type": "commonjs" on current npm, so an explicit value does not signal
+  // author intent — offer the flip whenever the field is not "module", and
+  // warn loudly after changing an explicit value (it re-types every .js
+  // file in the package).
+  const priorType = pkg["type"];
+  const needType = priorType !== "module";
+  const needFlowsDep =
+    !dependencies["@qawolf/flows"] && !devDependencies["@qawolf/flows"];
+
+  const changes: string[] = [];
+  if (needScript) changes.push(initMessages.pkgChanges.script);
+  if (needType) changes.push(initMessages.pkgChanges.type);
+  if (needFlowsDep) changes.push(initMessages.pkgChanges.flowsDep);
+
+  if (changes.length === 0) {
+    ctx.ui.info(initMessages.packageJsonUpToDate);
+    return;
+  }
+  if (!needScript) {
+    ctx.ui.warn(initMessages.packageJsonHasTestE2e);
+  }
+
+  const confirmed = await ctx.ui.confirm(
+    initMessages.updatePackageJsonPrompt(changes),
+    { yes, destructive: true },
+  );
+  if (!confirmed.ok || !confirmed.value) {
+    ctx.ui.info(initMessages.skippedUpdatingPackageJson);
+    return;
+  }
+
+  if (needScript) {
+    scripts["test:e2e"] = "qawolf flows run";
+    pkg["scripts"] = scripts;
+  }
+  if (needType) pkg["type"] = "module";
+  if (needFlowsDep) {
+    dependencies["@qawolf/flows"] = flowsVersion;
+    pkg["dependencies"] = dependencies;
+  }
+
+  const trailingNewline = raw.endsWith("\n") ? "\n" : "";
+  await deps.fs.writeFile(
+    pkgPath,
+    JSON.stringify(pkg, undefined, 2) + trailingNewline,
+  );
+  ctx.ui.step(initMessages.updatedPackageJson);
+  if (needType && priorType !== undefined) {
+    const label =
+      typeof priorType === "string" ? priorType : JSON.stringify(priorType);
+    ctx.ui.warn(initMessages.typeChanged(label));
+  }
+}

--- a/src/domains/init/init.fixtures.ts
+++ b/src/domains/init/init.fixtures.ts
@@ -1,0 +1,20 @@
+import type { CommandContext } from "~/shell/commandContext.js";
+
+export function makeCtx(confirmValue = true) {
+  const messages: { method: string; text: string }[] = [];
+  const ctx = {
+    ui: {
+      gap: () => {},
+      intro: () => {},
+      step: (m: string) => messages.push({ method: "step", text: m }),
+      info: (m: string) => messages.push({ method: "info", text: m }),
+      warn: (m: string) => messages.push({ method: "warn", text: m }),
+      outro: () => {},
+      confirm: async (_msg: string, opts?: { yes?: boolean }) => {
+        if (opts?.yes) return { ok: true, value: true };
+        return { ok: true, value: confirmValue };
+      },
+    },
+  } as unknown as CommandContext;
+  return { ctx, messages };
+}

--- a/src/domains/init/init.packageJson.test.ts
+++ b/src/domains/init/init.packageJson.test.ts
@@ -46,11 +46,9 @@ describe("handleInit with an existing package.json", () => {
       const { written, messages } = await initWithRaw(raw);
 
       expect(written).toBe(raw);
-      expect(
-        messages.some(
-          (m) => m.method === "warn" && m.text.includes("not a JSON object"),
-        ),
-      ).toBe(true);
+      expect(messages.find((m) => m.method === "warn")?.text).toBe(
+        "`package.json` must contain a JSON object. Update it, then run `qawolf init` again.",
+      );
     },
   );
 
@@ -64,11 +62,9 @@ describe("handleInit with an existing package.json", () => {
     expect(pkg["type"]).toBe("module");
     const deps = pkg["dependencies"] as Record<string, string>;
     expect(deps["@qawolf/flows"]).toBe(flowsVersion);
-    expect(
-      messages.some(
-        (m) => m.method === "warn" && m.text.includes('non-object "scripts"'),
-      ),
-    ).toBe(true);
+    expect(messages.find((m) => m.method === "warn")?.text).toBe(
+      "The `scripts` field in `package.json` must be a JSON object. Update it, then run `qawolf init` again.",
+    );
   });
 
   it("skips only the dependency repair when dependencies is not an object", async () => {

--- a/src/domains/init/init.packageJson.test.ts
+++ b/src/domains/init/init.packageJson.test.ts
@@ -28,7 +28,61 @@ async function initWithPkg(
   };
 }
 
+async function initWithRaw(raw: string) {
+  const memFs = makeMemoryFs();
+  await memFs.mkdir(cwd, { recursive: true });
+  await memFs.writeFile(pkgPath, raw);
+  const { ctx, messages } = makeCtx();
+
+  await handleInit(ctx, { yes: true }, { cwd, fs: memFs });
+
+  return { messages, written: await memFs.readFile(pkgPath) };
+}
+
 describe("handleInit with an existing package.json", () => {
+  it.each([["null"], ['"hello"'], ["[1]"]])(
+    "warns and leaves valid-JSON-but-not-an-object content %s unchanged",
+    async (raw) => {
+      const { written, messages } = await initWithRaw(raw);
+
+      expect(written).toBe(raw);
+      expect(
+        messages.some(
+          (m) => m.method === "warn" && m.text.includes("not a JSON object"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("skips only the script repair when scripts is not an object", async () => {
+    const { pkg, messages } = await initWithPkg({
+      name: "app",
+      scripts: "broken",
+    });
+
+    expect(pkg["scripts"]).toBe("broken");
+    expect(pkg["type"]).toBe("module");
+    const deps = pkg["dependencies"] as Record<string, string>;
+    expect(deps["@qawolf/flows"]).toBe(flowsVersion);
+    expect(
+      messages.some(
+        (m) => m.method === "warn" && m.text.includes('non-object "scripts"'),
+      ),
+    ).toBe(true);
+  });
+
+  it("skips only the dependency repair when dependencies is not an object", async () => {
+    const { pkg } = await initWithPkg({
+      name: "app",
+      dependencies: "broken",
+    });
+
+    expect(pkg["dependencies"]).toBe("broken");
+    expect(pkg["type"]).toBe("module");
+    const scripts = pkg["scripts"] as Record<string, string>;
+    expect(scripts["test:e2e"]).toBe("qawolf flows run");
+  });
+
   it('sets "type": "module" and adds @qawolf/flows when both are missing', async () => {
     // The npm-init default: no "type", no dependencies — the state the
     // scaffolded ESM flow could not load from.

--- a/src/domains/init/init.packageJson.test.ts
+++ b/src/domains/init/init.packageJson.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+
+import { makeMemoryFs } from "~/shell/fs.testUtils.js";
+import { flowsVersion } from "~/generated/dependencyVersions.js";
+import { handleInit } from "./init.js";
+import { makeCtx } from "./init.fixtures.js";
+
+const cwd = "/test/project";
+const pkgPath = join(cwd, "package.json");
+
+async function initWithPkg(
+  pkg: Record<string, unknown>,
+  opts: { yes: boolean } = { yes: true },
+) {
+  const memFs = makeMemoryFs();
+  await memFs.mkdir(cwd, { recursive: true });
+  await memFs.writeFile(pkgPath, JSON.stringify(pkg));
+  const { ctx, messages } = makeCtx();
+
+  await handleInit(ctx, opts, { cwd, fs: memFs });
+
+  const written = await memFs.readFile(pkgPath);
+  return {
+    messages,
+    written,
+    pkg: JSON.parse(written) as Record<string, unknown>,
+  };
+}
+
+describe("handleInit with an existing package.json", () => {
+  it('sets "type": "module" and adds @qawolf/flows when both are missing', async () => {
+    // The npm-init default: no "type", no dependencies — the state the
+    // scaffolded ESM flow could not load from.
+    const { pkg } = await initWithPkg({ name: "app" });
+
+    expect(pkg["type"]).toBe("module");
+    const deps = pkg["dependencies"] as Record<string, string>;
+    expect(deps["@qawolf/flows"]).toBe(flowsVersion);
+    const scripts = pkg["scripts"] as Record<string, string>;
+    expect(scripts["test:e2e"]).toBe("qawolf flows run");
+  });
+
+  it('flips an explicit "type": "commonjs" and warns about the change', async () => {
+    // Current npm writes "type": "commonjs" into every `npm init -y`
+    // package.json, so an explicit value does not signal author intent.
+    const { pkg, messages } = await initWithPkg({
+      name: "app",
+      type: "commonjs",
+    });
+
+    expect(pkg["type"]).toBe("module");
+    expect(
+      messages.some(
+        (m) =>
+          m.method === "warn" &&
+          m.text.includes('Changed "type" from "commonjs"'),
+      ),
+    ).toBe(true);
+    const deps = pkg["dependencies"] as Record<string, string>;
+    expect(deps["@qawolf/flows"]).toBe(flowsVersion);
+    const scripts = pkg["scripts"] as Record<string, string>;
+    expect(scripts["test:e2e"]).toBe("qawolf flows run");
+  });
+
+  it("does not warn about a type change when the field was absent", async () => {
+    const { pkg, messages } = await initWithPkg({ name: "app" });
+
+    expect(pkg["type"]).toBe("module");
+    expect(
+      messages.some(
+        (m) => m.method === "warn" && m.text.includes('Changed "type"'),
+      ),
+    ).toBe(false);
+  });
+
+  it("leaves a fully configured package.json byte-identical", async () => {
+    const configured = {
+      name: "app",
+      type: "module",
+      dependencies: { "@qawolf/flows": "0.0.1" },
+      scripts: { "test:e2e": "qawolf flows run" },
+    };
+    const { written, messages } = await initWithPkg(configured);
+
+    expect(written).toBe(JSON.stringify(configured));
+    expect(
+      messages.some(
+        (m) => m.method === "info" && m.text.includes("already configured"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not add the dependency when @qawolf/flows is in devDependencies", async () => {
+    const { pkg } = await initWithPkg({
+      name: "app",
+      type: "module",
+      devDependencies: { "@qawolf/flows": "0.0.1" },
+    });
+
+    expect(pkg["dependencies"]).toBeUndefined();
+    const devDeps = pkg["devDependencies"] as Record<string, string>;
+    expect(devDeps["@qawolf/flows"]).toBe("0.0.1");
+  });
+
+  it("repairs type and dependency on re-run even when test:e2e already exists", async () => {
+    // The old code returned early on an existing test:e2e script, so a
+    // half-configured project could never be repaired by running init again.
+    const { pkg, messages } = await initWithPkg({
+      name: "app",
+      scripts: { "test:e2e": "custom runner" },
+    });
+
+    expect(pkg["type"]).toBe("module");
+    const deps = pkg["dependencies"] as Record<string, string>;
+    expect(deps["@qawolf/flows"]).toBe(flowsVersion);
+    const scripts = pkg["scripts"] as Record<string, string>;
+    expect(scripts["test:e2e"]).toBe("custom runner");
+    expect(
+      messages.some((m) => m.method === "warn" && m.text.includes("test:e2e")),
+    ).toBe(true);
+  });
+});

--- a/src/domains/init/init.test.ts
+++ b/src/domains/init/init.test.ts
@@ -2,31 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { join } from "node:path";
 
 import { makeMemoryFs } from "~/shell/fs.testUtils.js";
-import type { CommandContext } from "~/shell/commandContext.js";
 import { handleInit } from "./init.js";
 import { flowsVersion } from "~/generated/dependencyVersions.js";
+import { makeCtx } from "./init.fixtures.js";
 import { exampleFlowTs, qawolfConfigTs, qawolfGitignore } from "./templates.js";
 
 const cwd = "/test/project";
-
-function makeCtx(confirmValue = true) {
-  const messages: { method: string; text: string }[] = [];
-  const ctx = {
-    ui: {
-      gap: () => {},
-      intro: () => {},
-      step: (m: string) => messages.push({ method: "step", text: m }),
-      info: (m: string) => messages.push({ method: "info", text: m }),
-      warn: (m: string) => messages.push({ method: "warn", text: m }),
-      outro: () => {},
-      confirm: async (_msg: string, opts?: { yes?: boolean }) => {
-        if (opts?.yes) return { ok: true, value: true };
-        return { ok: true, value: confirmValue };
-      },
-    },
-  } as unknown as CommandContext;
-  return { ctx, messages };
-}
 
 describe("handleInit", () => {
   it("should create all four artifacts in an empty directory", async () => {

--- a/src/domains/init/init.test.ts
+++ b/src/domains/init/init.test.ts
@@ -180,10 +180,8 @@ describe("handleInit", () => {
     await handleInit(ctx, { yes: false }, { cwd, fs: memFs });
 
     expect(await memFs.readFile(join(cwd, "package.json"))).toBe("not json {");
-    expect(
-      messages.some(
-        (m) => m.method === "warn" && m.text.includes("not valid JSON"),
-      ),
-    ).toBe(true);
+    expect(messages.find((m) => m.method === "warn")?.text).toBe(
+      "`package.json` contains invalid JSON. Correct the JSON syntax, then run `qawolf init` again.",
+    );
   });
 });

--- a/src/domains/init/init.ts
+++ b/src/domains/init/init.ts
@@ -2,8 +2,8 @@ import { dirname, join, relative } from "node:path";
 import type { CommandContext, CommandResult } from "~/shell/commandContext.js";
 import { makeDefaultFs } from "~/shell/fs.js";
 import type { Fs } from "~/shell/fs.js";
-import { flowsVersion } from "~/generated/dependencyVersions.js";
 import { initMessages } from "~/core/messages/index.js";
+import { ensurePackageJson } from "./ensurePackageJson.js";
 import { exampleFlowTs, qawolfConfigTs, qawolfGitignore } from "./templates.js";
 
 export type InitOpts = {
@@ -68,67 +68,4 @@ async function writeWithPrompt(
   await deps.fs.mkdir(dirname(filePath), { recursive: true });
   await deps.fs.writeFile(filePath, content);
   ctx.ui.step(initMessages.createdFile(relPath));
-}
-
-async function ensurePackageJson(
-  ctx: CommandContext,
-  yes: boolean,
-  deps: InitDeps,
-): Promise<void> {
-  const pkgPath = join(deps.cwd, "package.json");
-
-  if (!(await deps.fs.pathExists(pkgPath))) {
-    const confirmed = await ctx.ui.confirm(
-      initMessages.createPackageJsonPrompt,
-      { yes },
-    );
-    if (!confirmed.ok || !confirmed.value) {
-      ctx.ui.info(initMessages.skippedCreatingPackageJson);
-      return;
-    }
-    const pkg = {
-      private: true,
-      type: "module",
-      dependencies: { "@qawolf/flows": flowsVersion },
-      scripts: { "test:e2e": "qawolf flows run" },
-    };
-    await deps.fs.writeFile(pkgPath, JSON.stringify(pkg, undefined, 2) + "\n");
-    ctx.ui.step(initMessages.createdPackageJson);
-    return;
-  }
-
-  const raw = await deps.fs.readFile(pkgPath);
-
-  let pkg: Record<string, unknown>;
-  try {
-    pkg = JSON.parse(raw) as Record<string, unknown>;
-  } catch {
-    ctx.ui.warn(initMessages.packageJsonInvalidJson);
-    return;
-  }
-
-  const scripts = (pkg["scripts"] ?? {}) as Record<string, string>;
-  if (scripts["test:e2e"]) {
-    ctx.ui.warn(initMessages.packageJsonHasTestE2e);
-    return;
-  }
-
-  const confirmed = await ctx.ui.confirm(initMessages.addTestE2ePrompt, {
-    yes,
-    destructive: true,
-  });
-  if (!confirmed.ok || !confirmed.value) {
-    ctx.ui.info(initMessages.skippedAddingTestE2e);
-    return;
-  }
-
-  scripts["test:e2e"] = "qawolf flows run";
-  pkg["scripts"] = scripts;
-
-  const trailingNewline = raw.endsWith("\n") ? "\n" : "";
-  await deps.fs.writeFile(
-    pkgPath,
-    JSON.stringify(pkg, undefined, 2) + trailingNewline,
-  );
-  ctx.ui.step(initMessages.updatedPackageJson);
 }


### PR DESCRIPTION
## Problem

`qawolf init` in a project with an existing package.json scaffolds an example flow that cannot load:

```
SyntaxError: Cannot use import statement outside a module
```

The scaffolded flow and config are ES modules. Node reads their module format from the nearest package.json `type` field. The existing-package.json path of init only added the `test:e2e` script. It did not set `"type": "module"`. It did not add the `@qawolf/flows` dependency. Commit `cf24f24` fixed this for the no-package.json case only.

Two findings shaped the fix:

- Current npm writes `"type": "commonjs"` into every `npm init -y` package.json. An explicit value does not show author intent. A policy that only fills an absent field leaves the primary repro broken.
- The old code stopped at the first existing `test:e2e` script. A second run of init could not repair a half-configured project.

## Fix

init now computes three independent repairs: add the `test:e2e` script, set `"type": "module"`, and add the `@qawolf/flows` dependency. One prompt names the needed repairs. `--yes` applies all of them. init keeps an existing script. init keeps a dependency that is already in `devDependencies`. init prints a warning after it changes an explicit `type` value, because that change re-types every `.js` file in the package:

```
Changed "type" from "commonjs" to "module" — .js files in this package now load as ES modules.
```

A fully configured package.json stays byte-identical. `ensurePackageJson` moved to its own module to stay under the file size limit.

## Testing

Six new unit tests cover the repair matrix. A live check used the published 1.6.0 runner under Node. The client repro fails before the fix. The same `flows run` passes after it, with a real browser.

Each permutation below ran against this branch's init. The three monorepo rows also finished with a passing real flow run.

| # | Project shape | Result |
|---|---|---|
| P1 | No package.json | Created with `type: module`, dependency, and script |
| P2 | `npm init -y` (explicit `commonjs`) | Flipped to `module`, warning printed |
| P3 | Hand-written, no `type` field | `module` set, no warning |
| P4 | Already `type: module` | Only dependency and script added |
| P5 | Fully configured | File stays byte-identical |
| P6 | Invalid JSON | Warning printed, file not changed |
| P7 | `@qawolf/flows` in devDependencies | No `dependencies` entry created |
| P8 | npm-workspaces monorepo, init inside `packages/e2e` | Workspace package flipped, root not changed. Flow run: pass |
| P9 | Init at the monorepo root | Root flipped with warning, workspace package not changed. Flow run: pass |
| P10 | Bare subdir of a commonjs monorepo | New `type: module` package.json created in the subdir, root not changed. Flow run: pass |

init edits the same nearest package.json that Node reads. The fix therefore only touches the file that governs the scaffolded flow. Workspace packages stay insulated.

Fixes WIZ-11360
