### PR TITLE
fix(clients): surface the server's reason when a public API call fails

### DIFF
--- a/.changeset/public-api-error-reason.md
+++ b/.changeset/public-api-error-reason.md
@@ -1,0 +1,7 @@
+---
+"@qawolf/cli": patch
+---
+
+Show the server's reason when a public API call fails, instead of only an HTTP
+status. A rejected request now prints why it was rejected without needing
+`--verbose`.

--- a/src/commands/flows/withResolvedEnv.ts
+++ b/src/commands/flows/withResolvedEnv.ts
@@ -7,6 +7,7 @@ import type {
   AuthCommandContext,
   CommandResult,
 } from "~/shell/commandContext.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
 import type { SignalRegistry } from "~/shell/signals/createSignalRegistry.js";
 import { detectOutputMode, type OutputFlags } from "~/shell/ui/env.js";
 
@@ -56,7 +57,7 @@ export function withResolvedEnv(
         return;
       }
       if (outcome.kind === "error") {
-        return { error: outcome.error };
+        return failureFields(outcome);
       }
       return fn(ctx, outcome.env);
     })(opts, command);

--- a/src/domains/environments/pickEnvironment.ts
+++ b/src/domains/environments/pickEnvironment.ts
@@ -5,7 +5,7 @@ import { environmentsMessages } from "~/core/messages/index.js";
 import { pluralize } from "~/core/pluralize.js";
 import {
   failureFields,
-  type PlatformError,
+  type PlatformFailure,
 } from "~/shell/platform/requestWithRetry.js";
 import type {
   ResolveEnvironmentDeps,
@@ -100,7 +100,7 @@ const maxPages = 10;
 async function fetchAllEnvironments(
   platformClient: ResolveEnvironmentDeps["platformClient"],
 ): Promise<
-  { ok: true; environments: Environment[] } | ({ ok: false } & PlatformError)
+  { ok: true; environments: Environment[] } | ({ ok: false } & PlatformFailure)
 > {
   const environments: Environment[] = [];
   let cursor: string | undefined;

--- a/src/domains/environments/pickEnvironment.ts
+++ b/src/domains/environments/pickEnvironment.ts
@@ -3,6 +3,10 @@ import type { z } from "zod";
 
 import { environmentsMessages } from "~/core/messages/index.js";
 import { pluralize } from "~/core/pluralize.js";
+import {
+  failureFields,
+  type PlatformError,
+} from "~/shell/platform/requestWithRetry.js";
 import type {
   ResolveEnvironmentDeps,
   ResolveEnvironmentOutcome,
@@ -20,7 +24,7 @@ export async function pickEnvironment(
   deps: ResolveEnvironmentDeps,
 ): Promise<ResolveEnvironmentOutcome> {
   const fetched = await fetchAllEnvironments(deps.platformClient);
-  if (!fetched.ok) return { kind: "error", error: fetched.error };
+  if (!fetched.ok) return { ...failureFields(fetched), kind: "error" };
 
   const environments = fetched.environments;
   if (environments.length === 0) {
@@ -96,7 +100,7 @@ const maxPages = 10;
 async function fetchAllEnvironments(
   platformClient: ResolveEnvironmentDeps["platformClient"],
 ): Promise<
-  { ok: true; environments: Environment[] } | { ok: false; error: string }
+  { ok: true; environments: Environment[] } | ({ ok: false } & PlatformError)
 > {
   const environments: Environment[] = [];
   let cursor: string | undefined;

--- a/src/domains/environments/resolveEnvironment.errors.test.ts
+++ b/src/domains/environments/resolveEnvironment.errors.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveEnvironment } from "./resolveEnvironment.js";
+import { makeDeps } from "./resolveEnvironment.testUtils.js";
+
+const opts = { explicit: undefined, requiredMessage: "req" };
+
+describe("resolveEnvironment platform errors", () => {
+  it("surfaces an environment.get failure with the alias caveat", async () => {
+    const { deps } = makeDeps({ getError: "HTTP 400" });
+
+    const outcome = await resolveEnvironment(deps, {
+      ...opts,
+      explicit: "staging",
+    });
+
+    expect(outcome).toEqual({
+      kind: "error",
+      error:
+        "Could not resolve environment staging: HTTP 400 If staging is an alias, note that aliases require a team API key.",
+    });
+  });
+
+  it("carries the server's reason alongside the alias caveat", async () => {
+    const { deps } = makeDeps({
+      getError: "HTTP 404",
+      getErrorBody: "No environment named staging exists on this team.",
+    });
+
+    const outcome = await resolveEnvironment(deps, {
+      ...opts,
+      explicit: "staging",
+    });
+
+    expect(outcome).toEqual({
+      kind: "error",
+      error:
+        "Could not resolve environment staging: HTTP 404 If staging is an alias, note that aliases require a team API key.",
+      errorBody: "No environment named staging exists on this team.",
+    });
+  });
+
+  it("surfaces a platform error", async () => {
+    const { deps } = makeDeps({ findError: "HTTP 500" });
+
+    const outcome = await resolveEnvironment(deps, opts);
+
+    expect(outcome).toEqual({ kind: "error", error: "HTTP 500" });
+  });
+
+  it("carries the server's reason from the environment listing", async () => {
+    const { deps } = makeDeps({
+      findError: "HTTP 403",
+      findErrorBody: "This API key has no access to environments.",
+    });
+
+    const outcome = await resolveEnvironment(deps, opts);
+
+    expect(outcome).toEqual({
+      kind: "error",
+      error: "HTTP 403",
+      errorBody: "This API key has no access to environments.",
+    });
+  });
+});

--- a/src/domains/environments/resolveEnvironment.test.ts
+++ b/src/domains/environments/resolveEnvironment.test.ts
@@ -42,21 +42,6 @@ describe("resolveEnvironment", () => {
     expect(info).not.toHaveBeenCalled();
   });
 
-  it("surfaces an environment.get failure with the alias caveat", async () => {
-    const { deps } = makeDeps({ getError: "HTTP 400" });
-
-    const outcome = await resolveEnvironment(deps, {
-      explicit: "staging",
-      requiredMessage: "req",
-    });
-
-    expect(outcome).toEqual({
-      kind: "error",
-      error:
-        "Could not resolve environment staging: HTTP 400 If staging is an alias, note that aliases require a team API key.",
-    });
-  });
-
   it("falls back to QAWOLF_ENVIRONMENT, notes the source, and resolves it", async () => {
     const { deps, info, getEnvironment } = makeDeps({
       envVar: " prod ",
@@ -204,16 +189,5 @@ describe("resolveEnvironment", () => {
         "Stopped listing environments after 10 pages. Pass --env explicitly.",
     });
     expect(findEnvironments).toHaveBeenCalledTimes(10);
-  });
-
-  it("surfaces a platform error", async () => {
-    const { deps } = makeDeps({ findError: "HTTP 500" });
-
-    const outcome = await resolveEnvironment(deps, {
-      explicit: undefined,
-      requiredMessage: "req",
-    });
-
-    expect(outcome).toEqual({ kind: "error", error: "HTTP 500" });
   });
 });

--- a/src/domains/environments/resolveEnvironment.testUtils.ts
+++ b/src/domains/environments/resolveEnvironment.testUtils.ts
@@ -28,6 +28,7 @@ export function makeDeps(args: {
   envVar?: string;
   pages?: Page[];
   findError?: string;
+  findErrorBody?: string;
   // Every fetch returns a page with a nextCursor, so pagination never
   // terminates on its own — for testing the page cap.
   endlessCursor?: boolean;
@@ -35,6 +36,7 @@ export function makeDeps(args: {
   // trigger ref resolution omit both getEnv and getError.
   getEnv?: Page["environments"][number];
   getError?: string;
+  getErrorBody?: string;
   selectAnswers?: string[];
   selectCancelled?: boolean;
 }) {
@@ -43,7 +45,9 @@ export function makeDeps(args: {
   const findEnvironments = mock(
     async (): Promise<PlatformResult<FindOutput>> => {
       if (args.findError !== undefined) {
-        return { ok: false, error: args.findError };
+        return args.findErrorBody === undefined
+          ? { ok: false, error: args.findError }
+          : { ok: false, error: args.findError, errorBody: args.findErrorBody };
       }
       if (args.endlessCursor) {
         return { ok: true, value: { environments: [], nextCursor: "again" } };
@@ -57,7 +61,9 @@ export function makeDeps(args: {
   const getEnvironment = mock(
     async (_input: unknown): Promise<PlatformResult<GetOutput>> => {
       if (args.getError !== undefined) {
-        return { ok: false, error: args.getError };
+        return args.getErrorBody === undefined
+          ? { ok: false, error: args.getError }
+          : { ok: false, error: args.getError, errorBody: args.getErrorBody };
       }
       const value = args.getEnv;
       if (value === undefined)

--- a/src/domains/environments/resolveEnvironment.ts
+++ b/src/domains/environments/resolveEnvironment.ts
@@ -2,7 +2,10 @@ import { publicContractsV1 } from "@qawolf/api-contracts/v1";
 import type { z } from "zod";
 
 import { environmentsMessages } from "~/core/messages/index.js";
-import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
+import {
+  failureFields,
+  type PlatformResult,
+} from "~/shell/platform/requestWithRetry.js";
 import type { UI } from "~/shell/ui/index.js";
 import { pickEnvironment } from "./pickEnvironment.js";
 
@@ -15,7 +18,7 @@ type GetOutput = z.output<typeof getContract.output>;
 export type ResolveEnvironmentOutcome =
   | { kind: "resolved"; env: string }
   | { kind: "cancelled" }
-  | { kind: "error"; error: string };
+  | { kind: "error"; error: string; errorBody?: string };
 
 // The concrete instantiations of PlatformClient["callPublicApi"] this domain
 // needs. The real generic method is assignable to the overload set, and test
@@ -79,6 +82,7 @@ async function resolveRef(
   });
   if (!result.ok) {
     return {
+      ...failureFields(result),
       kind: "error",
       error: environmentsMessages.couldNotResolve(ref, result.error),
     };

--- a/src/domains/flows/listRemote.errors.test.ts
+++ b/src/domains/flows/listRemote.errors.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import type { AuthCommandContext } from "~/shell/commandContext.js";
+import { makeCtx as makeBaseCtx } from "~/shell/commandContext.testUtils.js";
+import type { PlatformResult } from "~/shell/platform/requestWithRetry.js";
+import {
+  makeCallPublicApiMock,
+  makeMockPlatformClient,
+} from "~/shell/platform/createPlatformClient.testUtils.js";
+import type { UI } from "~/shell/ui/index.js";
+
+import { makeFakeUI } from "~/domains/runner/run.fixtures.js";
+import { flowsListRemote, type FlowsListRemoteOptions } from "./listRemote.js";
+
+afterEach(() => {
+  mock.restore();
+});
+
+const options: FlowsListRemoteOptions = {
+  env: "environment-id",
+  includeDrafts: false,
+};
+
+async function runWithFailure(
+  failure: Extract<PlatformResult<never>, { ok: false }>,
+): Promise<{ ui: UI; result: unknown }> {
+  const ui = makeFakeUI();
+  const ctx: AuthCommandContext = {
+    ...makeBaseCtx("human"),
+    ui: { ...ui, mode: "human" },
+    apiKeySource: "env",
+    platformClient: makeMockPlatformClient({
+      callPublicApi: makeCallPublicApiMock().mockResolvedValue(failure),
+    }),
+  };
+  const result = await flowsListRemote(ctx, undefined, options);
+  return { ui, result };
+}
+
+describe("flowsListRemote platform error", () => {
+  it("returns a CommandResult with the platform error message", async () => {
+    const { ui, result } = await runWithFailure({
+      ok: false,
+      error: "QA Wolf API rejected the flow.list request (HTTP 401).",
+    });
+
+    expect(result).toEqual({
+      error: "QA Wolf API rejected the flow.list request (HTTP 401).",
+    });
+    expect(ui.write).not.toHaveBeenCalled();
+    expect(ui.json).not.toHaveBeenCalled();
+  });
+
+  it("passes the server's reason through as the error body", async () => {
+    const { result } = await runWithFailure({
+      ok: false,
+      error: "QA Wolf API flow.list request failed (HTTP 400).",
+      errorBody: "environmentId does not belong to your team.",
+    });
+
+    expect(result).toEqual({
+      error: "QA Wolf API flow.list request failed (HTTP 400).",
+      errorBody: "environmentId does not belong to your team.",
+    });
+  });
+});

--- a/src/domains/flows/listRemote.test.ts
+++ b/src/domains/flows/listRemote.test.ts
@@ -224,23 +224,3 @@ describe("flowsListRemote executionTarget shapes", () => {
     ]);
   });
 });
-
-describe("flowsListRemote platform error", () => {
-  it("returns a CommandResult with the platform error message", async () => {
-    const { ui, result } = await run({
-      mode: "human",
-      platformClient: makeMockPlatformClient({
-        callPublicApi: makeCallPublicApiMock().mockResolvedValue({
-          ok: false,
-          error: "QA Wolf API rejected the flow.list request (HTTP 401).",
-        }),
-      }),
-    });
-
-    expect(result).toEqual({
-      error: "QA Wolf API rejected the flow.list request (HTTP 401).",
-    });
-    expect(ui.write).not.toHaveBeenCalled();
-    expect(ui.json).not.toHaveBeenCalled();
-  });
-});

--- a/src/domains/flows/listRemote.ts
+++ b/src/domains/flows/listRemote.ts
@@ -5,6 +5,7 @@ import type {
   AuthCommandContext,
   CommandResult,
 } from "~/shell/commandContext.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
 import { flowsMessages, runnerMessages } from "~/core/messages/index.js";
 
 import { renderListTable } from "./renderListTable.js";
@@ -34,9 +35,7 @@ export async function flowsListRemote(
       includeDrafts: options.includeDrafts,
     },
   );
-  if (!result.ok) {
-    return { error: result.error };
-  }
+  if (!result.ok) return failureFields(result);
 
   const matches = pattern ? picomatch(pattern) : undefined;
   const items: RemoteListItem[] = result.value.flows

--- a/src/domains/flows/pull/wireErrors.ts
+++ b/src/domains/flows/pull/wireErrors.ts
@@ -10,12 +10,12 @@ export function describeBundleRequestError(
   err: WireError,
   baseUrl: string,
 ): string {
-  return describeRequestError(err, baseUrl);
+  return describeRequestError(err, baseUrl).error;
 }
 
 export function describeEnvVarsRequestError(
   err: WireError,
   baseUrl: string,
 ): string {
-  return describeRequestError(err, baseUrl, "env-vars");
+  return describeRequestError(err, baseUrl, "env-vars").error;
 }

--- a/src/domains/publicApi/handle.test.ts
+++ b/src/domains/publicApi/handle.test.ts
@@ -210,4 +210,26 @@ describe("handlePublicApiCommand", () => {
 
     expect(result).toEqual({ error: "run.create failed (500)." });
   });
+
+  it("passes the server's reason through as the error body", async () => {
+    const callPublicApi = makeCallPublicApiMock().mockResolvedValue({
+      ok: false,
+      error: "QA Wolf API run.create request failed (HTTP 400).",
+      errorBody: "environmentId does not belong to your team.",
+    });
+    const ctx = ctxWith(
+      makeFakeUI(),
+      makeMockPlatformClient({ callPublicApi }),
+    );
+
+    const result = await handlePublicApiCommand(ctx, runCreateSpec(), {
+      environmentId: "environment-id",
+      flowIds: ["flow-id"],
+    });
+
+    expect(result).toEqual({
+      error: "QA Wolf API run.create request failed (HTTP 400).",
+      errorBody: "environmentId does not belong to your team.",
+    });
+  });
 });

--- a/src/domains/publicApi/handle.ts
+++ b/src/domains/publicApi/handle.ts
@@ -5,6 +5,7 @@ import type {
   AuthCommandContext,
   CommandResult,
 } from "~/shell/commandContext.js";
+import { failureFields } from "~/shell/platform/requestWithRetry.js";
 
 import type { CommandSpec } from "./commandSpecs.js";
 
@@ -98,11 +99,7 @@ export async function handlePublicApiCommand(
     spec.contract,
     parsed.data,
   );
-  if (!result.ok) {
-    return result.errorBody
-      ? { error: result.error, errorBody: result.errorBody }
-      : { error: result.error };
-  }
+  if (!result.ok) return failureFields(result);
 
   ctx.ui.output(result.value, renderHuman(result.value));
   return undefined;

--- a/src/domains/publicApi/handle.ts
+++ b/src/domains/publicApi/handle.ts
@@ -98,7 +98,11 @@ export async function handlePublicApiCommand(
     spec.contract,
     parsed.data,
   );
-  if (!result.ok) return { error: result.error };
+  if (!result.ok) {
+    return result.errorBody
+      ? { error: result.error, errorBody: result.errorBody }
+      : { error: result.error };
+  }
 
   ctx.ui.output(result.value, renderHuman(result.value));
   return undefined;

--- a/src/shell/platform/createPlatformClient.callPublicApi.test.ts
+++ b/src/shell/platform/createPlatformClient.callPublicApi.test.ts
@@ -105,4 +105,65 @@ describe("callPublicApi", () => {
     expect(callCount(f)).toBe(2);
     expect(result).toEqual({ ok: true, value: { status: "completed" } });
   });
+
+  it("surfaces the server's reason alongside the status", async () => {
+    const message =
+      "src/flows/checkout.flow.ts is not a flow file. A run's entry point must be a flow file under src/flows.";
+    const f = mockFetch(
+      new Response(
+        JSON.stringify({
+          error: {
+            json: {
+              code: -32603,
+              data: {
+                code: "BAD_REQUEST",
+                httpStatus: 400,
+                path: "public.run.create",
+                message,
+              },
+              message,
+            },
+          },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const result = await createPlatformClient(apiKey, {
+      fetch: f,
+      baseUrl,
+      sleep: noSleep,
+    }).callPublicApi(publicContractsV1.run.create, {
+      environmentId: "environment-id",
+      flowIds: ["flow-id"],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "QA Wolf API run.create request failed (HTTP 400).",
+      errorBody: message,
+    });
+  });
+
+  it("keeps the status-only message when the body carries no reason", async () => {
+    const f = mockFetch(
+      new Response("<html><body>502 Bad Gateway</body></html>", {
+        status: 502,
+      }),
+    );
+
+    const result = await createPlatformClient(apiKey, {
+      fetch: f,
+      baseUrl,
+      sleep: noSleep,
+    }).callPublicApi(publicContractsV1.run.create, {
+      environmentId: "environment-id",
+      flowIds: ["flow-id"],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "QA Wolf API run.create request failed (HTTP 502).",
+    });
+  });
 });

--- a/src/shell/platform/describeErrors.test.ts
+++ b/src/shell/platform/describeErrors.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+
+import { describeRequestError } from "./describeErrors.js";
+
+const baseUrl = "https://app.qawolf.com";
+const reason = "Your API key has no access to this environment.";
+
+const httpError = (status: number, body = "") =>
+  ({ kind: "http", status, body }) as const;
+
+const envelope = (message: string) =>
+  JSON.stringify({ error: { json: { message } } });
+
+describe("describeRequestError", () => {
+  it.each([401, 403, 404, 500])(
+    "carries the server's reason on HTTP %i",
+    (status) => {
+      const described = describeRequestError(
+        httpError(status, envelope(reason)),
+        baseUrl,
+        "run.create",
+      );
+
+      expect(described.errorBody).toBe(reason);
+      expect(described.error).toContain(String(status));
+    },
+  );
+
+  it.each([401, 403, 404, 500])(
+    "omits the body entirely when HTTP %i carries no reason",
+    (status) => {
+      const described = describeRequestError(
+        httpError(status, "<html>gateway</html>"),
+        baseUrl,
+        "run.create",
+      );
+
+      expect("errorBody" in described).toBe(false);
+    },
+  );
+
+  it("omits the body for a network failure", () => {
+    const described = describeRequestError(
+      { kind: "network", cause: new Error("connection reset") },
+      baseUrl,
+    );
+
+    expect("errorBody" in described).toBe(false);
+    expect(described.error).toContain(baseUrl);
+  });
+
+  it("omits the body for a timeout", () => {
+    const described = describeRequestError(
+      { kind: "timeout", timeoutMs: 15_000 },
+      baseUrl,
+    );
+
+    expect("errorBody" in described).toBe(false);
+  });
+
+  it("omits the body for an unparseable response", () => {
+    const described = describeRequestError(
+      { kind: "parse", cause: new Error("bad shape") },
+      baseUrl,
+    );
+
+    expect("errorBody" in described).toBe(false);
+  });
+});

--- a/src/shell/platform/describeErrors.ts
+++ b/src/shell/platform/describeErrors.ts
@@ -2,14 +2,14 @@ import { formatSeconds } from "~/core/formatSeconds.js";
 import { authMessages } from "~/core/messages/index.js";
 import type { WireError } from "./createTrpcClient.js";
 import { parseErrorBody } from "./parseErrorBody.js";
-import type { PlatformError } from "./requestWithRetry.js";
+import type { PlatformFailure } from "./requestWithRetry.js";
 
 const m = authMessages.errors;
 
 /** Identity failures inline the reason into a single line, so keep it short. */
 const inlineReasonMaxLength = 200;
 
-export function describeIdentityError(err: WireError): PlatformError {
+export function describeIdentityError(err: WireError): PlatformFailure {
   if (err.kind === "http") {
     if (err.status === 401 || err.status === 403) {
       return { error: m.identity.invalidOrUnauthorized };
@@ -36,7 +36,7 @@ export function describeRequestError(
   err: WireError,
   baseUrl: string,
   noun?: string,
-): PlatformError {
+): PlatformFailure {
   if (err.kind === "http") {
     const reason = parseErrorBody(err.body);
     const body = reason ? { errorBody: reason } : {};

--- a/src/shell/platform/describeErrors.ts
+++ b/src/shell/platform/describeErrors.ts
@@ -1,57 +1,60 @@
 import { formatSeconds } from "~/core/formatSeconds.js";
 import { authMessages } from "~/core/messages/index.js";
 import type { WireError } from "./createTrpcClient.js";
+import { parseErrorBody } from "./parseErrorBody.js";
+import type { PlatformError } from "./requestWithRetry.js";
 
 const m = authMessages.errors;
 
-export function describeIdentityError(err: WireError): string {
+/** Identity failures inline the reason into a single line, so keep it short. */
+const inlineReasonMaxLength = 200;
+
+export function describeIdentityError(err: WireError): PlatformError {
   if (err.kind === "http") {
     if (err.status === 401 || err.status === 403) {
-      return m.identity.invalidOrUnauthorized;
+      return { error: m.identity.invalidOrUnauthorized };
     }
-    return m.identity.couldNotVerify(parseErrorBody(err.body), err.status);
+    return {
+      error: m.identity.couldNotVerify(
+        parseErrorBody(err.body, inlineReasonMaxLength),
+        err.status,
+      ),
+    };
   }
   if (err.kind === "network") {
-    return m.identity.couldNotVerifyNetwork(err.cause.message);
+    return { error: m.identity.couldNotVerifyNetwork(err.cause.message) };
   }
-  if (err.kind === "timeout") return m.identity.timedOut(err.timeoutMs);
-  return m.identity.unexpectedFormat;
+  if (err.kind === "timeout") {
+    return { error: m.identity.timedOut(err.timeoutMs) };
+  }
+  return { error: m.identity.unexpectedFormat };
 }
 
-function parseErrorBody(body: string): string {
-  if (!body) return "";
-  try {
-    const parsed: unknown = JSON.parse(body);
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      "error" in parsed &&
-      typeof (parsed as { error: unknown }).error === "string"
-    ) {
-      return (parsed as { error: string }).error;
-    }
-  } catch {
-    // not JSON; fall through
-  }
-  return "";
-}
-
+// The title stays short and stable so a caller can branch on it; the server's
+// reason goes in the body.
 export function describeRequestError(
   err: WireError,
   baseUrl: string,
   noun?: string,
-): string {
+): PlatformError {
   if (err.kind === "http") {
-    if (err.status === 401) return m.request.rejected401(noun);
-    if (err.status === 403) return m.request.rejected403(noun);
-    if (err.status === 404) return m.request.notFound404(noun);
-    return m.request.failedWithStatus(err.status, noun);
+    const reason = parseErrorBody(err.body);
+    const body = reason ? { errorBody: reason } : {};
+    if (err.status === 401)
+      return { error: m.request.rejected401(noun), ...body };
+    if (err.status === 403)
+      return { error: m.request.rejected403(noun), ...body };
+    if (err.status === 404)
+      return { error: m.request.notFound404(noun), ...body };
+    return { error: m.request.failedWithStatus(err.status, noun), ...body };
   }
   if (err.kind === "network") {
-    return m.request.networkUnreachable(baseUrl, noun);
+    return { error: m.request.networkUnreachable(baseUrl, noun) };
   }
-  if (err.kind === "timeout") return m.request.timedOut(err.timeoutMs, noun);
-  return m.request.unexpectedResponse(noun);
+  if (err.kind === "timeout") {
+    return { error: m.request.timedOut(err.timeoutMs, noun) };
+  }
+  return { error: m.request.unexpectedResponse(noun) };
 }
 
 export function describeBundleDownloadError(err: WireError): string {

--- a/src/shell/platform/parseErrorBody.test.ts
+++ b/src/shell/platform/parseErrorBody.test.ts
@@ -90,4 +90,16 @@ describe("parseErrorBody", () => {
 
     expect(parseErrorBody(body, 4)).toBe("abcd");
   });
+
+  it("returns just the ellipsis when the limit leaves room for nothing else", () => {
+    const body = JSON.stringify({ error: "abcdefghij" });
+
+    expect(parseErrorBody(body, 1)).toBe("…");
+  });
+
+  it.each([0, -5])("returns an empty string for a limit of %i", (maxLength) => {
+    const body = JSON.stringify({ error: "abcdefghij" });
+
+    expect(parseErrorBody(body, maxLength)).toBe("");
+  });
 });

--- a/src/shell/platform/parseErrorBody.test.ts
+++ b/src/shell/platform/parseErrorBody.test.ts
@@ -75,13 +75,19 @@ describe("parseErrorBody", () => {
     });
 
     const parsed = parseErrorBody(body);
-    expect(parsed).toHaveLength(1025);
+    expect(parsed).toHaveLength(1024);
     expect(parsed.endsWith("…")).toBe(true);
   });
 
-  it("clips to a caller-supplied limit", () => {
+  it("clips to a caller-supplied limit, counting the ellipsis", () => {
     const body = JSON.stringify({ error: "abcdefghij" });
 
-    expect(parseErrorBody(body, 4)).toBe("abcd…");
+    expect(parseErrorBody(body, 4)).toBe("abc…");
+  });
+
+  it("leaves a message that exactly fills the limit alone", () => {
+    const body = JSON.stringify({ error: "abcd" });
+
+    expect(parseErrorBody(body, 4)).toBe("abcd");
   });
 });

--- a/src/shell/platform/parseErrorBody.test.ts
+++ b/src/shell/platform/parseErrorBody.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseErrorBody } from "./parseErrorBody.js";
+
+const notAFlowFile =
+  "src/flows/checkout.flow.ts is not a flow file. A run's entry point must be a flow file under src/flows.";
+
+describe("parseErrorBody", () => {
+  it("reads the message from a tRPC error envelope", () => {
+    const body = JSON.stringify({
+      error: {
+        json: {
+          code: -32603,
+          data: {
+            code: "BAD_REQUEST",
+            httpStatus: 400,
+            path: "public.runner.runFlow",
+            message: notAFlowFile,
+          },
+          message: notAFlowFile,
+        },
+      },
+    });
+
+    expect(parseErrorBody(body)).toBe(notAFlowFile);
+  });
+
+  it("reads the message from an envelope without the superjson layer", () => {
+    const body = JSON.stringify({ error: { message: "Runner is not ready." } });
+
+    expect(parseErrorBody(body)).toBe("Runner is not ready.");
+  });
+
+  it("reads the flat legacy shape", () => {
+    const body = JSON.stringify({ error: "API key is not valid." });
+
+    expect(parseErrorBody(body)).toBe("API key is not valid.");
+  });
+
+  it("returns an empty string for a non-JSON body", () => {
+    expect(parseErrorBody("<html><body>502 Bad Gateway</body></html>")).toBe(
+      "",
+    );
+  });
+
+  it("returns an empty string for an empty body", () => {
+    expect(parseErrorBody("")).toBe("");
+  });
+
+  it("returns an empty string when the envelope carries no message", () => {
+    const body = JSON.stringify({ error: { json: { code: -32603 } } });
+
+    expect(parseErrorBody(body)).toBe("");
+  });
+
+  it("returns an empty string when the message is not a string", () => {
+    const body = JSON.stringify({ error: { json: { message: { a: 1 } } } });
+
+    expect(parseErrorBody(body)).toBe("");
+  });
+
+  it("returns an empty string for a JSON body that is not an object", () => {
+    expect(parseErrorBody('"boom"')).toBe("");
+    expect(parseErrorBody("[1,2,3]")).toBe("");
+    expect(parseErrorBody("null")).toBe("");
+  });
+
+  it("returns an empty string when the message is only whitespace", () => {
+    expect(parseErrorBody(JSON.stringify({ error: "   " }))).toBe("");
+  });
+
+  it("clips an oversized message", () => {
+    const body = JSON.stringify({
+      error: { json: { message: "x".repeat(5000) } },
+    });
+
+    const parsed = parseErrorBody(body);
+    expect(parsed).toHaveLength(1025);
+    expect(parsed.endsWith("…")).toBe(true);
+  });
+
+  it("clips to a caller-supplied limit", () => {
+    const body = JSON.stringify({ error: "abcdefghij" });
+
+    expect(parseErrorBody(body, 4)).toBe("abcd…");
+  });
+});

--- a/src/shell/platform/parseErrorBody.ts
+++ b/src/shell/platform/parseErrorBody.ts
@@ -53,9 +53,12 @@ export function parseErrorBody(
 
   const message = extractMessage(parsed)?.trim();
   if (!message) return "";
-  // The ellipsis counts toward the limit, so the result is never longer
-  // than `maxLength`.
-  return message.length > maxLength
-    ? `${message.slice(0, maxLength - 1)}…`
-    : message;
+  return clip(message, maxLength);
+}
+
+// The ellipsis counts toward the limit, so the result is never longer than
+// `maxLength` — including a limit with no room for anything but the ellipsis.
+function clip(message: string, maxLength: number): string {
+  if (message.length <= maxLength) return message;
+  return maxLength < 1 ? "" : `${message.slice(0, maxLength - 1)}…`;
 }

--- a/src/shell/platform/parseErrorBody.ts
+++ b/src/shell/platform/parseErrorBody.ts
@@ -1,6 +1,6 @@
 /**
  * Longest server message we will surface. Anything longer is almost certainly
- * a stack trace or an HTML error page rather than a reason a caller can act on.
+ * a stack trace rather than a reason a caller can act on.
  */
 const defaultMaxLength = 1024;
 

--- a/src/shell/platform/parseErrorBody.ts
+++ b/src/shell/platform/parseErrorBody.ts
@@ -38,7 +38,10 @@ function extractMessage(parsed: unknown): string | undefined {
  * HTML or a stack trace, neither of which belongs in CLI output. Returns ""
  * when the body is empty, is not JSON, or carries no message.
  */
-export function parseErrorBody(body: string, maxLength = defaultMaxLength) {
+export function parseErrorBody(
+  body: string,
+  maxLength = defaultMaxLength,
+): string {
   if (!body) return "";
 
   let parsed: unknown;

--- a/src/shell/platform/parseErrorBody.ts
+++ b/src/shell/platform/parseErrorBody.ts
@@ -1,0 +1,56 @@
+/**
+ * Longest server message we will surface. Anything longer is almost certainly
+ * a stack trace or an HTML error page rather than a reason a caller can act on.
+ */
+const defaultMaxLength = 1024;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+// tRPC wraps the reason as {"error":{"json":{"message":"..."}}}; superjson is
+// what adds the `json` level, so answer to both with and without it. Older
+// non-tRPC endpoints answer with a flat {"error":"..."}.
+function extractMessage(parsed: unknown): string | undefined {
+  const root = asRecord(parsed);
+  if (!root) return undefined;
+
+  const flat = asString(root["error"]);
+  if (flat !== undefined) return flat;
+
+  const error = asRecord(root["error"]);
+  if (!error) return undefined;
+
+  const json = asRecord(error["json"]);
+  return asString(json?.["message"]) ?? asString(error["message"]);
+}
+
+/**
+ * Pulls the server's own explanation out of an error response body.
+ *
+ * Only the envelope's `message` field is read — a raw body may be a proxy's
+ * HTML or a stack trace, neither of which belongs in CLI output. Returns ""
+ * when the body is empty, is not JSON, or carries no message.
+ */
+export function parseErrorBody(body: string, maxLength = defaultMaxLength) {
+  if (!body) return "";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return "";
+  }
+
+  const message = extractMessage(parsed)?.trim();
+  if (!message) return "";
+  return message.length > maxLength
+    ? `${message.slice(0, maxLength)}…`
+    : message;
+}

--- a/src/shell/platform/parseErrorBody.ts
+++ b/src/shell/platform/parseErrorBody.ts
@@ -50,7 +50,9 @@ export function parseErrorBody(body: string, maxLength = defaultMaxLength) {
 
   const message = extractMessage(parsed)?.trim();
   if (!message) return "";
+  // The ellipsis counts toward the limit, so the result is never longer
+  // than `maxLength`.
   return message.length > maxLength
-    ? `${message.slice(0, maxLength)}…`
+    ? `${message.slice(0, maxLength - 1)}…`
     : message;
 }

--- a/src/shell/platform/requestWithRetry.ts
+++ b/src/shell/platform/requestWithRetry.ts
@@ -11,6 +11,17 @@ export type PlatformResult<T> =
   | { ok: true; value: T }
   | ({ ok: false } & PlatformError);
 
+/**
+ * Narrows a failed result to just its error fields, so a caller can rebuild
+ * it as its own result type. Omits `errorBody` entirely when the server gave
+ * no reason, rather than setting it to undefined.
+ */
+export function failureFields(failure: PlatformError): PlatformError {
+  return failure.errorBody
+    ? { error: failure.error, errorBody: failure.errorBody }
+    : { error: failure.error };
+}
+
 type RequestWithRetryArgs<T> = {
   // The wire call to make. Should return a WireResult<T>; do not throw.
   call: () => Promise<WireResult<T>>;

--- a/src/shell/platform/requestWithRetry.ts
+++ b/src/shell/platform/requestWithRetry.ts
@@ -1,9 +1,15 @@
 import { sleep as defaultSleep } from "~/core/sleep.js";
 import type { WireError, WireResult } from "./createTrpcClient.js";
 
+/**
+ * A failure split into a short, stable title callers can branch on and an
+ * optional longer reason from the server.
+ */
+export type PlatformError = { error: string; errorBody?: string };
+
 export type PlatformResult<T> =
   | { ok: true; value: T }
-  | { ok: false; error: string };
+  | ({ ok: false } & PlatformError);
 
 type RequestWithRetryArgs<T> = {
   // The wire call to make. Should return a WireResult<T>; do not throw.
@@ -11,8 +17,8 @@ type RequestWithRetryArgs<T> = {
   // Backoff schedule. Length = retry budget. Final attempt has no backoff
   // and surfaces the error if it still hasn't succeeded.
   backoffMs: readonly number[];
-  // Builds the user-facing error message from the WireError.
-  describe: (err: WireError) => string;
+  // Builds the user-facing error from the WireError.
+  describe: (err: WireError) => PlatformError;
   // Override for sleep (tests pass a no-op). Pass undefined for production
   // callers; the helper supplies the real implementation.
   sleep: ((ms: number) => Promise<void>) | undefined;
@@ -34,7 +40,7 @@ export async function requestWithRetry<T>(
     const retryable =
       result.error.kind === "network" || result.error.kind === "timeout";
     if (backoff === undefined || !retryable) {
-      return { ok: false, error: args.describe(result.error) };
+      return { ok: false, ...args.describe(result.error) };
     }
     await sleep(backoff);
   }

--- a/src/shell/platform/requestWithRetry.ts
+++ b/src/shell/platform/requestWithRetry.ts
@@ -5,18 +5,18 @@ import type { WireError, WireResult } from "./createTrpcClient.js";
  * A failure split into a short, stable title callers can branch on and an
  * optional longer reason from the server.
  */
-export type PlatformError = { error: string; errorBody?: string };
+export type PlatformFailure = { error: string; errorBody?: string };
 
 export type PlatformResult<T> =
   | { ok: true; value: T }
-  | ({ ok: false } & PlatformError);
+  | ({ ok: false } & PlatformFailure);
 
 /**
  * Narrows a failed result to just its error fields, so a caller can rebuild
  * it as its own result type. Omits `errorBody` entirely when the server gave
  * no reason, rather than setting it to undefined.
  */
-export function failureFields(failure: PlatformError): PlatformError {
+export function failureFields(failure: PlatformFailure): PlatformFailure {
   return failure.errorBody
     ? { error: failure.error, errorBody: failure.errorBody }
     : { error: failure.error };
@@ -29,7 +29,7 @@ type RequestWithRetryArgs<T> = {
   // and surfaces the error if it still hasn't succeeded.
   backoffMs: readonly number[];
   // Builds the user-facing error from the WireError.
-  describe: (err: WireError) => PlatformError;
+  describe: (err: WireError) => PlatformFailure;
   // Override for sleep (tests pass a no-op). Pass undefined for production
   // callers; the helper supplies the real implementation.
   sleep: ((ms: number) => Promise<void>) | undefined;


### PR DESCRIPTION
# Overview of Changes

When a public API call failed, the CLI printed only the HTTP status — `QA Wolf API runner.runFlow request failed (HTTP 400).` The server had actually said why, but that reason was thrown away. The only way to see it was `--verbose`, which dumps the raw body at warn level. For a surface built for agents that's a dead end: the caller can't tell a fixable mistake from a broken service.

Failures now carry the server's own explanation as the error body. The title stays short and stable so a caller can still branch on it. This covers every command that talks to the public API — the generated ones, `flows list --remote`, and environment resolution — and the `--json` and agent output modes already had a place to put it.

Only the error envelope's `message` field is read — never the raw body, since a 502 from a proxy is HTML and a 500 can carry a stack trace. Long messages are clipped. When nothing parses, the output is exactly what it is today, with no body at all.

Before:

```
{"type":"error","title":"QA Wolf API run.create request failed (HTTP 400)."}
```

After:

```
{"type":"error","title":"QA Wolf API run.create request failed (HTTP 400).","body":"Validation error: Invalid ID format for kind at \"flowIds[0]\""}
```

# Testing

Verified by hand against a preview host, which produced the "after" output above. A later run against the same host returned a plain-text `404 page not found`, which correctly produced no body at all.

```bash
bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run test
bun run build
```

# Checklist

- [x] Changes follow the [code style](AGENTS.md) of this project
- [x] Self-review completed
- [x] Tests added/updated (or not applicable)
- [x] No breaking changes (or described below)