### PR TITLE
Version Packages (1.7.0)

### DIFF
--- a/.changeset/portable-agent-skill.md
+++ b/.changeset/portable-agent-skill.md
@@ -1,5 +1,0 @@
----
-"@qawolf/cli": patch
----
-
-Document cross-harness Agent Skill installation and declare the CLI runtime requirement in the portable skill metadata.

--- a/.changeset/upgrade-playwright-1-62.md
+++ b/.changeset/upgrade-playwright-1-62.md
@@ -1,5 +1,0 @@
----
-"@qawolf/cli": minor
----
-
-Upgrade Playwright from 1.58.2 to 1.62.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @qawolf/cli
 
+## 1.7.0
+
+### Minor Changes
+
+- cb5d34e: Upgrade Playwright from 1.58.2 to 1.62.0
+
+### Patch Changes
+
+- 1b2234d: Document cross-harness Agent Skill installation and declare the CLI runtime requirement in the portable skill metadata.
+
 ## 1.6.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qawolf/cli",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Run and manage QA Wolf flows from the terminal, CI, or an AI agent",
   "keywords": [
     "automation",


### PR DESCRIPTION
Releases @qawolf/cli 1.7.0 by applying the two pending changesets:

### Minor
- Upgrade Playwright from 1.58.2 to 1.62.0 (cb5d34e)

### Patch
- Document cross-harness Agent Skill installation and declare the CLI runtime requirement in the portable skill metadata (1b2234d)

Generated with `bun run version-packages` (same command the release workflow runs). Merging publishes 1.7.0 via the release workflow.

The published 1.6.0 already ships `@qawolf/api-contracts` 0.20.0; all 16 generated public-API commands were smoke-tested live against the platform before this release PR.