### PR TITLE
docs(cli): fix environment variable guidance

### DIFF
--- a/.changeset/fix-agent-environment-variable.md
+++ b/.changeset/fix-agent-environment-variable.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Correct the agent skill to use `QAWOLF_ENVIRONMENT`, matching the environment variable consumed by CLI flow commands.

--- a/skills/qawolf-cli/SKILL.md
+++ b/skills/qawolf-cli/SKILL.md
@@ -26,8 +26,8 @@ target another deployment host, for example
 `https://app.staging.example.com`. `QAWOLF_API_URL` is a separate API endpoint
 and does not select the deployment host used by CLI commands.
 
-For tasks that need the current environment, use `QAWOLF_ENVIRONMENT_ID`. If it
-is unset, select an id from `qawolf --json environment find` and export it.
+For tasks that need the current environment, use `QAWOLF_ENVIRONMENT`. If it is
+unset, select an id from `qawolf --json environment find` and export it.
 Check the command's help for its environment flag: variable commands use
 `--environment-id`; `qawolf flows run` uses `--env`.
 

--- a/src/commands/qawolfCliSkill.template.md
+++ b/src/commands/qawolfCliSkill.template.md
@@ -26,8 +26,8 @@ target another deployment host, for example
 `https://app.staging.example.com`. `QAWOLF_API_URL` is a separate API endpoint
 and does not select the deployment host used by CLI commands.
 
-For tasks that need the current environment, use `QAWOLF_ENVIRONMENT_ID`. If it
-is unset, select an id from `qawolf --json environment find` and export it.
+For tasks that need the current environment, use `QAWOLF_ENVIRONMENT`. If it is
+unset, select an id from `qawolf --json environment find` and export it.
 Check the command's help for its environment flag: variable commands use
 `--environment-id`; `qawolf flows run` uses `--env`.
 


### PR DESCRIPTION
# Overview of Problem

The bundled agent skill tells agents to export `QAWOLF_ENVIRONMENT_ID`, but CLI flow resolution reads `QAWOLF_ENVIRONMENT` as introduced in #1431. Agents following the published guidance therefore do not provide the default environment consumed by the CLI.

# Overview of Changes

- Update the source skill template to name `QAWOLF_ENVIRONMENT`.
- Regenerate the checked-in `skills/qawolf-cli/SKILL.md` artifact.
- Add a patch changeset for the corrected published guidance.

This aligns the skill with the CLI implementation and with qawolf/platform#30706, which exposes the selected AI-task environment to CLI-enabled Tester shells.

# Testing

- `bun run test src/commands/skill.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run knip`

# Checklist

- [x] Changes follow the code style of this project.
- [x] Self-review completed.
- [x] Generated skill output is updated and covered by the skill synchronization test.
- [x] No breaking changes.
