### PR TITLE
fix(publicApi): skip runner.performAction ahead of the contracts bump

### DIFF
--- a/.changeset/skip-runner-performaction.md
+++ b/.changeset/skip-runner-performaction.md
@@ -1,0 +1,5 @@
+---
+"@qawolf/cli": patch
+---
+
+Skip `runner.performAction` in the generated public API commands. An upcoming `@qawolf/api-contracts` version adds this contract, and its action-union input has no flag form; without the skip, upgrading the dependency would make command generation throw while the program is built, breaking every command. The verb will get a hand-written command instead.

--- a/src/commands/publicApi/index.test.ts
+++ b/src/commands/publicApi/index.test.ts
@@ -172,6 +172,35 @@ describe("registerPublicApiCommands", () => {
     ).toBeDefined();
   });
 
+  // Mirrors the shape `runner.performAction` will arrive with: an action union
+  // has no flag form, and an unmappable contract throws while the program is
+  // built. The skip has to be in place before the contracts dependency brings
+  // the real one in.
+  it("survives a contracts version that includes runner.performAction", () => {
+    const performActionContract = {
+      description: "Perform one raw browser action on an interactive runner.",
+      input: z.object({
+        action: z.union([
+          z.object({ type: z.literal("click"), x: z.number(), y: z.number() }),
+          z.object({ text: z.string(), type: z.literal("type") }),
+        ]),
+        id: z.string(),
+      }),
+      kind: "write",
+      name: "runner.performAction",
+      output: z.object({ outcome: z.literal("performed") }),
+    } as const;
+    const program = makeProgram();
+
+    registerPublicApiCommands(program, createSignalRegistry(), {
+      contracts: { runner: { performAction: performActionContract } },
+    });
+
+    expect(
+      program.commands.find((command) => command.name() === "runner"),
+    ).toBeUndefined();
+  });
+
   it("registers nested namespaces from custom contract trees", () => {
     const contract = {
       description: "Look up a run attempt.",

--- a/src/commands/publicApi/index.ts
+++ b/src/commands/publicApi/index.ts
@@ -31,11 +31,15 @@ const groupDescriptions: Record<string, string> = {
 const handWrittenContractNames: ReadonlySet<string> = new Set(["flow.list"]);
 
 // Kept out of generated commands: the hand-written ones above, plus contracts
-// whose input can't be expressed as CLI flags (issue.update is a
-// discriminator-less union).
+// whose input can't be expressed as CLI flags. `issue.update` is a
+// discriminator-less union. `runner.performAction` (in an upcoming contracts
+// version) takes an action union where the arm a caller means is the whole
+// request; listed ahead of the bump because an unmappable contract throws while
+// the program is built, taking every command down with it.
 const skippedContractNames: ReadonlySet<string> = new Set([
   ...handWrittenContractNames,
   "issue.update",
+  "runner.performAction",
 ]);
 
 function resolveGroup(parent: Command, segment: string): Command {


### PR DESCRIPTION
Relates to qawolf/platform#30200

# Overview of Changes

An upcoming `@qawolf/api-contracts` version adds `runner.performAction`, whose action-union input has no flag form. The command generator throws on an unmappable input while the program is built, so bumping the dependency without this skip would break every command, `--help` included. This lists the contract in the skip set ahead of the bump; it will be served by a hand-written command.

A test registers the commands against a contract tree containing the incoming shape and holds that the program still builds.

# Testing

```bash
bun run typecheck
bun run lint
bun run format:check
bun run test
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)