### PR TITLE
feat(run-create): default AI task ID from environment

### DIFF
--- a/.changeset/track-ai-created-runs.md
+++ b/.changeset/track-ai-created-runs.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Default the generated `run create` AI task option from `QAWOLF_AI_TASK_ID`.

--- a/src/commands/publicApi/index.aiTask.test.ts
+++ b/src/commands/publicApi/index.aiTask.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, expect, it } from "bun:test";
+import { Command } from "commander";
+import { z } from "zod";
+
+import {
+  makeCallPublicApiMock,
+  makeMockPlatformClient,
+} from "~/shell/platform/createPlatformClient.testUtils.js";
+import { createSignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { registerPublicApiCommands } from "./index.js";
+
+const contract = {
+  description: "Create a run.",
+  input: z.object({
+    aiTaskId: z.string().optional(),
+    environmentId: z.string(),
+  }),
+  kind: "write",
+  name: "run.create",
+  output: z.object({ runId: z.string() }),
+} as const;
+
+afterEach(() => {
+  delete process.env["QAWOLF_AI_TASK_ID"];
+});
+
+async function runCreate({ aiTaskId }: { aiTaskId?: string } = {}) {
+  const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: { runId: "run-id" },
+  });
+  const program = new Command().name("qawolf").exitOverride();
+  registerPublicApiCommands(program, createSignalRegistry(), {
+    authDeps: {
+      requireApiKey: async () => ({ key: "qawolf_key", source: "env" }),
+      createPlatform: () => makeMockPlatformClient({ callPublicApi }),
+    },
+    contracts: { run: { create: contract } },
+  });
+  const args = ["run", "create", "--environment-id", "environment-id"];
+  if (aiTaskId) args.push("--ai-task-id", aiTaskId);
+  await program.parseAsync(args, { from: "user" });
+  return callPublicApi;
+}
+
+it("defaults the generated run.create AI task option from the environment", async () => {
+  process.env["QAWOLF_AI_TASK_ID"] = "task-from-env";
+
+  const callPublicApi = await runCreate();
+
+  expect(callPublicApi).toHaveBeenCalledWith(contract, {
+    aiTaskId: "task-from-env",
+    environmentId: "environment-id",
+  });
+});
+
+it("prefers an explicit AI task option over the environment", async () => {
+  process.env["QAWOLF_AI_TASK_ID"] = "task-from-env";
+
+  const callPublicApi = await runCreate({ aiTaskId: "task-from-flag" });
+
+  expect(callPublicApi).toHaveBeenCalledWith(contract, {
+    aiTaskId: "task-from-flag",
+    environmentId: "environment-id",
+  });
+});

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
 import { withAuthContext } from "~/commands/context.js";
@@ -37,6 +37,8 @@ const skippedContractNames: ReadonlySet<string> = new Set([
   ...handWrittenContractNames,
   "issue.update",
 ]);
+
+const runCreateTrpcPath = "public.run.create";
 
 function resolveGroup(parent: Command, segment: string): Command {
   const existing = parent.commands.find(
@@ -78,13 +80,17 @@ function registerSpec(
     spec.kind,
   ).description(spec.description);
   for (const flag of spec.flags) {
-    if (flag.required) {
+    if (spec.trpcPath === runCreateTrpcPath && flag.field === "aiTaskId") {
+      const option = new Option(flag.flag, flag.description).env(
+        "QAWOLF_AI_TASK_ID",
+      );
+      command.addOption(flag.required ? option.makeOptionMandatory() : option);
+    } else if (flag.required) {
       command.requiredOption(flag.flag, flag.description);
     } else {
       command.option(flag.flag, flag.description);
     }
   }
-
   command.action((options: Record<string, unknown>, leaf: Command) =>
     withAuthContext(
       signals,


### PR DESCRIPTION
# Overview of Changes

Teach the generated `qawolf run create` command to source its contract-defined `aiTaskId` option from `QAWOLF_AI_TASK_ID`. An explicit `--ai-task-id` value takes precedence over the environment, using Commander option precedence.

The value remains ordinary `run.create` input. The CLI performs exactly one public API write and does not make a follow-up internal mutation or retry run creation. Platform PR qawolf/platform#30807 owns authorization, Suite creation, and the conversation association using the server-created Suite ID.

The implementation is contract-driven: it only adds the environment default when the published `run.create` schema contains `aiTaskId`. Tests inject the pending schema to verify the environment default and explicit-option precedence without vendoring an unpublished contract.

# Release Order and Current Blocker

1. Merge qawolf/platform#30807.
2. Publish its updated `@qawolf/api-contracts` package.
3. Bump this PR from `@qawolf/api-contracts@0.20.0` to that published version and run the full validation suite again.
4. Merge and release this CLI patch.
5. Rebuild the AI task runner image with the released CLI.

This PR is intentionally still draft and does not bump the dependency yet because the required package version is not published. Platform PR #30707 also proposes package version 0.22.0, so the final version may need to advance after the platform branches are reconciled.

# Testing

- `bun test src/commands/publicApi/index.test.ts src/commands/publicApi/index.aiTask.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run build`

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
- [ ] Bump to the published contracts package and re-run full validation
