### PR TITLE
fix(clients): make public API errors name the resource, flag, and server reason

### DIFF
--- a/.changeset/fix-not-found-and-server-error-messages.md
+++ b/.changeset/fix-not-found-and-server-error-messages.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Clearer public API errors. A 404 now names the resource, the id, and the flag you actually passed (e.g. `No issue found with id "…". Check the --issue-id value.`) instead of a hardcoded template that pointed everyone at a non-existent `--env` flag. Server-side 400s and ambiguous 404s now surface the platform's own explanation (e.g. `A tag named "…" already exists for this team.`) instead of a bare `request failed (HTTP 400)`.

--- a/src/commands/publicApi/index.test.ts
+++ b/src/commands/publicApi/index.test.ts
@@ -83,12 +83,22 @@ describe("registerPublicApiCommands", () => {
       { from: "user" },
     );
 
-    expect(callPublicApi).toHaveBeenCalledWith(publicContractsV1.run.create, {
-      environmentId,
-      flowIds: [flowId],
-      ignoreRules: false,
-      tagNames: [],
-    });
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.run.create,
+      {
+        environmentId,
+        flowIds: [flowId],
+        ignoreRules: false,
+        tagNames: [],
+      },
+      {
+        notFound: {
+          resource: "environment",
+          idFlag: "--environment-id",
+          idValue: environmentId,
+        },
+      },
+    );
   });
 
   it("emits the structured response as a JSON line on stdout in agent mode", async () => {

--- a/src/core/messages/auth.ts
+++ b/src/core/messages/auth.ts
@@ -45,11 +45,32 @@ export const authMessages = {
       rejected401: (noun: string | undefined) =>
         `QA Wolf API rejected the${noun ? ` ${noun}` : ""} request (HTTP 401). Check your API key.`,
       rejected403: (noun: string | undefined) =>
-        `QA Wolf API rejected the${noun ? ` ${noun}` : ""} request (HTTP 403). Check that your API key has access to this environment.`,
-      notFound404: (noun: string | undefined) =>
-        `QA Wolf API could not find ${noun ? `${noun} for that environment` : "that environment"} (HTTP 404). Check the --env value.`,
-      failedWithStatus: (status: number, noun: string | undefined) =>
-        `QA Wolf API${noun ? ` ${noun}` : ""} request failed (HTTP ${status}).`,
+        `QA Wolf API rejected the${noun ? ` ${noun}` : ""} request (HTTP 403). Check that your API key has access to it.`,
+      // A 404 where the command identified one resource by id: name the
+      // resource, the id, and the flag the user actually passed.
+      notFoundResource: (input: {
+        resource: string;
+        idFlag: string;
+        idValue: string;
+      }) =>
+        `No ${input.resource} found with id "${input.idValue}" (HTTP 404). Check the ${input.idFlag} value.`,
+      // A 404 whose missing resource is ambiguous, but the server explained it.
+      notFoundWithMessage: (serverMessage: string) =>
+        `QA Wolf API returned not found (HTTP 404): ${serverMessage}`,
+      // A 404 on a command that resolves its environment via the --env flag.
+      notFoundEnvironment: () =>
+        `QA Wolf API could not find that environment (HTTP 404). Check the --env value.`,
+      // A 404 with no resource context and no server explanation.
+      notFound404: () =>
+        `QA Wolf API could not find the requested resource (HTTP 404).`,
+      failedWithStatus: (input: {
+        status: number;
+        noun: string | undefined;
+        serverMessage: string | undefined;
+      }) =>
+        input.serverMessage
+          ? `QA Wolf API${input.noun ? ` ${input.noun}` : ""} request failed (HTTP ${input.status}): ${input.serverMessage}`
+          : `QA Wolf API${input.noun ? ` ${input.noun}` : ""} request failed (HTTP ${input.status}).`,
       networkUnreachable: (baseUrl: string, noun: string | undefined) =>
         `Could not reach the QA Wolf API at ${baseUrl}${noun ? ` to fetch ${noun}` : ""}. Check your network connection and QAWOLF_HOST_URL.`,
       timedOut: (timeoutMs: number, noun: string | undefined) =>

--- a/src/core/publicApi/notFoundHint.test.ts
+++ b/src/core/publicApi/notFoundHint.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FlagSpec } from "./flagSpecs.js";
+import { buildNotFoundHint } from "./notFoundHint.js";
+
+const flag = (overrides: Partial<FlagSpec> & { field: string }): FlagSpec => ({
+  flag: `--${overrides.field} <value>`,
+  description: "",
+  required: true,
+  kind: "string",
+  ...overrides,
+});
+
+describe("buildNotFoundHint", () => {
+  it("names the resource, flag, and value for a single required id flag", () => {
+    const flags = [flag({ field: "issueId", flag: "--issue-id <value>" })];
+
+    expect(buildNotFoundHint(flags, { issueId: "abc123" })).toEqual({
+      resource: "issue",
+      idFlag: "--issue-id",
+      idValue: "abc123",
+    });
+  });
+
+  it("identifies the id resource even alongside other required flags", () => {
+    const flags = [
+      flag({ field: "environmentId", flag: "--environment-id <value>" }),
+      flag({ field: "name", flag: "--name <value>" }),
+      flag({ field: "value", flag: "--value <value>" }),
+    ];
+
+    expect(
+      buildNotFoundHint(flags, {
+        environmentId: "env-1",
+        name: "KEY",
+        value: "v",
+      }),
+    ).toEqual({
+      resource: "environment",
+      idFlag: "--environment-id",
+      idValue: "env-1",
+    });
+  });
+
+  it("returns undefined when no required flag looks like an id", () => {
+    const flags = [
+      flag({
+        field: "flowIds",
+        flag: "--flow-ids <values...>",
+        kind: "string-array",
+      }),
+      flag({ field: "tagName", flag: "--tag-name <value>" }),
+    ];
+
+    expect(
+      buildNotFoundHint(flags, { flowIds: ["f1"], tagName: "t" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when several required id flags are ambiguous", () => {
+    const flags = [
+      flag({ field: "issueId", flag: "--issue-id <value>" }),
+      flag({ field: "runId", flag: "--run-id <value>" }),
+    ];
+
+    expect(
+      buildNotFoundHint(flags, { issueId: "i", runId: "r" }),
+    ).toBeUndefined();
+  });
+
+  it("ignores optional id flags", () => {
+    const flags = [
+      flag({ field: "workspaceId", required: false }),
+      flag({ field: "cursor", required: false }),
+    ];
+
+    expect(buildNotFoundHint(flags, { workspaceId: "w" })).toBeUndefined();
+  });
+
+  it("returns undefined when the id value is missing or not a string", () => {
+    const flags = [flag({ field: "issueId", flag: "--issue-id <value>" })];
+
+    expect(buildNotFoundHint(flags, {})).toBeUndefined();
+    expect(buildNotFoundHint(flags, { issueId: "" })).toBeUndefined();
+    expect(buildNotFoundHint(flags, { issueId: 42 })).toBeUndefined();
+  });
+});

--- a/src/core/publicApi/notFoundHint.ts
+++ b/src/core/publicApi/notFoundHint.ts
@@ -1,0 +1,40 @@
+import type { FlagSpec } from "./flagSpecs.js";
+
+// Enough context for a 404 to name the resource the user looked up, the id
+// they passed, and the flag that carried it — e.g. `--issue-id`.
+export type NotFoundHint = {
+  // Human resource label, e.g. "issue".
+  resource: string;
+  // The flag the user passed to identify it, e.g. "--issue-id".
+  idFlag: string;
+  // The id value the user passed.
+  idValue: string;
+};
+
+const flagName = (flag: FlagSpec): string =>
+  flag.flag.split(" ", 1)[0] ?? flag.flag;
+
+// When a command identifies exactly one resource by a required `*Id` flag, a
+// 404 can name that resource, its flag, and the value the user passed.
+// Endpoints that take several ids (or none) get no hint — the missing one is
+// ambiguous, so callers fall back to the server's message or a neutral
+// not-found.
+export function buildNotFoundHint(
+  flags: FlagSpec[],
+  options: Record<string, unknown>,
+): NotFoundHint | undefined {
+  const idFlags = flags.filter(
+    (flag) => flag.required && flag.field.endsWith("Id"),
+  );
+  const only = idFlags.length === 1 ? idFlags[0] : undefined;
+  if (!only) return undefined;
+
+  const value = options[only.field];
+  if (typeof value !== "string" || !value) return undefined;
+
+  return {
+    resource: only.field.replace(/Id$/, ""),
+    idFlag: flagName(only),
+    idValue: value,
+  };
+}

--- a/src/domains/flows/pull/wireErrors.ts
+++ b/src/domains/flows/pull/wireErrors.ts
@@ -10,12 +10,15 @@ export function describeBundleRequestError(
   err: WireError,
   baseUrl: string,
 ): string {
-  return describeRequestError(err, baseUrl);
+  return describeRequestError(err, baseUrl, { environmentLookup: true });
 }
 
 export function describeEnvVarsRequestError(
   err: WireError,
   baseUrl: string,
 ): string {
-  return describeRequestError(err, baseUrl, "env-vars");
+  return describeRequestError(err, baseUrl, {
+    noun: "env-vars",
+    environmentLookup: true,
+  });
 }

--- a/src/domains/publicApi/handle.test.ts
+++ b/src/domains/publicApi/handle.test.ts
@@ -71,13 +71,23 @@ describe("handlePublicApiCommand", () => {
     });
 
     expect(result).toBeUndefined();
-    expect(callPublicApi).toHaveBeenCalledWith(publicContractsV1.run.create, {
-      environmentId,
-      environmentVariables: { BAZ: "qux=quux", FOO: "bar" },
-      flowIds: [flowId],
-      ignoreRules: false,
-      tagNames: [],
-    });
+    expect(callPublicApi).toHaveBeenCalledWith(
+      publicContractsV1.run.create,
+      {
+        environmentId,
+        environmentVariables: { BAZ: "qux=quux", FOO: "bar" },
+        flowIds: [flowId],
+        ignoreRules: false,
+        tagNames: [],
+      },
+      {
+        notFound: {
+          resource: "environment",
+          idFlag: "--environment-id",
+          idValue: environmentId,
+        },
+      },
+    );
     expect(ui.output).toHaveBeenCalledTimes(1);
     const [data, humanMessage] = (ui.output as ReturnType<typeof mock>).mock
       .calls[0] as [unknown, string];
@@ -138,7 +148,11 @@ describe("handlePublicApiCommand", () => {
     const result = await handlePublicApiCommand(ctx, spec, { count: "5" });
 
     expect(result).toBeUndefined();
-    expect(callPublicApi).toHaveBeenCalledWith(spec.contract, { count: 5 });
+    expect(callPublicApi).toHaveBeenCalledWith(
+      spec.contract,
+      { count: 5 },
+      { notFound: undefined },
+    );
   });
 
   it("passes an empty number flag value through as 0 (Number('') coercion)", async () => {
@@ -155,7 +169,11 @@ describe("handlePublicApiCommand", () => {
     const result = await handlePublicApiCommand(ctx, spec, { count: "" });
 
     expect(result).toBeUndefined();
-    expect(callPublicApi).toHaveBeenCalledWith(spec.contract, { count: 0 });
+    expect(callPublicApi).toHaveBeenCalledWith(
+      spec.contract,
+      { count: 0 },
+      { notFound: undefined },
+    );
   });
 
   it("rejects a non-numeric number flag value before calling the platform", async () => {

--- a/src/domains/publicApi/handle.ts
+++ b/src/domains/publicApi/handle.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { FlagSpec } from "~/core/publicApi/flagSpecs.js";
+import { buildNotFoundHint } from "~/core/publicApi/notFoundHint.js";
 import type {
   AuthCommandContext,
   CommandResult,
@@ -97,6 +98,7 @@ export async function handlePublicApiCommand(
   const result = await ctx.platformClient.callPublicApi(
     spec.contract,
     parsed.data,
+    { notFound: buildNotFoundHint(spec.flags, options) },
   );
   if (!result.ok) return { error: result.error };
 

--- a/src/shell/platform/callPublicApi.ts
+++ b/src/shell/platform/callPublicApi.ts
@@ -1,6 +1,8 @@
 import { type PublicApiContractKind } from "@qawolf/api-contracts/v1";
 import type { z } from "zod";
 
+import type { NotFoundHint } from "~/core/publicApi/notFoundHint.js";
+
 import { describeRequestError } from "./describeErrors.js";
 import type {
   RequestOptions,
@@ -37,10 +39,16 @@ export function callPublicApi<Input, Output>(
   return trpc.mutation(path, input, contract.output, options);
 }
 
+// Per-call options: the wire-level RequestOptions plus a presentation-only
+// not-found hint the command layer supplies (it knows the CLI flag names).
+export type CallPublicApiOptions = RequestOptions & {
+  notFound?: NotFoundHint | undefined;
+};
+
 export type CallPublicApiMethod = <Input, Output>(
   contract: PublicApiContractOf<Input, Output>,
   input: Input,
-  options?: RequestOptions,
+  options?: CallPublicApiOptions,
 ) => Promise<PlatformResult<Output>>;
 
 type MethodDeps = {
@@ -60,7 +68,11 @@ export function makeCallPublicApiMethod(
     requestWithRetry({
       call: () => callPublicApi(trpc, contract, input, options),
       backoffMs: contract.kind === "read" ? readBackoffMs : [],
-      describe: (err) => describeRequestError(err, deps.baseUrl, contract.name),
+      describe: (err) =>
+        describeRequestError(err, deps.baseUrl, {
+          noun: contract.name,
+          notFound: options?.notFound,
+        }),
       sleep: deps.sleep,
     });
 }

--- a/src/shell/platform/createPlatformClient.test.ts
+++ b/src/shell/platform/createPlatformClient.test.ts
@@ -236,7 +236,7 @@ describe("getEnvVars", () => {
     expect(parsed.json).toEqual({ id: envId });
   });
 
-  it("returns ok:false with env-vars named message on HTTP 404", async () => {
+  it("points at the --env value when the environment is not found (HTTP 404)", async () => {
     const result = await createPlatformClient(apiKey, {
       fetch: mockFetch(new Response("not found", { status: 404 })),
       baseUrl,
@@ -244,6 +244,6 @@ describe("getEnvVars", () => {
     }).getEnvVars(envId);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toMatch(/env-vars/i);
+    if (!result.ok) expect(result.error).toContain("--env");
   });
 });

--- a/src/shell/platform/createPlatformClient.testUtils.ts
+++ b/src/shell/platform/createPlatformClient.testUtils.ts
@@ -1,14 +1,14 @@
 import { mock, type Mock } from "bun:test";
 import type { AnyPublicApiContract } from "@qawolf/api-contracts/v1";
 
+import type { CallPublicApiOptions } from "./callPublicApi.js";
 import type { PlatformClient } from "./createPlatformClient.js";
-import type { RequestOptions } from "./createTrpcClient.js";
 import type { PlatformResult } from "./requestWithRetry.js";
 
 type CallPublicApiFn = (
   contract: AnyPublicApiContract,
   input: unknown,
-  options?: RequestOptions,
+  options?: CallPublicApiOptions,
 ) => Promise<PlatformResult<unknown>>;
 
 // callPublicApi is a generic method, which bun's mock() cannot express;

--- a/src/shell/platform/createPlatformClient.ts
+++ b/src/shell/platform/createPlatformClient.ts
@@ -71,7 +71,8 @@ export function createPlatformClient(
           flowsBundleResponseSchema,
         ),
       backoffMs: requestBackoffMs,
-      describe: (err) => describeRequestError(err, deps.baseUrl),
+      describe: (err) =>
+        describeRequestError(err, deps.baseUrl, { environmentLookup: true }),
       sleep: deps.sleep,
     });
     if (!result.ok) return result;
@@ -101,7 +102,11 @@ export function createPlatformClient(
             environmentWithVariablesResponseSchema,
           ),
         backoffMs: requestBackoffMs,
-        describe: (err) => describeRequestError(err, deps.baseUrl, "env-vars"),
+        describe: (err) =>
+          describeRequestError(err, deps.baseUrl, {
+            noun: "env-vars",
+            environmentLookup: true,
+          }),
         sleep: deps.sleep,
       });
       if (!result.ok) return result;

--- a/src/shell/platform/describeErrors.test.ts
+++ b/src/shell/platform/describeErrors.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import superjson from "superjson";
+
+import type { WireError } from "./createTrpcClient.js";
+import {
+  describeRequestError,
+  extractServerMessage,
+} from "./describeErrors.js";
+
+const baseUrl = "https://test.qawolf.com";
+
+// The wire shape the platform returns for a tRPC error: superjson-serialized
+// error shape under `error`, with the human message on both the shape and its
+// data.
+function errorBody(message: string, code = "BAD_REQUEST"): string {
+  return JSON.stringify({
+    error: superjson.serialize({
+      message,
+      code: -32600,
+      data: { code, httpStatus: 400, message, path: "public.tag.create" },
+    }),
+  });
+}
+
+const http = (status: number, body = ""): WireError => ({
+  kind: "http",
+  status,
+  body,
+});
+
+describe("extractServerMessage", () => {
+  it("pulls the human message out of a tRPC/superjson error body", () => {
+    const message =
+      'A tag named "brian-cli-probe" already exists for this team.';
+    expect(extractServerMessage(errorBody(message))).toBe(message);
+  });
+
+  it("returns undefined for a bare enum-style code", () => {
+    expect(extractServerMessage(errorBody("NOT_FOUND"))).toBeUndefined();
+  });
+
+  it("returns undefined for an empty or non-JSON body", () => {
+    expect(extractServerMessage("")).toBeUndefined();
+    expect(extractServerMessage("not found")).toBeUndefined();
+  });
+});
+
+describe("describeRequestError 404", () => {
+  it("names the resource, id, and flag when a lookup hint is given", () => {
+    const message = describeRequestError(http(404), baseUrl, {
+      noun: "issue.get",
+      notFound: {
+        resource: "issue",
+        idFlag: "--issue-id",
+        idValue: "0000-0000",
+      },
+    });
+
+    expect(message).toBe(
+      'No issue found with id "0000-0000" (HTTP 404). Check the --issue-id value.',
+    );
+    expect(message).not.toContain("environment");
+    expect(message).not.toContain("--env");
+  });
+
+  it("surfaces the server message when the missing resource is ambiguous", () => {
+    const message = describeRequestError(
+      http(404, errorBody("Flow flow-1 was not found.", "NOT_FOUND")),
+      baseUrl,
+      { noun: "flow.addTag" },
+    );
+
+    expect(message).toContain("Flow flow-1 was not found.");
+    expect(message).not.toContain("--env");
+  });
+
+  it("keeps the --env hint for commands that resolve an environment", () => {
+    const message = describeRequestError(http(404), baseUrl, {
+      noun: "env-vars",
+      environmentLookup: true,
+    });
+
+    expect(message).toContain("environment");
+    expect(message).toContain("--env");
+  });
+
+  it("falls back to a neutral not-found with no context", () => {
+    const message = describeRequestError(http(404), baseUrl, {
+      noun: "flow.addTag",
+    });
+
+    expect(message).toBe(
+      "QA Wolf API could not find the requested resource (HTTP 404).",
+    );
+    expect(message).not.toContain("--env");
+  });
+});
+
+describe("describeRequestError other statuses", () => {
+  it("surfaces the server message on a 400", () => {
+    const detail =
+      'A tag named "brian-cli-probe" already exists for this team.';
+    const message = describeRequestError(
+      http(400, errorBody(detail)),
+      baseUrl,
+      {
+        noun: "tag.create",
+      },
+    );
+
+    expect(message).toContain(detail);
+    expect(message).toContain("400");
+  });
+
+  it("stays generic on a 400 with no server message", () => {
+    const message = describeRequestError(http(400), baseUrl, {
+      noun: "tag.create",
+    });
+
+    expect(message).toBe("QA Wolf API tag.create request failed (HTTP 400).");
+  });
+
+  it("does not surface 5xx bodies, which may carry internal detail", () => {
+    const message = describeRequestError(
+      http(500, errorBody("connection to db-primary refused", "INTERNAL")),
+      baseUrl,
+      { noun: "run.create" },
+    );
+
+    expect(message).not.toContain("db-primary");
+    expect(message).toContain("500");
+  });
+
+  it("keeps auth guidance free of environment wording on 403", () => {
+    const message = describeRequestError(http(403), baseUrl, {
+      noun: "issue.get",
+    });
+
+    expect(message).toContain("API key");
+    expect(message).not.toContain("environment");
+  });
+});

--- a/src/shell/platform/describeErrors.ts
+++ b/src/shell/platform/describeErrors.ts
@@ -1,8 +1,56 @@
 import { formatSeconds } from "~/core/formatSeconds.js";
 import { authMessages } from "~/core/messages/index.js";
+import type { NotFoundHint } from "~/core/publicApi/notFoundHint.js";
 import type { WireError } from "./createTrpcClient.js";
 
 const m = authMessages.errors;
+
+export type RequestErrorContext = {
+  // Operation label for generic request-failure messages, e.g. "issue.get"
+  // or "env-vars".
+  noun?: string | undefined;
+  // When the command looked up a single resource by id, lets a 404 name the
+  // resource, the id, and the flag the user passed.
+  notFound?: NotFoundHint | undefined;
+  // Commands that resolve their target environment via the --env flag; a 404
+  // means that environment wasn't found.
+  environmentLookup?: boolean | undefined;
+};
+
+function dig(value: unknown, path: string[]): unknown {
+  return path.reduce<unknown>(
+    (node, key) =>
+      node && typeof node === "object"
+        ? (node as Record<string, unknown>)[key]
+        : undefined,
+    value,
+  );
+}
+
+// Pulls the platform's human-readable message out of a tRPC/superjson error
+// body: `{ error: { json: { message, data: { message } } } }`. Returns
+// undefined when the body has none, or carries only a bare error code.
+export function extractServerMessage(body: string): string | undefined {
+  if (!body) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  const message = [
+    dig(parsed, ["error", "json", "message"]),
+    dig(parsed, ["error", "json", "data", "message"]),
+    dig(parsed, ["error", "message"]),
+    dig(parsed, ["message"]),
+  ].find(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  if (message === undefined) return undefined;
+  // Bare enum-style codes (NOT_FOUND, BAD_REQUEST) read as noise, not help.
+  if (/^[A-Z][A-Z0-9_]+$/.test(message)) return undefined;
+  return message;
+}
 
 export function describeIdentityError(err: WireError): string {
   if (err.kind === "http") {
@@ -39,13 +87,28 @@ function parseErrorBody(body: string): string {
 export function describeRequestError(
   err: WireError,
   baseUrl: string,
-  noun?: string,
+  context: RequestErrorContext = {},
 ): string {
+  const { noun, notFound, environmentLookup } = context;
   if (err.kind === "http") {
+    // The platform sends a human-ready message in the error body for client
+    // errors; surface it rather than a bare status. 5xx bodies may carry
+    // internal detail, so they stay generic.
+    const serverMessage =
+      err.status < 500 ? extractServerMessage(err.body) : undefined;
     if (err.status === 401) return m.request.rejected401(noun);
     if (err.status === 403) return m.request.rejected403(noun);
-    if (err.status === 404) return m.request.notFound404(noun);
-    return m.request.failedWithStatus(err.status, noun);
+    if (err.status === 404) {
+      if (notFound) return m.request.notFoundResource(notFound);
+      if (serverMessage) return m.request.notFoundWithMessage(serverMessage);
+      if (environmentLookup) return m.request.notFoundEnvironment();
+      return m.request.notFound404();
+    }
+    return m.request.failedWithStatus({
+      status: err.status,
+      noun,
+      serverMessage,
+    });
   }
   if (err.kind === "network") {
     return m.request.networkUnreachable(baseUrl, noun);

--- a/src/shell/platform/teamStorage.ts
+++ b/src/shell/platform/teamStorage.ts
@@ -35,7 +35,9 @@ export async function listTeamStorageFiles(
         ),
       backoffMs: requestBackoffMs,
       describe: (err) =>
-        describeRequestError(err, deps.baseUrl, "team-storage assets"),
+        describeRequestError(err, deps.baseUrl, {
+          noun: "team-storage assets",
+        }),
       sleep: deps.sleep,
     });
     if (!result.ok) return result;


### PR DESCRIPTION
Relates to WIZ-11396

# Overview of Changes

Public-API error output was misleading. Every 404 shared one hardcoded helper that read `… for that environment (HTTP 404). Check the --env value.` — but these commands have no `--env` flag (that belongs to the local `flows` family; the real flags are `--environment-id`, `--issue-id`, …), and the "environment" wording is nonsense for a bad `issue.get` id. Separately, server-side 400s (and ambiguous 404s) collapsed into a bare `request failed (HTTP 400)`, throwing away the human-ready explanation the platform already sends in the error body (e.g. `A tag named "…" already exists for this team.`).

Now a 404 on a single-id lookup names the resource, the id, and the flag the user passed (`No issue found with id "…" (HTTP 404). Check the --issue-id value.`), client-error bodies (4xx) are surfaced instead of discarded, and the `--env` guidance is kept only for the flows-local family that actually uses that flag. All error text is CLI-side presentation — no public API contract changes.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
```

New unit tests cover `buildNotFoundHint` (single/ambiguous/absent id flags) and `describeRequestError` (hint 404, server-message 404, `--env` 404, neutral 404, 400 with/without server message, 5xx bodies stay generic, 403 free of environment wording).

# Checklist

- [x] Changes follow the code style of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)