### PR TITLE
fix(cli): apply environment-backed API options

### DIFF
--- a/.changeset/forward-ai-task-id.md
+++ b/.changeset/forward-ai-task-id.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Pass `QAWOLF_AI_TASK_ID` to the public `run create` API input when the generated `--ai-task-id` option is available. An explicit `--ai-task-id` value takes precedence over the environment.

--- a/.changeset/forward-ai-task-id.md
+++ b/.changeset/forward-ai-task-id.md
@@ -2,4 +2,4 @@
 "@qawolf/cli": patch
 ---
 
-Pass `QAWOLF_AI_TASK_ID` to the public `run create` API input when the generated `--ai-task-id` option is available. An explicit `--ai-task-id` value takes precedence over the environment.
+Use `QAWOLF_ENVIRONMENT` as the default for generated public API `--environment-id` options. Pass `QAWOLF_AI_TASK_ID` to the public `run create` API input when the generated `--ai-task-id` option is available. Explicit flags take precedence over the environment.

--- a/src/commands/publicApi/index.environment.test.ts
+++ b/src/commands/publicApi/index.environment.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, expect, it } from "bun:test";
+import { Command } from "commander";
+import { z } from "zod";
+
+import {
+  makeCallPublicApiMock,
+  makeMockPlatformClient,
+} from "~/shell/platform/createPlatformClient.testUtils.js";
+import { createSignalRegistry } from "~/shell/signals/createSignalRegistry.js";
+
+import { registerPublicApiCommands } from "./index.js";
+
+const originalAiTaskId = process.env["QAWOLF_AI_TASK_ID"];
+
+afterEach(() => {
+  process.exitCode = undefined;
+  if (originalAiTaskId === undefined) {
+    delete process.env["QAWOLF_AI_TASK_ID"];
+  } else {
+    process.env["QAWOLF_AI_TASK_ID"] = originalAiTaskId;
+  }
+});
+
+it("defaults the run create AI task id from the environment", async () => {
+  const contract = {
+    description: "Create a run.",
+    input: z.object({
+      aiTaskId: z.string().optional(),
+      environmentId: z.string(),
+    }),
+    kind: "write",
+    name: "run.create",
+    output: z.object({ runId: z.string() }),
+  } as const;
+  const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+    ok: true,
+    value: { runId: "run-id" },
+  });
+  const register = () => {
+    const program = new Command().name("qawolf").exitOverride();
+    registerPublicApiCommands(program, createSignalRegistry(), {
+      authDeps: {
+        requireApiKey: async () => ({ key: "qawolf_key", source: "env" }),
+        createPlatform: () => makeMockPlatformClient({ callPublicApi }),
+      },
+      contracts: { run: { create: contract } },
+    });
+    return program;
+  };
+  process.env["QAWOLF_AI_TASK_ID"] = "environment-task-id";
+
+  await register().parseAsync(
+    ["run", "create", "--environment-id", "environment-id"],
+    { from: "user" },
+  );
+  await register().parseAsync(
+    [
+      "run",
+      "create",
+      "--ai-task-id",
+      "flag-task-id",
+      "--environment-id",
+      "environment-id",
+    ],
+    { from: "user" },
+  );
+
+  expect(callPublicApi).toHaveBeenNthCalledWith(1, contract, {
+    aiTaskId: "environment-task-id",
+    environmentId: "environment-id",
+  });
+  expect(callPublicApi).toHaveBeenNthCalledWith(2, contract, {
+    aiTaskId: "flag-task-id",
+    environmentId: "environment-id",
+  });
+});

--- a/src/commands/publicApi/index.environment.test.ts
+++ b/src/commands/publicApi/index.environment.test.ts
@@ -11,6 +11,7 @@ import { createSignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { registerPublicApiCommands } from "./index.js";
 
 const originalAiTaskId = process.env["QAWOLF_AI_TASK_ID"];
+const originalEnvironment = process.env["QAWOLF_ENVIRONMENT"];
 
 afterEach(() => {
   process.exitCode = undefined;
@@ -19,9 +20,14 @@ afterEach(() => {
   } else {
     process.env["QAWOLF_AI_TASK_ID"] = originalAiTaskId;
   }
+  if (originalEnvironment === undefined) {
+    delete process.env["QAWOLF_ENVIRONMENT"];
+  } else {
+    process.env["QAWOLF_ENVIRONMENT"] = originalEnvironment;
+  }
 });
 
-it("defaults the run create AI task id from the environment", async () => {
+it("defaults public API options from their environment variables", async () => {
   const contract = {
     description: "Create a run.",
     input: z.object({
@@ -48,11 +54,9 @@ it("defaults the run create AI task id from the environment", async () => {
     return program;
   };
   process.env["QAWOLF_AI_TASK_ID"] = "environment-task-id";
+  process.env["QAWOLF_ENVIRONMENT"] = "environment-environment-id";
 
-  await register().parseAsync(
-    ["run", "create", "--environment-id", "environment-id"],
-    { from: "user" },
-  );
+  await register().parseAsync(["run", "create"], { from: "user" });
   await register().parseAsync(
     [
       "run",
@@ -60,17 +64,17 @@ it("defaults the run create AI task id from the environment", async () => {
       "--ai-task-id",
       "flag-task-id",
       "--environment-id",
-      "environment-id",
+      "flag-environment-id",
     ],
     { from: "user" },
   );
 
   expect(callPublicApi).toHaveBeenNthCalledWith(1, contract, {
     aiTaskId: "environment-task-id",
-    environmentId: "environment-id",
+    environmentId: "environment-environment-id",
   });
   expect(callPublicApi).toHaveBeenNthCalledWith(2, contract, {
     aiTaskId: "flag-task-id",
-    environmentId: "environment-id",
+    environmentId: "flag-environment-id",
   });
 });

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -39,8 +39,19 @@ const skippedContractNames: ReadonlySet<string> = new Set([
 ]);
 
 const optionEnvironmentVariables = new Map([
+  ["environmentId", "QAWOLF_ENVIRONMENT"],
   ["public.run.create.aiTaskId", "QAWOLF_AI_TASK_ID"],
 ]);
+
+function optionEnvironmentVariable(
+  spec: CommandSpec,
+  field: string,
+): string | undefined {
+  return (
+    optionEnvironmentVariables.get(`${spec.trpcPath}.${field}`) ??
+    optionEnvironmentVariables.get(field)
+  );
+}
 
 function resolveGroup(parent: Command, segment: string): Command {
   const existing = parent.commands.find(
@@ -82,9 +93,7 @@ function registerSpec(
     spec.kind,
   ).description(spec.description);
   for (const flag of spec.flags) {
-    const environmentVariable = optionEnvironmentVariables.get(
-      `${spec.trpcPath}.${flag.field}`,
-    );
+    const environmentVariable = optionEnvironmentVariable(spec, flag.field);
     if (environmentVariable) {
       const option = new Option(flag.flag, flag.description).env(
         environmentVariable,

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -1,4 +1,4 @@
-import type { Command } from "commander";
+import { Option, type Command } from "commander";
 import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 
 import { withAuthContext } from "~/commands/context.js";
@@ -36,6 +36,10 @@ const handWrittenContractNames: ReadonlySet<string> = new Set(["flow.list"]);
 const skippedContractNames: ReadonlySet<string> = new Set([
   ...handWrittenContractNames,
   "issue.update",
+]);
+
+const optionEnvironmentVariables = new Map([
+  ["public.run.create.aiTaskId", "QAWOLF_AI_TASK_ID"],
 ]);
 
 function resolveGroup(parent: Command, segment: string): Command {
@@ -78,7 +82,16 @@ function registerSpec(
     spec.kind,
   ).description(spec.description);
   for (const flag of spec.flags) {
-    if (flag.required) {
+    const environmentVariable = optionEnvironmentVariables.get(
+      `${spec.trpcPath}.${flag.field}`,
+    );
+    if (environmentVariable) {
+      const option = new Option(flag.flag, flag.description).env(
+        environmentVariable,
+      );
+      if (flag.required) option.makeOptionMandatory();
+      command.addOption(option);
+    } else if (flag.required) {
       command.requiredOption(flag.flag, flag.description);
     } else {
       command.option(flag.flag, flag.description);


### PR DESCRIPTION
Relates to qawolf/platform#30807

# Overview of Changes

Generated public API commands only forwarded explicit Commander options, even when the CLI already had canonical environment values for them. This adds environment-backed defaults for every generated `--environment-id` option through `QAWOLF_ENVIRONMENT`, and for `run create --ai-task-id` through `QAWOLF_AI_TASK_ID`. Explicit flags remain the higher-priority values.

The AI task binding becomes active when the CLI consumes the `@qawolf/api-contracts` release containing the optional `run.create.aiTaskId` field. A patch changeset and focused coverage for both environment defaults and flag precedence are included.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

All 1,329 tests pass.

## To Do

- [x] Coordinate the compatible `@qawolf/api-contracts` release and runner image rollout with qawolf/platform#30807.

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated
- [x] No breaking changes
